### PR TITLE
Enhancing OpenStackStateMapper test according new definitions

### DIFF
--- a/src/main/java/org/fogbowcloud/manager/core/plugins/cloud/openstack/OpenStackStateMapper.java
+++ b/src/main/java/org/fogbowcloud/manager/core/plugins/cloud/openstack/OpenStackStateMapper.java
@@ -8,28 +8,28 @@ public class OpenStackStateMapper {
 
     private static final Logger LOGGER = Logger.getLogger(OpenStackStateMapper.class);
 
-    public static final String ACTIVE_STATUS = "active";
-    public static final String BUILD_STATUS = "build";
-    public static final String DOWN_STATUS = "down";
-    public static final String ERROR_STATUS = "error";
-    public static final String CREATING_STATUS = "creating";
-    public static final String AVAILABLE_STATUS = "available";
-    public static final String ATTACHING_STATUS = "attaching";
-    public static final String DETACHING_STATUS = "detaching";
-    public static final String IN_USE_STATUS = "in-use";
-    public static final String MAINTENANCE_STATUS = "maintenance";
-    public static final String DELETING_STATUS = "deleting";
-    public static final String AWAITING_TRANSFER_STATUS = "awaiting-transfer";
-    public static final String ERROR_DELETING_STATUS = "error_deleting";
-    public static final String BACKING_UP_STATUS = "backing-up";
-    public static final String RESTORING_BACKUP_STATUS = "restoring-backup";
-    public static final String ERROR_BACKING_UP_STATUS = "error_backing-up";
-    public static final String ERROR_RESTORING_STATUS = "error_restoring";
-    public static final String ERROR_EXTENDING_STATUS = "error_extending";
-    public static final String DOWNLOADING_STATUS = "downloading";
-    public static final String UPLOADING_STATUS = "uploading";
-    public static final String RETYPING_STATUS = "retyping";
-    public static final String EXTENDING_STATUS = "extending";
+    protected static final String ACTIVE_STATUS = "active";
+    protected static final String BUILD_STATUS = "build";
+    protected static final String DOWN_STATUS = "down";
+    protected static final String ERROR_STATUS = "error";
+    protected static final String CREATING_STATUS = "creating";
+    protected static final String AVAILABLE_STATUS = "available";
+    protected static final String ATTACHING_STATUS = "attaching";
+    protected static final String DETACHING_STATUS = "detaching";
+    protected static final String IN_USE_STATUS = "in-use";
+    protected static final String MAINTENANCE_STATUS = "maintenance";
+    protected static final String DELETING_STATUS = "deleting";
+    protected static final String AWAITING_TRANSFER_STATUS = "awaiting-transfer";
+    protected static final String ERROR_DELETING_STATUS = "error_deleting";
+    protected static final String BACKING_UP_STATUS = "backing-up";
+    protected static final String RESTORING_BACKUP_STATUS = "restoring-backup";
+    protected static final String ERROR_BACKING_UP_STATUS = "error_backing-up";
+    protected static final String ERROR_RESTORING_STATUS = "error_restoring";
+    protected static final String ERROR_EXTENDING_STATUS = "error_extending";
+    protected static final String DOWNLOADING_STATUS = "downloading";
+    protected static final String UPLOADING_STATUS = "uploading";
+    protected static final String RETYPING_STATUS = "retyping";
+    protected static final String EXTENDING_STATUS = "extending";
 
     public static InstanceState map(InstanceType type, String openStackState) {
 

--- a/src/main/java/org/fogbowcloud/manager/core/plugins/cloud/openstack/OpenStackStateMapper.java
+++ b/src/main/java/org/fogbowcloud/manager/core/plugins/cloud/openstack/OpenStackStateMapper.java
@@ -12,24 +12,24 @@ public class OpenStackStateMapper {
     public static final String BUILD_STATUS = "build";
     public static final String DOWN_STATUS = "down";
     public static final String ERROR_STATUS = "error";
-    private static final String CREATING_STATUS = "creating";
-    private static final String AVAILABLE_STATUS = "available";
-    private static final String ATTACHING_STATUS = "attaching";
-    private static final String DETACHING_STATUS = "detaching";
-    private static final String IN_USE_STATUS = "in-use";
-    private static final String MAINTENANCE_STATUS = "maintenance";
-    private static final String DELETING_STATUS = "deleting";
-    private static final String AWAITING_TRANSFER_STATUS = "awaiting-transfer";
-    private static final String ERROR_DELETING_STATUS = "error_deleting";
-    private static final String BACKING_UP_STATUS = "backing-up";
-    private static final String RESTORING_BACKUP_STATUS = "restoring-backup";
-    private static final String ERROR_BACKING_UP_STATUS = "error_backing-up";
-    private static final String ERROR_RESTORING_STATUS = "error_restoring";
-    private static final String ERROR_EXTENDING_STATUS = "error_extending";
-    private static final String DOWNLOADING_STATUS = "downloading";
-    private static final String UPLOADING_STATUS = "uploading";
-    private static final String RETYPING_STATUS = "retyping";
-    private static final String EXTENDING_STATUS = "extending";
+    public static final String CREATING_STATUS = "creating";
+    public static final String AVAILABLE_STATUS = "available";
+    public static final String ATTACHING_STATUS = "attaching";
+    public static final String DETACHING_STATUS = "detaching";
+    public static final String IN_USE_STATUS = "in-use";
+    public static final String MAINTENANCE_STATUS = "maintenance";
+    public static final String DELETING_STATUS = "deleting";
+    public static final String AWAITING_TRANSFER_STATUS = "awaiting-transfer";
+    public static final String ERROR_DELETING_STATUS = "error_deleting";
+    public static final String BACKING_UP_STATUS = "backing-up";
+    public static final String RESTORING_BACKUP_STATUS = "restoring-backup";
+    public static final String ERROR_BACKING_UP_STATUS = "error_backing-up";
+    public static final String ERROR_RESTORING_STATUS = "error_restoring";
+    public static final String ERROR_EXTENDING_STATUS = "error_extending";
+    public static final String DOWNLOADING_STATUS = "downloading";
+    public static final String UPLOADING_STATUS = "uploading";
+    public static final String RETYPING_STATUS = "retyping";
+    public static final String EXTENDING_STATUS = "extending";
 
     public static InstanceState map(InstanceType type, String openStackState) {
 

--- a/src/test/java/org/fogbowcloud/manager/core/plugins/cloud/openstack/OpenStackStateMapperTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/plugins/cloud/openstack/OpenStackStateMapperTest.java
@@ -9,342 +9,383 @@ public class OpenStackStateMapperTest {
 
     @Test
     public void testComputeActiveStatusToReady() {
+        // set up
         InstanceType instanceType = InstanceType.COMPUTE;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "active");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ACTIVE");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ACTIVE_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.READY);
-        Assert.assertEquals(instanceState2, InstanceState.READY);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.READY);
     }
 
     @Test
     public void testComputeBuildStatusToSpawning() {
+        // set up
         InstanceType instanceType = InstanceType.COMPUTE;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "build");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "BUILD");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.BUILD_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.SPAWNING);
-        Assert.assertEquals(instanceState2, InstanceState.SPAWNING);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.SPAWNING);
     }
 
     @Test
     public void testComputeErrorStatusToFailed() {
+        // set up
         InstanceType instanceType = InstanceType.COMPUTE;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "error");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ERROR");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.FAILED);
-        Assert.assertEquals(instanceState2, InstanceState.FAILED);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.FAILED);
     }
 
     @Test
     public void testComputeInvalidStatusToInconsistent() {
+        // set up
         InstanceType instanceType = InstanceType.COMPUTE;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "invalid");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, "invalid");
         InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "INVALID");
 
-        Assert.assertEquals(instanceState1, InstanceState.INCONSISTENT);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.INCONSISTENT);
         Assert.assertEquals(instanceState2, InstanceState.INCONSISTENT);
     }
 
     @Test
     public void testNetworkBuildStatusToInactive() {
+        // set up
         InstanceType instanceType = InstanceType.NETWORK;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "build");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "BUILD");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.BUILD_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.INACTIVE);
-        Assert.assertEquals(instanceState2, InstanceState.INACTIVE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.INACTIVE);
     }
 
     @Test
     public void testNetworkDownStatusToInactive() {
+        // set up
         InstanceType instanceType = InstanceType.NETWORK;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "down");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "DOWN");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.DOWN_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.INACTIVE);
-        Assert.assertEquals(instanceState2, InstanceState.INACTIVE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.INACTIVE);
     }
 
     @Test
     public void testNetworkActiveStatusToReady() {
+        // set up
         InstanceType instanceType = InstanceType.NETWORK;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "active");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ACTIVE");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ACTIVE_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.READY);
-        Assert.assertEquals(instanceState2, InstanceState.READY);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.READY);
     }
 
     @Test
     public void testNetworkErrorStatusToFailed() {
+        // set up
         InstanceType instanceType = InstanceType.NETWORK;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "error");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ERROR");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.FAILED);
-        Assert.assertEquals(instanceState2, InstanceState.FAILED);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.FAILED);
     }
 
     @Test
     public void testNetworkInvalidStatusToFailed() {
+        // set up
         InstanceType instanceType = InstanceType.NETWORK;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "invalid");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, "invalid");
         InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "INVALID");
 
-        Assert.assertEquals(instanceState1, InstanceState.INCONSISTENT);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.INCONSISTENT);
         Assert.assertEquals(instanceState2, InstanceState.INCONSISTENT);
     }
 
     @Test
     public void testVolumeCreatingStatusToCreating() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "creating");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "CREATING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.CREATING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.CREATING);
-        Assert.assertEquals(instanceState2, InstanceState.CREATING);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.CREATING);
     }
 
     @Test
     public void testVolumeAvailableStatusToReady() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "available");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "AVAILABLE");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.AVAILABLE_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.READY);
-        Assert.assertEquals(instanceState2, InstanceState.READY);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.READY);
     }
 
     @Test
     public void testVolumeDetachingStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "detaching");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "DETACHING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.DETACHING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.UNAVAILABLE);
-        Assert.assertEquals(instanceState2, InstanceState.UNAVAILABLE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
     }
 
     @Test
     public void testVolumeMaintenceStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "maintenance");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "MAINTENANCE");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.MAINTENANCE_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.UNAVAILABLE);
-        Assert.assertEquals(instanceState2, InstanceState.UNAVAILABLE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
     }
 
     @Test
     public void testVolumeDeletingStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "deleting");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "DELETING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.DELETING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.UNAVAILABLE);
-        Assert.assertEquals(instanceState2, InstanceState.UNAVAILABLE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
     }
 
     @Test
     public void testVolumeAwaitingTransferStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "awaiting-transfer");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "AWAITING-TRANSFER");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.AWAITING_TRANSFER_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.UNAVAILABLE);
-        Assert.assertEquals(instanceState2, InstanceState.UNAVAILABLE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
     }
 
     @Test
     public void testVolumeBackingUpStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "backing-up");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "BACKING-UP");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.BACKING_UP_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.UNAVAILABLE);
-        Assert.assertEquals(instanceState2, InstanceState.UNAVAILABLE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
     }
 
     @Test
     public void testVolumeRestoringBackupStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "restoring-backup");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "RESTORING-BACKUP");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.RESTORING_BACKUP_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.UNAVAILABLE);
-        Assert.assertEquals(instanceState2, InstanceState.UNAVAILABLE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
     }
 
     @Test
     public void testVolumeDownloadingStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "downloading");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "DOWNLOADING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.DOWNLOADING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.UNAVAILABLE);
-        Assert.assertEquals(instanceState2, InstanceState.UNAVAILABLE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
     }
 
     @Test
     public void testVolumeUploadingStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "uploading");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "UPLOADING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.UPLOADING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.UNAVAILABLE);
-        Assert.assertEquals(instanceState2, InstanceState.UNAVAILABLE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
     }
 
     @Test
     public void testVolumeRetypingStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "retyping");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "RETYPING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.RETYPING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.UNAVAILABLE);
-        Assert.assertEquals(instanceState2, InstanceState.UNAVAILABLE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
     }
 
     @Test
     public void testVolumeExtendingStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "extending");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "EXTENDING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.EXTENDING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.UNAVAILABLE);
-        Assert.assertEquals(instanceState2, InstanceState.UNAVAILABLE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
     }
 
     @Test
     public void testVolumeAttachingStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "attaching");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ATTACHING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ATTACHING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.ATTACHING);
-        Assert.assertEquals(instanceState2, InstanceState.ATTACHING);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.ATTACHING);
     }
 
     @Test
     public void testVolumeInUseStatusToUnavailable() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "in-use");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "IN-USE");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.IN_USE_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.IN_USE);
-        Assert.assertEquals(instanceState2, InstanceState.IN_USE);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.IN_USE);
     }
 
     @Test
     public void testVolumeErrorBackingUpStatusToFailed() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "error_backing-up");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ERROR_BACKING-UP");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_BACKING_UP_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.FAILED);
-        Assert.assertEquals(instanceState2, InstanceState.FAILED);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.FAILED);
     }
 
     @Test
     public void testVolumeErrorDeletingStatusToFailed() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "error_deleting");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ERROR_DELETING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_DELETING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.FAILED);
-        Assert.assertEquals(instanceState2, InstanceState.FAILED);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.FAILED);
     }
 
     @Test
     public void testVolumeErrorExtendingStatusToFailed() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "error_extending");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ERROR_EXTENDING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_EXTENDING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.FAILED);
-        Assert.assertEquals(instanceState2, InstanceState.FAILED);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.FAILED);
     }
 
     @Test
     public void testVolumeErrorRestoringStatusToFailed() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "error_restoring");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ERROR_RESTORING");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_RESTORING_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.FAILED);
-        Assert.assertEquals(instanceState2, InstanceState.FAILED);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.FAILED);
     }
 
     @Test
     public void testVolumeErrorStatusToFailed() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "error");
-        InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ERROR");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_STATUS);
 
-        Assert.assertEquals(instanceState1, InstanceState.FAILED);
-        Assert.assertEquals(instanceState2, InstanceState.FAILED);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.FAILED);
     }
 
     @Test
     public void testVolumeInvalidStatusToInconsistent() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "invalid");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, "invalid");
         InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "INVALID");
 
-        Assert.assertEquals(instanceState1, InstanceState.INCONSISTENT);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.INCONSISTENT);
         Assert.assertEquals(instanceState2, InstanceState.INCONSISTENT);
     }
 
     @Test
     public void testVolumeInvalidStatusToFailed() {
+        // set up
         InstanceType instanceType = InstanceType.VOLUME;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "invalid");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, "invalid");
         InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "invalid");
 
-        Assert.assertEquals(instanceState1, InstanceState.INCONSISTENT);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.INCONSISTENT);
         Assert.assertEquals(instanceState2, InstanceState.INCONSISTENT);
     }
 
     @Test
     public void testAttachmentAnyStatusToReady() {
+        // set up
         InstanceType instanceType = InstanceType.ATTACHMENT;
 
-        InstanceState instanceState1 = OpenStackStateMapper.map(instanceType, "any_state");
+        // exercise
+        InstanceState instanceState = OpenStackStateMapper.map(instanceType, "any_state");
         InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ANY_STATE");
 
-        Assert.assertEquals(instanceState1, InstanceState.READY);
+        // verify
+        Assert.assertEquals(instanceState, InstanceState.READY);
         Assert.assertEquals(instanceState2, InstanceState.READY);
     }
 }

--- a/src/test/java/org/fogbowcloud/manager/core/plugins/cloud/openstack/OpenStackStateMapperTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/plugins/cloud/openstack/OpenStackStateMapperTest.java
@@ -16,7 +16,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ACTIVE_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.READY);
+        Assert.assertEquals(InstanceState.READY, instanceState);
     }
 
     @Test
@@ -28,7 +28,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.BUILD_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.SPAWNING);
+        Assert.assertEquals(InstanceState.SPAWNING, instanceState);
     }
 
     @Test
@@ -40,7 +40,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.FAILED);
+        Assert.assertEquals(InstanceState.FAILED, instanceState);
     }
 
     @Test
@@ -53,8 +53,8 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "INVALID");
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.INCONSISTENT);
-        Assert.assertEquals(instanceState2, InstanceState.INCONSISTENT);
+        Assert.assertEquals(InstanceState.INCONSISTENT, instanceState);
+        Assert.assertEquals(InstanceState.INCONSISTENT, instanceState2);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.BUILD_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.INACTIVE);
+        Assert.assertEquals(InstanceState.INACTIVE, instanceState);
     }
 
     @Test
@@ -78,7 +78,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.DOWN_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.INACTIVE);
+        Assert.assertEquals(InstanceState.INACTIVE, instanceState);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ACTIVE_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.READY);
+        Assert.assertEquals(InstanceState.READY, instanceState);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.FAILED);
+        Assert.assertEquals(InstanceState.FAILED, instanceState);
     }
 
     @Test
@@ -115,8 +115,8 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "INVALID");
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.INCONSISTENT);
-        Assert.assertEquals(instanceState2, InstanceState.INCONSISTENT);
+        Assert.assertEquals(InstanceState.INCONSISTENT, instanceState);
+        Assert.assertEquals(InstanceState.INCONSISTENT, instanceState2);
     }
 
     @Test
@@ -128,7 +128,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.CREATING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.CREATING);
+        Assert.assertEquals(InstanceState.CREATING, instanceState);
     }
 
     @Test
@@ -140,7 +140,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.AVAILABLE_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.READY);
+        Assert.assertEquals(InstanceState.READY, instanceState);
     }
 
     @Test
@@ -152,7 +152,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.DETACHING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
+        Assert.assertEquals(InstanceState.UNAVAILABLE, instanceState);
     }
 
     @Test
@@ -164,7 +164,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.MAINTENANCE_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
+        Assert.assertEquals(InstanceState.UNAVAILABLE, instanceState);
     }
 
     @Test
@@ -176,7 +176,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.DELETING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
+        Assert.assertEquals(InstanceState.UNAVAILABLE, instanceState);
     }
 
     @Test
@@ -188,7 +188,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.AWAITING_TRANSFER_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
+        Assert.assertEquals(InstanceState.UNAVAILABLE, instanceState);
     }
 
     @Test
@@ -200,7 +200,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.BACKING_UP_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
+        Assert.assertEquals(InstanceState.UNAVAILABLE, instanceState);
     }
 
     @Test
@@ -212,7 +212,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.RESTORING_BACKUP_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
+        Assert.assertEquals(InstanceState.UNAVAILABLE, instanceState);
     }
 
     @Test
@@ -224,7 +224,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.DOWNLOADING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
+        Assert.assertEquals(InstanceState.UNAVAILABLE, instanceState);
     }
 
     @Test
@@ -236,7 +236,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.UPLOADING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
+        Assert.assertEquals(InstanceState.UNAVAILABLE, instanceState);
     }
 
     @Test
@@ -248,7 +248,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.RETYPING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
+        Assert.assertEquals(InstanceState.UNAVAILABLE, instanceState);
     }
 
     @Test
@@ -260,7 +260,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.EXTENDING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.UNAVAILABLE);
+        Assert.assertEquals(InstanceState.UNAVAILABLE, instanceState);
     }
 
     @Test
@@ -272,7 +272,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ATTACHING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.ATTACHING);
+        Assert.assertEquals(InstanceState.ATTACHING, instanceState);
     }
 
     @Test
@@ -284,7 +284,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.IN_USE_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.IN_USE);
+        Assert.assertEquals(InstanceState.IN_USE, instanceState);
     }
 
     @Test
@@ -296,7 +296,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_BACKING_UP_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.FAILED);
+        Assert.assertEquals(InstanceState.FAILED, instanceState);
     }
 
     @Test
@@ -308,7 +308,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_DELETING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.FAILED);
+        Assert.assertEquals(InstanceState.FAILED, instanceState);
     }
 
     @Test
@@ -320,7 +320,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_EXTENDING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.FAILED);
+        Assert.assertEquals(InstanceState.FAILED, instanceState);
     }
 
     @Test
@@ -332,7 +332,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_RESTORING_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.FAILED);
+        Assert.assertEquals(InstanceState.FAILED, instanceState);
     }
 
     @Test
@@ -344,7 +344,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState = OpenStackStateMapper.map(instanceType, OpenStackStateMapper.ERROR_STATUS);
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.FAILED);
+        Assert.assertEquals(InstanceState.FAILED, instanceState);
     }
 
     @Test
@@ -357,8 +357,8 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "INVALID");
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.INCONSISTENT);
-        Assert.assertEquals(instanceState2, InstanceState.INCONSISTENT);
+        Assert.assertEquals(InstanceState.INCONSISTENT, instanceState);
+        Assert.assertEquals(InstanceState.INCONSISTENT, instanceState2);
     }
 
     @Test
@@ -371,8 +371,8 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "invalid");
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.INCONSISTENT);
-        Assert.assertEquals(instanceState2, InstanceState.INCONSISTENT);
+        Assert.assertEquals(InstanceState.INCONSISTENT, instanceState);
+        Assert.assertEquals(InstanceState.INCONSISTENT, instanceState2);
     }
 
     @Test
@@ -385,7 +385,7 @@ public class OpenStackStateMapperTest {
         InstanceState instanceState2 = OpenStackStateMapper.map(instanceType, "ANY_STATE");
 
         // verify
-        Assert.assertEquals(instanceState, InstanceState.READY);
-        Assert.assertEquals(instanceState2, InstanceState.READY);
+        Assert.assertEquals(InstanceState.READY, instanceState);
+        Assert.assertEquals(InstanceState.READY, instanceState2);
     }
 }


### PR DESCRIPTION
I don't think the comment `// test case: ...` is needed here.