### PR TITLE
Tests for remote requesters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@
 ### Private Folder ###
 src/main/resources/private/
 
+### LOGS ###
+*.log

--- a/src/main/java/org/fogbowcloud/manager/core/intercomponent/xmpp/handlers/RemoteGetImageRequestHandler.java
+++ b/src/main/java/org/fogbowcloud/manager/core/intercomponent/xmpp/handlers/RemoteGetImageRequestHandler.java
@@ -1,17 +1,16 @@
 package org.fogbowcloud.manager.core.intercomponent.xmpp.handlers;
 
+import com.google.gson.Gson;
 import org.apache.log4j.Logger;
 import org.dom4j.Element;
 import org.fogbowcloud.manager.core.intercomponent.RemoteFacade;
-import org.fogbowcloud.manager.core.intercomponent.xmpp.XmppExceptionToErrorConditionTranslator;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.IqElement;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.RemoteMethod;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.XmppExceptionToErrorConditionTranslator;
 import org.fogbowcloud.manager.core.models.images.Image;
 import org.fogbowcloud.manager.core.models.tokens.FederationUser;
 import org.jamppa.component.handler.AbstractQueryHandler;
 import org.xmpp.packet.IQ;
-
-import com.google.gson.Gson;
 
 public class RemoteGetImageRequestHandler extends AbstractQueryHandler {
 
@@ -25,32 +24,52 @@ public class RemoteGetImageRequestHandler extends AbstractQueryHandler {
 
     @Override
     public IQ handle(IQ iq) {
-        Element queryElement = iq.getElement().element(IqElement.QUERY.toString());
-
-        Element imageIdElementRequest = queryElement.element(IqElement.IMAGE_ID.toString());
-        String imageId = imageIdElementRequest.getText();
-
-        Element memberIdElement = queryElement.element(IqElement.MEMBER_ID.toString());
-        String memberId = memberIdElement.getText();
-
-        Element federationUserElement = queryElement.element(IqElement.FEDERATION_USER.toString());
-        FederationUser federationUser = new Gson().fromJson(federationUserElement.getText(), FederationUser.class);
+        String imageId = unmarshalImageId(iq);
+        String memberId = unmarshalMemberId(iq);
+        FederationUser federationUser = unmarshalFederationUser(iq);
 
         IQ response = IQ.createResultIQ(iq);
-
         try {
             Image image = RemoteFacade.getInstance().getImage(memberId, imageId, federationUser);
-
-            Element queryEl = response.getElement().addElement(IqElement.QUERY.toString(), REMOTE_GET_IMAGE);
-            Element imageElement = queryEl.addElement(IqElement.IMAGE.toString());
-
-            Element imageClassNameElement = queryEl.addElement(IqElement.IMAGE_CLASS_NAME.toString());
-            imageClassNameElement.setText(image.getClass().getName());
-
-            imageElement.setText(new Gson().toJson(image));
+            updateResponse(response, image);
         } catch (Exception e) {
             XmppExceptionToErrorConditionTranslator.updateErrorCondition(response, e);
         }
+
         return response;
     }
+
+    private void updateResponse(IQ response, Image image) {
+        Element queryEl = response.getElement()
+            .addElement(IqElement.QUERY.toString(), REMOTE_GET_IMAGE);
+        Element imageElement = queryEl.addElement(IqElement.IMAGE.toString());
+
+        Element imageClassNameElement = queryEl
+            .addElement(IqElement.IMAGE_CLASS_NAME.toString());
+        imageClassNameElement.setText(image.getClass().getName());
+
+        imageElement.setText(new Gson().toJson(image));
+    }
+
+    private String unmarshalImageId(IQ iq) {
+        Element queryElement = iq.getElement().element(IqElement.QUERY.toString());
+
+        Element imageIdElementRequest = queryElement.element(IqElement.IMAGE_ID.toString());
+        return imageIdElementRequest.getText();
+    }
+
+    private String unmarshalMemberId(IQ iq) {
+        Element queryElement = iq.getElement().element(IqElement.QUERY.toString());
+
+        Element memberIdElement = queryElement.element(IqElement.MEMBER_ID.toString());
+        return memberIdElement.getText();
+    }
+
+    private FederationUser unmarshalFederationUser(IQ iq) {
+        Element queryElement = iq.getElement().element(IqElement.QUERY.toString());
+
+        Element federationUserElement = queryElement.element(IqElement.FEDERATION_USER.toString());
+        return new Gson().fromJson(federationUserElement.getText(), FederationUser.class);
+    }
+
 }

--- a/src/main/java/org/fogbowcloud/manager/core/intercomponent/xmpp/handlers/RemoteGetUserQuotaRequestHandler.java
+++ b/src/main/java/org/fogbowcloud/manager/core/intercomponent/xmpp/handlers/RemoteGetUserQuotaRequestHandler.java
@@ -27,8 +27,7 @@ public class RemoteGetUserQuotaRequestHandler extends AbstractQueryHandler {
     public IQ handle(IQ iq) {
         Element queryElement = iq.getElement().element(IqElement.QUERY.toString());
 
-        Element memberIdElement = iq.getElement().element(IqElement.MEMBER_ID.toString());
-        String memberId = new Gson().fromJson(memberIdElement.getText(), String.class);
+        String memberId = iq.getTo().toString();
 
         Element federationUserElement = iq.getElement().element(IqElement.FEDERATION_USER.toString());
         FederationUser federationUser = new Gson().fromJson(federationUserElement.getText(), FederationUser.class);

--- a/src/main/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetUserQuotaRequest.java
+++ b/src/main/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetUserQuotaRequest.java
@@ -4,6 +4,7 @@ import org.apache.log4j.Logger;
 import org.dom4j.Element;
 import org.fogbowcloud.manager.core.exceptions.FogbowManagerException;
 import org.fogbowcloud.manager.core.exceptions.UnavailableProviderException;
+import org.fogbowcloud.manager.core.exceptions.UnexpectedException;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.XmppErrorConditionToExceptionTranslator;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.IqElement;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.PacketSenderHolder;
@@ -45,9 +46,6 @@ public class RemoteGetUserQuotaRequest implements RemoteRequest<Quota> {
         Element queryElement = iq.getElement().addElement(IqElement.QUERY.toString(),
                 RemoteMethod.REMOTE_GET_USER_QUOTA.toString());
 
-        Element memberIdElement = iq.getElement().addElement(IqElement.MEMBER_ID.toString());
-        memberIdElement.setText(new Gson().toJson(this.provider));
-
         Element userElement = iq.getElement().addElement(IqElement.FEDERATION_USER.toString());
         userElement.setText(new Gson().toJson(this.federationUser));
 
@@ -57,7 +55,7 @@ public class RemoteGetUserQuotaRequest implements RemoteRequest<Quota> {
         return iq;
     }
 
-    private Quota getUserQuotaFromResponse(IQ response) throws FogbowManagerException {
+    private Quota getUserQuotaFromResponse(IQ response) throws UnexpectedException {
         Element queryElement = response.getElement().element(IqElement.QUERY.toString());
         String quotaStr = queryElement.element(IqElement.USER_QUOTA.toString()).getText();
 
@@ -67,7 +65,7 @@ public class RemoteGetUserQuotaRequest implements RemoteRequest<Quota> {
         try {
             quota = (Quota) new Gson().fromJson(quotaStr, Class.forName(instanceClassName));
         } catch (Exception e) {
-            throw new UnavailableProviderException(e.getMessage());
+            throw new UnexpectedException(e.getMessage());
         }
 
         return quota;

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/IQMatcher.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/IQMatcher.java
@@ -9,6 +9,8 @@ import org.xmpp.packet.IQ;
  */
 public class IQMatcher extends ArgumentMatcher<IQ> {
 
+    public static final String NO_ID_REGEX = "id\\=\".*\"";
+
     private final IQ expectedIQ;
 
     public IQMatcher(IQ expectedIQ) {
@@ -17,7 +19,14 @@ public class IQMatcher extends ArgumentMatcher<IQ> {
 
     @Override
     public boolean matches(Object argument) {
-        IQ comparedRequest = (IQ) argument;
-        return expectedIQ.toString().equals(comparedRequest.toString());
+        IQ comparedIq = (IQ) argument;
+
+        // jamppa generates random iq ids by default, our matcher ignores ids
+        return removeIdAttribute(expectedIQ.toString()).equals(removeIdAttribute(comparedIq.toString()));
     }
+
+    private String removeIdAttribute(String s) {
+        return s.replaceFirst(NO_ID_REGEX, "");
+    }
+
 }

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/handlers/RemoteGetOrderRequestHandlerTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/handlers/RemoteGetOrderRequestHandlerTest.java
@@ -25,106 +25,111 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.xmpp.packet.IQ;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ RemoteFacade.class, PacketSenderHolder.class })
+@PrepareForTest({RemoteFacade.class, PacketSenderHolder.class})
 public class RemoteGetOrderRequestHandlerTest {
 
-	private static final String IQ_RESULT = "\n<iq type=\"result\" id=\"%s\" from=\"%s\">\n"
-			+ "  <query xmlns=\"remoteGetOrder\">\n" + "    <instance>{\"id\":\"fake-instance-id\"}</instance>\n"
-			+ "    <instanceClassName>org.fogbowcloud.manager.core.models.instances.Instance</instanceClassName>\n"
-			+ "  </query>\n" + "</iq>";
+    private static final String IQ_RESULT = "\n<iq type=\"result\" id=\"%s\" from=\"%s\">\n"
+        + "  <query xmlns=\"remoteGetOrder\">\n"
+        + "    <instance>{\"id\":\"fake-instance-id\"}</instance>\n"
+        + "    <instanceClassName>org.fogbowcloud.manager.core.models.instances.Instance</instanceClassName>\n"
+        + "  </query>\n" + "</iq>";
 
-	private static final String IQ_ERROR_RESULT = "\n<iq type=\"error\" id=\"%s\" from=\"%s\">\n"
-			+ "  <error code=\"500\" type=\"wait\">\n"
-			+ "    <undefined-condition xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\"/>\n"
-			+ "    <text xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\">Unexpected exceptionjava.lang.Exception</text>\n"
-			+ "  </error>\n" + "</iq>";
+    private static final String IQ_ERROR_RESULT = "\n<iq type=\"error\" id=\"%s\" from=\"%s\">\n"
+        + "  <error code=\"500\" type=\"wait\">\n"
+        + "    <undefined-condition xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\"/>\n"
+        + "    <text xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\">Unexpected exception: java.lang.Exception</text>\n"
+        + "  </error>\n" + "</iq>";
 
-	private static final String FAKE_INSTANCE_ID = "fake-instance-id";
+    private static final String FAKE_INSTANCE_ID = "fake-instance-id";
 
-	private RemoteGetOrderRequestHandler remoteGetOrderRequestHandler;
-	private RemoteFacade remoteFacade;
-	private PacketSender packetSender;
+    private RemoteGetOrderRequestHandler remoteGetOrderRequestHandler;
+    private RemoteFacade remoteFacade;
 
-	@Before
-	public void setUp() {
-		this.remoteGetOrderRequestHandler = new RemoteGetOrderRequestHandler();
+    private PacketSender packetSender;
 
-		this.remoteFacade = Mockito.mock(RemoteFacade.class);
-		PowerMockito.mockStatic(RemoteFacade.class);
-		BDDMockito.given(RemoteFacade.getInstance()).willReturn(this.remoteFacade);
+    @Before
+    public void setUp() {
+        this.remoteGetOrderRequestHandler = new RemoteGetOrderRequestHandler();
 
-		this.packetSender = Mockito.mock(PacketSender.class);
-		PowerMockito.mockStatic(PacketSenderHolder.class);
-		BDDMockito.given(PacketSenderHolder.getPacketSender()).willReturn(this.packetSender);
-	}
+        this.remoteFacade = Mockito.mock(RemoteFacade.class);
+        PowerMockito.mockStatic(RemoteFacade.class);
+        BDDMockito.given(RemoteFacade.getInstance()).willReturn(this.remoteFacade);
 
-	// test case: When the handle method is called passing an IQ request, it must
-	// return the Order from that.
-	@Test
-	public void testHandleWithValidIQ() throws Exception {
-		// set up
-		FederationUser federationUser = createFederationUser();
-		Order order = createOrder(federationUser);
-		String orderId = order.getId();
-		Instance instance = new Instance(FAKE_INSTANCE_ID);
+        this.packetSender = Mockito.mock(PacketSender.class);
+        PowerMockito.mockStatic(PacketSenderHolder.class);
+        BDDMockito.given(PacketSenderHolder.getPacketSender()).willReturn(this.packetSender);
+    }
 
-		Mockito.when(this.remoteFacade.getResourceInstance(Mockito.eq(orderId), Mockito.eq(federationUser),
-				Mockito.eq(ResourceType.COMPUTE))).thenReturn(instance);
+    // test case: When the handle method is called passing an IQ request, it must
+    // return the Order from that.
+    @Test
+    public void testHandleWithValidIQ() throws Exception {
+        // set up
+        FederationUser federationUser = createFederationUser();
+        Order order = createOrder(federationUser);
+        String orderId = order.getId();
+        Instance instance = new Instance(FAKE_INSTANCE_ID);
 
-		IQ iq = RemoteGetOrderRequest.marshal(order);
+        Mockito.when(
+            this.remoteFacade.getResourceInstance(Mockito.eq(orderId), Mockito.eq(federationUser),
+                Mockito.eq(ResourceType.COMPUTE))).thenReturn(instance);
 
-		// exercise
-		IQ result = this.remoteGetOrderRequestHandler.handle(iq);
+        IQ iq = RemoteGetOrderRequest.marshal(order);
 
-		// verify
-		Mockito.verify(this.remoteFacade, Mockito.times(1)).getResourceInstance(Mockito.eq(orderId),
-				Mockito.eq(federationUser), Mockito.eq(ResourceType.COMPUTE));
+        // exercise
+        IQ result = this.remoteGetOrderRequestHandler.handle(iq);
 
-		String iqId = iq.getID();
-		String providingMember = order.getProvidingMember();
-		String expected = String.format(IQ_RESULT, iqId, providingMember);
+        // verify
+        Mockito.verify(this.remoteFacade, Mockito.times(1)).getResourceInstance(Mockito.eq(orderId),
+            Mockito.eq(federationUser), Mockito.eq(ResourceType.COMPUTE));
 
-		Assert.assertEquals(expected, result.toString());
+        String iqId = iq.getID();
+        String providingMember = order.getProvidingMember();
+        String expected = String.format(IQ_RESULT, iqId, providingMember);
 
-	}
+        Assert.assertEquals(expected, result.toString());
 
-	// test case: When an Exception occurs, the handle method must return a response
-	// error.
-	@Test
-	public void testHandleWhenThrowsException() throws Exception {
-		// set up
-		FederationUser federationUser = null;
-		Order order = createOrder(federationUser);
-		String orderId = order.getId();
+    }
 
-		Mockito.when(this.remoteFacade.getResourceInstance(Mockito.eq(orderId), Mockito.eq(federationUser),
-				Mockito.eq(ResourceType.COMPUTE))).thenThrow(new Exception());
+    // test case: When an Exception occurs, the handle method must return a response
+    // error.
+    @Test
+    public void testHandleWhenThrowsException() throws Exception {
+        // set up
+        FederationUser federationUser = null;
+        Order order = createOrder(federationUser);
+        String orderId = order.getId();
 
-		IQ iq = RemoteGetOrderRequest.marshal(order);
+        Mockito.when(
+            this.remoteFacade.getResourceInstance(Mockito.eq(orderId), Mockito.eq(federationUser),
+                Mockito.eq(ResourceType.COMPUTE))).thenThrow(new Exception());
 
-		// exercise
-		IQ result = this.remoteGetOrderRequestHandler.handle(iq);
+        IQ iq = RemoteGetOrderRequest.marshal(order);
 
-		// verify
-		Mockito.verify(this.remoteFacade, Mockito.times(1)).getResourceInstance(Mockito.eq(orderId),
-				Mockito.eq(federationUser), Mockito.eq(ResourceType.COMPUTE));
+        // exercise
+        IQ result = this.remoteGetOrderRequestHandler.handle(iq);
 
-		String iqId = iq.getID();
-		String providingMember = order.getProvidingMember();
-		String expected = String.format(IQ_ERROR_RESULT, iqId, providingMember);
+        // verify
+        Mockito.verify(this.remoteFacade, Mockito.times(1)).getResourceInstance(Mockito.eq(orderId),
+            Mockito.eq(federationUser), Mockito.eq(ResourceType.COMPUTE));
 
-		Assert.assertEquals(expected, result.toString());
-	}
+        String iqId = iq.getID();
+        String providingMember = order.getProvidingMember();
+        String expected = String.format(IQ_ERROR_RESULT, iqId, providingMember);
 
-	private Order createOrder(FederationUser federationUser) throws InvalidParameterException {
-		return new ComputeOrder(federationUser, "requestingMember", "providingmember", 1, 2, 3, "imageId", null,
-				"publicKey", new ArrayList<>());
-	}
+        Assert.assertEquals(expected, result.toString());
+    }
 
-	private FederationUser createFederationUser() throws InvalidParameterException {
-		Map<String, String> attributes = new HashMap<>();
-		attributes.put("user-name", "fogbow");
-		return new FederationUser("fake-id", attributes);
-	}
+    private Order createOrder(FederationUser federationUser) throws InvalidParameterException {
+        return new ComputeOrder(federationUser, "requestingMember", "providingmember", 1, 2, 3,
+            "imageId", null,
+            "publicKey", new ArrayList<>());
+    }
+
+    private FederationUser createFederationUser() throws InvalidParameterException {
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("user-name", "fogbow");
+        return new FederationUser("fake-id", attributes);
+    }
 
 }

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/handlers/RemoteGetUserQuotaRequestHandlerTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/handlers/RemoteGetUserQuotaRequestHandlerTest.java
@@ -1,4 +1,4 @@
-package org.fogbowcloud.manager.core.intercomponent.xmpp.requests;
+package org.fogbowcloud.manager.core.intercomponent.xmpp.handlers;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,7 +35,6 @@ public class RemoteGetUserQuotaRequestHandlerTest {
 	private static final String PROVIDING_MEMBER = "providingmember";
 	
 	private RemoteGetUserQuotaRequestHandler remoteGetUserQuotaRequestHandler;
-	private RemoteGetUserQuotaRequest getUserQuotaRequest;
 
 	private static final String EXPECTED_QUOTA = "\n<iq type=\"result\" id=\"%s\" from=\"%s\">\n"
 					+ "  <query xmlns=\"remoteGetUserQuota\">\n"
@@ -49,7 +48,7 @@ public class RemoteGetUserQuotaRequestHandlerTest {
 	private static final String IQ_ERROR_RESPONSE = "\n<iq type=\"error\" id=\"%s\" from=\"%s\">\n"
 					+ "  <error code=\"500\" type=\"wait\">\n"
 					+ "    <undefined-condition xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\"/>\n"
-					+ "    <text xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\">Unexpected exceptionjava.lang.Exception</text>\n"
+					+ "    <text xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\">Unexpected exception: java.lang.Exception</text>\n"
 					+ "  </error>\n</iq>";
 
 	@Before
@@ -63,10 +62,6 @@ public class RemoteGetUserQuotaRequestHandlerTest {
 
 		PowerMockito.mockStatic(PacketSenderHolder.class);
 		BDDMockito.given(PacketSenderHolder.getPacketSender()).willReturn(this.packetSender);
-		this.getUserQuotaRequest = new RemoteGetUserQuotaRequest(
-												PROVIDING_MEMBER,
-												this.createFederationUser(),
-												ResourceType.COMPUTE);
 	}
 
 	// test case: When the handle method is called passing an IQ request, it must return the User Quota from that.
@@ -79,7 +74,7 @@ public class RemoteGetUserQuotaRequestHandlerTest {
 			.when(this.remoteFacade)
 				.getUserQuota(Mockito.anyString(), Mockito.any(), Mockito.any());
 
-		IQ iq = this.getUserQuotaRequest.createIq();
+		IQ iq = RemoteGetUserQuotaRequest.marshal(PROVIDING_MEMBER, this.createFederationUser(), ResourceType.COMPUTE);
 
 		// exercise
 		IQ result = this.remoteGetUserQuotaRequestHandler.handle(iq);
@@ -100,7 +95,7 @@ public class RemoteGetUserQuotaRequestHandlerTest {
 			.getUserQuota(Mockito.anyString(), Mockito.any(), Mockito.any()))
 				.thenThrow(new Exception());
 
-		IQ iq = this.getUserQuotaRequest.createIq();
+		IQ iq = RemoteGetUserQuotaRequest.marshal(PROVIDING_MEMBER, this.createFederationUser(), ResourceType.COMPUTE);
 
 		// exercise
 		IQ result = this.remoteGetUserQuotaRequestHandler.handle(iq);

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteCreateOrderRequestTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteCreateOrderRequestTest.java
@@ -16,61 +16,63 @@ import org.xmpp.packet.PacketError;
 
 public class RemoteCreateOrderRequestTest {
 
-	private final String providingMember = "providing-member";
+    private final String providingMember = "providing-member";
 
-	private RemoteCreateOrderRequest remoteCreateOrderRequest;
-	private Order order;
-	private PacketSender packetSender;
-	private IQ iqResponse;
+    private RemoteCreateOrderRequest remoteCreateOrderRequest;
+    private Order order;
+    private PacketSender packetSender;
+    private IQ iqResponse;
 
-	@Before
-	public void setUp() throws InvalidParameterException {
-		this.order = new ComputeOrder(null, "requesting-member", this.providingMember, 10, 20, 30, "imageid", null,
-				"publicKey", null);
-		this.remoteCreateOrderRequest = new RemoteCreateOrderRequest(this.order);
-		this.packetSender = Mockito.mock(PacketSender.class);
-		PacketSenderHolder.init(packetSender);
-		this.iqResponse = new IQ();
-	}
+    @Before
+    public void setUp() throws InvalidParameterException {
+        this.order = new ComputeOrder(null, "requesting-member", this.providingMember, 10, 20, 30,
+            "imageid", null,
+            "publicKey", null);
+        this.remoteCreateOrderRequest = new RemoteCreateOrderRequest(this.order);
+        this.packetSender = Mockito.mock(PacketSender.class);
+        PacketSenderHolder.init(packetSender);
+        this.iqResponse = new IQ();
+    }
 
-	//test case: check if IQ attributes is according to both Order parameters and remote create order request rules
-	@Test
-	public void testSend() throws Exception {
+    //test case: check if IQ attributes is according to both Order parameters and remote create order request rules
+    @Test
+    public void testSend() throws Exception {
+        // set up
+        IQ expectedIQ = RemoteCreateOrderRequest.marshal(this.order);
 
-		// set up
-		IQ expectedIQ = RemoteCreateOrderRequest.marshal(this.order);
+        Mockito.doReturn(this.iqResponse).when(this.packetSender)
+            .syncSendPacket(Mockito.any(IQ.class));
 
-		Mockito.doReturn(this.iqResponse).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
+        // exercise
+        this.remoteCreateOrderRequest.send();
 
-		// exercise
-		this.remoteCreateOrderRequest.send();
+        // verify
+        // as IQ does not implement equals we need a matcher
+        IQMatcher matcher = new IQMatcher(expectedIQ);
+        Mockito.verify(this.packetSender).syncSendPacket(Mockito.argThat(matcher));
+    }
 
-		// verify
-		//as IQ does not implement equals we need a matcher
-		IQMatcher matcher = new IQMatcher(expectedIQ);
-		Mockito.verify(this.packetSender).syncSendPacket(Mockito.argThat(matcher));
-	}
+    //test case: Check if "send" is properly forwarding UnavailableProviderException thrown by
+    //"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response is null
+    @Test(expected = UnavailableProviderException.class)
+    public void testSendWhenResponseIsNull() throws Exception {
+        // set up
+        Mockito.doReturn(null).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
 
-	//test case: Check if "send" is properly forwarding UnavailableProviderException thrown by
-	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response is null
-	@Test (expected = UnavailableProviderException.class)
-	public void testSendWhenResponseIsNull() throws Exception {
-		// set up
-		Mockito.doReturn(null).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
+        // exercise/verify
+        this.remoteCreateOrderRequest.send();
+    }
 
-		// exercise/verify
-		this.remoteCreateOrderRequest.send();
-	}
-	
-	//test case: Check if "send" is properly forwarding UnauthorizedRequestException thrown by
-	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response status is forbidden
-	@Test (expected = UnauthorizedRequestException.class)
-	public void testSendWhenResponseReturnsForbidden() throws Exception {
-		// set up
-		Mockito.doReturn(this.iqResponse).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
-		this.iqResponse.setError(new PacketError(PacketError.Condition.forbidden));
-		
-		// exercise/verify
-		this.remoteCreateOrderRequest.send();
-	}
+    //test case: Check if "send" is properly forwarding UnauthorizedRequestException thrown by
+    //"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response status is forbidden
+    @Test(expected = UnauthorizedRequestException.class)
+    public void testSendWhenResponseReturnsForbidden() throws Exception {
+        // set up
+        Mockito.doReturn(this.iqResponse).when(this.packetSender)
+            .syncSendPacket(Mockito.any(IQ.class));
+        this.iqResponse.setError(new PacketError(PacketError.Condition.forbidden));
+
+        // exercise/verify
+        this.remoteCreateOrderRequest.send();
+    }
 }

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetAllImagesRequestTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetAllImagesRequestTest.java
@@ -103,7 +103,7 @@ public class RemoteGetAllImagesRequestTest {
 	}
 	
 	//test case: checks if "send" is properly forwading UnexpectedException thrown by 
-	//"getImageFromResponse" when the image class map name from the IQ response is undefined (wrong or not found)
+	//"getImageFromResponse" when the images map class name from the IQ response is undefined (wrong or not found)
 	@Test(expected = UnexpectedException.class)
 	public void testSendWhenImageClassIsUndefined() throws Exception {
 		//set up

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetAllImagesRequestTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetAllImagesRequestTest.java
@@ -1,0 +1,5 @@
+package org.fogbowcloud.manager.core.intercomponent.xmpp.requesters;
+
+public class RemoteGetAllImagesRequestTest {
+
+}

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetAllImagesRequestTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetAllImagesRequestTest.java
@@ -1,5 +1,140 @@
 package org.fogbowcloud.manager.core.intercomponent.xmpp.requesters;
 
-public class RemoteGetAllImagesRequestTest {
+import java.util.HashMap;
+import java.util.Map;
 
+import org.dom4j.Element;
+import org.fogbowcloud.manager.core.exceptions.InvalidParameterException;
+import org.fogbowcloud.manager.core.exceptions.UnauthorizedRequestException;
+import org.fogbowcloud.manager.core.exceptions.UnavailableProviderException;
+import org.fogbowcloud.manager.core.exceptions.UnexpectedException;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.IqElement;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.PacketSenderHolder;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.RemoteMethod;
+import org.fogbowcloud.manager.core.models.tokens.FederationUser;
+import org.jamppa.component.PacketSender;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.PacketError;
+
+import com.google.gson.Gson;
+
+public class RemoteGetAllImagesRequestTest {
+	
+ 	private RemoteGetAllImagesRequest remoteGetAllImagesRequest;
+	private PacketSender packetSender;
+	private ArgumentCaptor<IQ> argIQ = ArgumentCaptor.forClass(IQ.class);
+	private FederationUser federationUser;
+	HashMap<String, String> imagesMap;
+	private final String provider = "provider";
+	
+ 	@Before
+	public void setUp() throws InvalidParameterException {
+ 		Map<String, String> attributes = new HashMap<String, String>();
+ 		attributes.put("user-name", "user-name");
+ 		this.federationUser = new FederationUser("federation-user-id", attributes);
+ 		
+		this.remoteGetAllImagesRequest = new RemoteGetAllImagesRequest(provider, federationUser);
+		this.packetSender = Mockito.mock(PacketSender.class);
+		PacketSenderHolder.init(packetSender);
+		
+		this.imagesMap = new HashMap<String, String>();
+		this.imagesMap.put("key-1", "value-1");
+		this.imagesMap.put("key-2", "value-2");
+		this.imagesMap.put("key-3", "value-3");
+	}
+ 	
+ 	//test case: checks if IQ attributes is according to both RemoteGetAllImagesRequestTest constructor parameters 
+ 	//and remote get all images request rules. In addition, it checks if the image map from a possible response is 
+ 	//properly created and returned by the "send" method
+	@Test
+	public void testSend() throws Exception {
+		//set up
+		IQ iqResponse = getImagesMapIQResponse(this.imagesMap);
+		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(argIQ.capture());
+ 		String federationUserJson = new Gson().toJson(this.federationUser);
+
+ 		//exercise
+		HashMap<String, String> responseImagesMap = this.remoteGetAllImagesRequest.send();
+		
+ 		//verify
+		IQ iq = argIQ.getValue();
+		Assert.assertEquals(IQ.Type.get.toString(), iq.getType().toString());
+		Assert.assertEquals(this.provider, iq.getTo().toString());
+		
+		Element iqElementQuery = iq.getElement().element(IqElement.QUERY.toString());
+		Assert.assertEquals(RemoteMethod.REMOTE_GET_ALL_IMAGES.toString(), iqElementQuery.getNamespaceURI());
+		
+		String iqQueryMemberId = iqElementQuery.element(IqElement.MEMBER_ID.toString()).getText();
+		Assert.assertEquals(this.provider, iqQueryMemberId);
+		
+		String iqQueryUser = iqElementQuery.element(IqElement.FEDERATION_USER.toString()).getText();
+		Assert.assertEquals(federationUserJson, iqQueryUser);
+		
+		Assert.assertEquals(this.imagesMap, responseImagesMap);
+	}
+	
+	//test case: checks if "send" is properly forwading UnavailableProviderException thrown by 
+	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response is null
+	@Test (expected = UnavailableProviderException.class)
+	public void testSendWhenResponseIsNull() throws Exception {
+		//set up
+		Mockito.doReturn(null).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+ 		
+		//exercise/verify
+		this.remoteGetAllImagesRequest.send();
+	}
+	
+	//test case: checks if "send" is properly forwading UnauthorizedRequestException thrown by 
+	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response status is forbidden
+	@Test (expected = UnauthorizedRequestException.class)
+	public void testSendWhenResponseReturnsForbidden() throws Exception {
+		//set up
+		IQ iqResponse = new IQ();
+		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+		iqResponse.setError(new PacketError(PacketError.Condition.forbidden));
+		
+		//exercise/verify
+		this.remoteGetAllImagesRequest.send();
+	}
+	
+	//test case: checks if "send" is properly forwading UnexpectedException thrown by 
+	//"getImageFromResponse" when the image class map name from the IQ response is undefined (wrong or not found)
+	@Test(expected = UnexpectedException.class)
+	public void testSendWhenImageClassIsUndefined() throws Exception {
+		//set up
+		IQ iqResponse = getImagesMapIQResponseWithWrongClass(this.imagesMap);
+		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(argIQ.capture());
+
+ 		//exercise/verify
+		this.remoteGetAllImagesRequest.send();
+	}
+	
+	private IQ getImagesMapIQResponse(Map<String, String> imagesMap) {
+        IQ iqResponse = new IQ();
+        Element queryEl = iqResponse.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_ALL_IMAGES.toString());
+        Element imagesMapElement = queryEl.addElement(IqElement.IMAGES_MAP.toString());
+
+        Element imagesMapClassNameElement = queryEl.addElement(IqElement.IMAGES_MAP_CLASS_NAME.toString());
+        imagesMapClassNameElement.setText(imagesMap.getClass().getName());
+
+        imagesMapElement.setText(new Gson().toJson(imagesMap));
+        return iqResponse;
+	}
+	
+	private IQ getImagesMapIQResponseWithWrongClass(Map<String, String> imagesMap) {
+        IQ iqResponse = new IQ();
+        Element queryEl = iqResponse.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_ALL_IMAGES.toString());
+        Element imagesMapElement = queryEl.addElement(IqElement.IMAGES_MAP.toString());
+
+        Element imagesMapClassNameElement = queryEl.addElement(IqElement.IMAGES_MAP_CLASS_NAME.toString());
+        imagesMapClassNameElement.setText("wrong-class-name");
+
+        imagesMapElement.setText(new Gson().toJson(imagesMap));
+        return iqResponse;
+	}
 }

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetAllImagesRequestTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetAllImagesRequestTest.java
@@ -1,19 +1,19 @@
 package org.fogbowcloud.manager.core.intercomponent.xmpp.requesters;
 
+import com.google.gson.Gson;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.dom4j.Element;
 import org.fogbowcloud.manager.core.exceptions.InvalidParameterException;
 import org.fogbowcloud.manager.core.exceptions.UnauthorizedRequestException;
 import org.fogbowcloud.manager.core.exceptions.UnavailableProviderException;
 import org.fogbowcloud.manager.core.exceptions.UnexpectedException;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.IQMatcher;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.IqElement;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.PacketSenderHolder;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.RemoteMethod;
 import org.fogbowcloud.manager.core.models.tokens.FederationUser;
 import org.jamppa.component.PacketSender;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -21,120 +21,105 @@ import org.mockito.Mockito;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.PacketError;
 
-import com.google.gson.Gson;
-
 public class RemoteGetAllImagesRequestTest {
-	
- 	private RemoteGetAllImagesRequest remoteGetAllImagesRequest;
-	private PacketSender packetSender;
-	private ArgumentCaptor<IQ> argIQ = ArgumentCaptor.forClass(IQ.class);
-	private FederationUser federationUser;
-	HashMap<String, String> imagesMap;
-	private final String provider = "provider";
-	
- 	@Before
-	public void setUp() throws InvalidParameterException {
- 		Map<String, String> attributes = new HashMap<String, String>();
- 		attributes.put("user-name", "user-name");
- 		this.federationUser = new FederationUser("federation-user-id", attributes);
- 		
-		this.remoteGetAllImagesRequest = new RemoteGetAllImagesRequest(provider, federationUser);
-		this.packetSender = Mockito.mock(PacketSender.class);
-		PacketSenderHolder.init(packetSender);
-		
-		this.imagesMap = new HashMap<String, String>();
-		this.imagesMap.put("key-1", "value-1");
-		this.imagesMap.put("key-2", "value-2");
-		this.imagesMap.put("key-3", "value-3");
-	}
- 	
- 	//test case: checks if IQ attributes is according to both RemoteGetAllImagesRequestTest constructor parameters 
- 	//and remote get all images request rules. In addition, it checks if the image map from a possible response is 
- 	//properly created and returned by the "send" method
-	@Test
-	public void testSend() throws Exception {
-		//set up
-		IQ iqResponse = getImagesMapIQResponse(this.imagesMap);
-		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(argIQ.capture());
- 		String federationUserJson = new Gson().toJson(this.federationUser);
 
- 		//exercise
-		HashMap<String, String> responseImagesMap = this.remoteGetAllImagesRequest.send();
-		
- 		//verify
-		IQ iq = argIQ.getValue();
-		Assert.assertEquals(IQ.Type.get.toString(), iq.getType().toString());
-		Assert.assertEquals(this.provider, iq.getTo().toString());
-		
-		Element iqElementQuery = iq.getElement().element(IqElement.QUERY.toString());
-		Assert.assertEquals(RemoteMethod.REMOTE_GET_ALL_IMAGES.toString(), iqElementQuery.getNamespaceURI());
-		
-		String iqQueryMemberId = iqElementQuery.element(IqElement.MEMBER_ID.toString()).getText();
-		Assert.assertEquals(this.provider, iqQueryMemberId);
-		
-		String iqQueryUser = iqElementQuery.element(IqElement.FEDERATION_USER.toString()).getText();
-		Assert.assertEquals(federationUserJson, iqQueryUser);
-		
-		Assert.assertEquals(this.imagesMap, responseImagesMap);
-	}
-	
-	//test case: checks if "send" is properly forwading UnavailableProviderException thrown by 
-	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response is null
-	@Test (expected = UnavailableProviderException.class)
-	public void testSendWhenResponseIsNull() throws Exception {
-		//set up
-		Mockito.doReturn(null).when(this.packetSender).syncSendPacket(this.argIQ.capture());
- 		
-		//exercise/verify
-		this.remoteGetAllImagesRequest.send();
-	}
-	
-	//test case: checks if "send" is properly forwading UnauthorizedRequestException thrown by 
-	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response status is forbidden
-	@Test (expected = UnauthorizedRequestException.class)
-	public void testSendWhenResponseReturnsForbidden() throws Exception {
-		//set up
-		IQ iqResponse = new IQ();
-		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
-		iqResponse.setError(new PacketError(PacketError.Condition.forbidden));
-		
-		//exercise/verify
-		this.remoteGetAllImagesRequest.send();
-	}
-	
-	//test case: checks if "send" is properly forwading UnexpectedException thrown by 
-	//"getImageFromResponse" when the images map class name from the IQ response is undefined (wrong or not found)
-	@Test(expected = UnexpectedException.class)
-	public void testSendWhenImageClassIsUndefined() throws Exception {
-		//set up
-		IQ iqResponse = getImagesMapIQResponseWithWrongClass(this.imagesMap);
-		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(argIQ.capture());
+    private final String PROVIDER = "provider";
 
- 		//exercise/verify
-		this.remoteGetAllImagesRequest.send();
-	}
-	
-	private IQ getImagesMapIQResponse(Map<String, String> imagesMap) {
+    private PacketSender packetSender;
+    private RemoteGetAllImagesRequest remoteGetAllImagesRequest;
+
+    private HashMap<String, String> imagesMap;
+    private FederationUser federationUser;
+
+    private ArgumentCaptor<IQ> argIQ = ArgumentCaptor.forClass(IQ.class);
+
+    @Before
+    public void setUp() throws InvalidParameterException {
+        Map<String, String> attributes = new HashMap<String, String>();
+        attributes.put("user-name", "user-name");
+        this.federationUser = new FederationUser("federation-user-id", attributes);
+
+        this.remoteGetAllImagesRequest = new RemoteGetAllImagesRequest(PROVIDER, federationUser);
+        this.packetSender = Mockito.mock(PacketSender.class);
+        PacketSenderHolder.init(packetSender);
+
+        this.imagesMap = new HashMap<String, String>();
+        this.imagesMap.put("key-1", "value-1");
+        this.imagesMap.put("key-2", "value-2");
+        this.imagesMap.put("key-3", "value-3");
+    }
+
+    // test case: checks if IQ attributes is according to both RemoteGetAllImagesRequestTest constructor parameters
+    // and remote get all images request rules. In addition, it checks if the image map from a possible response is
+    // properly created and returned by the "send" method
+    @Test
+    public void testSend() throws Exception {
+        // set up
+        IQ response = getImagesResponse(this.imagesMap, this.imagesMap.getClass().getName());
+        Mockito.doReturn(response).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
+
+        // exercise
+        this.remoteGetAllImagesRequest.send();
+
+        // verify
+        // as IQ does not implement equals we need a matcher
+        IQ expectedIQ = RemoteGetAllImagesRequest.marshal(PROVIDER, federationUser);
+        IQMatcher matcher = new IQMatcher(expectedIQ);
+        Mockito.verify(this.packetSender).syncSendPacket(Mockito.argThat(matcher));
+    }
+
+    // test case: checks if "send" is properly forwading UnavailableProviderException thrown by
+    // "XmppErrorConditionToExceptionTranslator.handleError" when the IQ response is null
+    @Test(expected = UnavailableProviderException.class)
+    public void testSendWhenResponseIsNull() throws Exception {
+        // set up
+        Mockito.doReturn(null).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
+
+        // exercise/verify
+        this.remoteGetAllImagesRequest.send();
+    }
+
+    // test case: checks if "send" is properly forwading UnauthorizedRequestException thrown by
+    // "XmppErrorConditionToExceptionTranslator.handleError" when the IQ response status is forbidden
+    @Test(expected = UnauthorizedRequestException.class)
+    public void testSendWhenResponseReturnsForbidden() throws Exception {
+        // set up
         IQ iqResponse = new IQ();
-        Element queryEl = iqResponse.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_ALL_IMAGES.toString());
+        Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
+        iqResponse.setError(new PacketError(PacketError.Condition.forbidden));
+
+        // exercise/verify
+        this.remoteGetAllImagesRequest.send();
+    }
+
+    // test case: checks if "send" is properly forwading UnexpectedException thrown by
+    // "getImageFromResponse" when the images map class name from the IQ response is undefined (wrong or not found)
+    @Test(expected = UnexpectedException.class)
+    public void testSendWhenImageClassIsUndefined() throws Exception {
+        // set up
+        IQ iqResponse = getImagesMapIQResponseWithWrongClass(this.imagesMap);
+        Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
+
+        // exercise/verify
+        this.remoteGetAllImagesRequest.send();
+    }
+
+    private IQ getImagesResponse(Map<String, String> imagesMap,
+        String className) {
+        IQ iqResponse = new IQ();
+        Element queryEl = iqResponse.getElement()
+            .addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_ALL_IMAGES.toString());
         Element imagesMapElement = queryEl.addElement(IqElement.IMAGES_MAP.toString());
 
-        Element imagesMapClassNameElement = queryEl.addElement(IqElement.IMAGES_MAP_CLASS_NAME.toString());
-        imagesMapClassNameElement.setText(imagesMap.getClass().getName());
+        Element imagesMapClassNameElement = queryEl
+            .addElement(IqElement.IMAGES_MAP_CLASS_NAME.toString());
+        imagesMapClassNameElement.setText(className);
 
         imagesMapElement.setText(new Gson().toJson(imagesMap));
         return iqResponse;
-	}
-	
-	private IQ getImagesMapIQResponseWithWrongClass(Map<String, String> imagesMap) {
-        IQ iqResponse = new IQ();
-        Element queryEl = iqResponse.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_ALL_IMAGES.toString());
-        Element imagesMapElement = queryEl.addElement(IqElement.IMAGES_MAP.toString());
+    }
 
-        Element imagesMapClassNameElement = queryEl.addElement(IqElement.IMAGES_MAP_CLASS_NAME.toString());
-        imagesMapClassNameElement.setText("wrong-class-name");
-
-        imagesMapElement.setText(new Gson().toJson(imagesMap));
-        return iqResponse;
-	}
+    private IQ getImagesMapIQResponseWithWrongClass(Map<String, String> imagesMap) {
+        return getImagesResponse(imagesMap, "wrongClassName");
+    }
 }

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetImageRequestTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetImageRequestTest.java
@@ -1,137 +1,122 @@
 package org.fogbowcloud.manager.core.intercomponent.xmpp.requesters;
 
+import com.google.gson.Gson;
 import java.util.HashMap;
 import java.util.Map;
- import org.dom4j.Element;
+import org.dom4j.Element;
 import org.fogbowcloud.manager.core.exceptions.InvalidParameterException;
 import org.fogbowcloud.manager.core.exceptions.UnauthorizedRequestException;
 import org.fogbowcloud.manager.core.exceptions.UnavailableProviderException;
 import org.fogbowcloud.manager.core.exceptions.UnexpectedException;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.IQMatcher;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.IqElement;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.PacketSenderHolder;
 import org.fogbowcloud.manager.core.intercomponent.xmpp.RemoteMethod;
 import org.fogbowcloud.manager.core.models.images.Image;
 import org.fogbowcloud.manager.core.models.tokens.FederationUser;
 import org.jamppa.component.PacketSender;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.xmpp.packet.IQ;
 import org.xmpp.packet.PacketError;
-import com.google.gson.Gson;
- 
+
 
 public class RemoteGetImageRequestTest {
 
- 	private RemoteGetImageRequest remoteGetImageRequest;
-	private PacketSender packetSender;
-	private ArgumentCaptor<IQ> argIQ = ArgumentCaptor.forClass(IQ.class);
-	private FederationUser federationUser;
-	
-	private final String provider = "provider";
-	private final String imageId = "imageId";
-	
- 	@Before
-	public void setUp() throws InvalidParameterException {
- 		Map<String, String> attributes = new HashMap<String, String>();
- 		attributes.put("user-name", "user-name");
- 		this.federationUser = new FederationUser("federation-user-id", attributes);
- 		
-		this.remoteGetImageRequest = new RemoteGetImageRequest(provider, imageId, federationUser);
-		this.packetSender = Mockito.mock(PacketSender.class);
-		PacketSenderHolder.init(packetSender);
-	}
- 	
- 	//test case: checks if IQ attributes is according to both RemoteGetImageRequest constructor parameters 
- 	//and remote get image request rules. In addition, it checks if the image from a possible response is 
- 	//properly created and returned by the "send" method
-	@Test
-	public void testSend() throws Exception {
-		//set up
-		Image image = new Image("image-id", "image-name", 10, 20, 30, "status");
-		IQ iqResponse = getImageIQResponse(image);
-		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(argIQ.capture());
- 		String federationUserJson = new Gson().toJson(this.federationUser);
+    private final String provider = "provider";
+    private final String imageId = "imageId";
+    private RemoteGetImageRequest remoteGetImageRequest;
+    private PacketSender packetSender;
+    private FederationUser federationUser;
 
- 		//exercise
-		Image responseImage = this.remoteGetImageRequest.send();
-		
- 		//verify
-		IQ iq = argIQ.getValue();
-		Assert.assertEquals(IQ.Type.get.toString(), iq.getType().toString());
-		Assert.assertEquals(this.provider, iq.getTo().toString());
-		
-		Element iqElementQuery = iq.getElement().element(IqElement.QUERY.toString());
-		Assert.assertEquals(RemoteMethod.REMOTE_GET_IMAGE.toString(), iqElementQuery.getNamespaceURI());
-		
-		String iqQueryMemberId = iqElementQuery.element(IqElement.MEMBER_ID.toString()).getText();
-		Assert.assertEquals(this.provider, iqQueryMemberId);
-		
-		String iqQueryImageId = iqElementQuery.element(IqElement.IMAGE_ID.toString()).getText();
-		Assert.assertEquals(this.imageId, iqQueryImageId);
-		
-		String iqQueryUser = iqElementQuery.element(IqElement.FEDERATION_USER.toString()).getText();
-		Assert.assertEquals(federationUserJson, iqQueryUser);
-		
-		Assert.assertEquals(image, responseImage);
-	}
-	
-	//test case: checks if "send" is properly forwading UnavailableProviderException thrown by 
-	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response is null
-	@Test (expected = UnavailableProviderException.class)
-	public void testSendWhenResponseIsNull() throws Exception {
-		//set up
-		Mockito.doReturn(null).when(this.packetSender).syncSendPacket(this.argIQ.capture());
- 		
-		//exercise/verify
-		this.remoteGetImageRequest.send();
-	}
-	
-	//test case: checks if "send" is properly forwading UnauthorizedRequestException thrown by 
-	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response status is forbidden
-	@Test (expected = UnauthorizedRequestException.class)
-	public void testSendWhenResponseReturnsForbidden() throws Exception {
-		//set up
-		IQ iqResponse = new IQ();
-		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
-		iqResponse.setError(new PacketError(PacketError.Condition.forbidden));
-		
-		//exercise/verify
-		this.remoteGetImageRequest.send();
-	}
-	
-	//test case: checks if "send" is properly forwading UnexpectedException thrown by 
-	//"getImageFromResponse" when the image class name from the IQ response is undefined (wrong or not found)
-	@Test(expected = UnexpectedException.class)
-	public void testSendWhenImageClassIsUndefined() throws Exception {
-		//set up
-		Image image = new Image("image-id", "image-name", 10, 20, 30, "status");
-		IQ iqResponse = getImageIQResponseWithWrongClass(image);
-		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(argIQ.capture());
+    @Before
+    public void setUp() throws InvalidParameterException {
+        Map<String, String> attributes = new HashMap<String, String>();
+        attributes.put("user-name", "user-name");
+        this.federationUser = new FederationUser("federation-user-id", attributes);
 
- 		//exercise/verify
-		this.remoteGetImageRequest.send();
-	}
-	
-	private IQ getImageIQResponse(Image image) {
-		IQ iqResponse = new IQ();
-        Element queryEl = iqResponse.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_IMAGE.toString());
+        this.remoteGetImageRequest = new RemoteGetImageRequest(provider, imageId, federationUser);
+        this.packetSender = Mockito.mock(PacketSender.class);
+        PacketSenderHolder.init(packetSender);
+    }
+
+    // test case: checks if IQ attributes is according to both RemoteGetImageRequest constructor parameters
+    // and remote get image request rules. In addition, it checks if the image from a possible response is
+    // properly created and returned by the "send" method
+    @Test
+    public void testSend() throws Exception {
+        // set up
+        Image image = new Image("image-id", "image-name", 10, 20, 30, "status");
+        IQ iqResponse = getImageIQResponse(image);
+        Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
+
+        // exercise
+        this.remoteGetImageRequest.send();
+
+        // verify
+        IQ expectedIq = RemoteGetImageRequest.marshal(provider, imageId, federationUser);
+        IQMatcher matcher = new IQMatcher(expectedIq);
+        Mockito.verify(this.packetSender).syncSendPacket(Mockito.argThat(matcher));
+    }
+
+    // test case: checks if "send" is properly forwading UnavailableProviderException thrown by
+    // "XmppErrorConditionToExceptionTranslator.handleError" when the IQ response is null
+    @Test(expected = UnavailableProviderException.class)
+    public void testSendWhenResponseIsNull() throws Exception {
+        // set up
+        Mockito.doReturn(null).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
+
+        // exercise/verify
+        this.remoteGetImageRequest.send();
+    }
+
+    //test case: checks if "send" is properly forwading UnauthorizedRequestException thrown by
+    //"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response status is forbidden
+    @Test(expected = UnauthorizedRequestException.class)
+    public void testSendWhenResponseReturnsForbidden() throws Exception {
+        // set up
+        IQ iqResponse = new IQ();
+        Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
+        iqResponse.setError(new PacketError(PacketError.Condition.forbidden));
+
+        // exercise/verify
+        this.remoteGetImageRequest.send();
+    }
+
+    // test case: checks if "send" is properly forwading UnexpectedException thrown by
+    // "getImageFromResponse" when the image class name from the IQ response is undefined (wrong or not found)
+    @Test(expected = UnexpectedException.class)
+    public void testSendWhenImageClassIsUndefined() throws Exception {
+        //set up
+        Image image = new Image("image-id", "image-name", 10, 20, 30, "status");
+        IQ iqResponse = getImageIQResponseWithWrongClass(image);
+        Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(Mockito.any(IQ.class));
+
+        // exercise/verify
+        this.remoteGetImageRequest.send();
+    }
+
+    private IQ getImageIQResponse(Image image) {
+        IQ iqResponse = new IQ();
+        Element queryEl = iqResponse.getElement()
+            .addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_IMAGE.toString());
         Element imageElement = queryEl.addElement(IqElement.IMAGE.toString());
         Element imageClassNameElement = queryEl.addElement(IqElement.IMAGE_CLASS_NAME.toString());
         imageClassNameElement.setText(image.getClass().getName());
         imageElement.setText(new Gson().toJson(image));
-		return iqResponse;
-	}
-	
-	private IQ getImageIQResponseWithWrongClass(Image image) {
-		IQ iqResponse = new IQ();
-        Element queryEl = iqResponse.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_IMAGE.toString());
+        return iqResponse;
+    }
+
+    private IQ getImageIQResponseWithWrongClass(Image image) {
+        IQ iqResponse = new IQ();
+        Element queryEl = iqResponse.getElement()
+            .addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_IMAGE.toString());
         Element imageElement = queryEl.addElement(IqElement.IMAGE.toString());
         Element imageClassNameElement = queryEl.addElement(IqElement.IMAGE_CLASS_NAME.toString());
         imageClassNameElement.setText("wrong-class-name");
         imageElement.setText(new Gson().toJson(image));
-		return iqResponse;
-	}
+        return iqResponse;
+    }
 }

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetImageRequestTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetImageRequestTest.java
@@ -1,0 +1,113 @@
+package org.fogbowcloud.manager.core.intercomponent.xmpp.requesters;
+
+import java.util.HashMap;
+import java.util.Map;
+ import org.dom4j.Element;
+import org.fogbowcloud.manager.core.exceptions.InvalidParameterException;
+import org.fogbowcloud.manager.core.exceptions.UnauthorizedRequestException;
+import org.fogbowcloud.manager.core.exceptions.UnavailableProviderException;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.IqElement;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.PacketSenderHolder;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.RemoteMethod;
+import org.fogbowcloud.manager.core.models.images.Image;
+import org.fogbowcloud.manager.core.models.tokens.FederationUser;
+import org.jamppa.component.PacketSender;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.PacketError;
+import com.google.gson.Gson;
+ 
+
+public class RemoteGetImageRequestTest {
+
+ 	private RemoteGetImageRequest remoteGetImageRequest;
+	private PacketSender packetSender;
+	private ArgumentCaptor<IQ> argIQ = ArgumentCaptor.forClass(IQ.class);
+	private FederationUser federationUser;
+	
+	private final String provider = "provider";
+	private final String imageId = "imageId";
+	
+ 	@Before
+	public void setUp() throws InvalidParameterException {
+ 		Map<String, String> attributes = new HashMap<String, String>();
+ 		attributes.put("user-name", "user-name");
+ 		this.federationUser = new FederationUser("federation-user-id", attributes);
+ 		
+		this.remoteGetImageRequest = new RemoteGetImageRequest(provider, imageId, federationUser);
+		this.packetSender = Mockito.mock(PacketSender.class);
+		PacketSenderHolder.init(packetSender);
+	}
+ 	
+ 	//test case: checks if IQ attributes is according to both RemoteGetImageRequest constructor parameters 
+ 	//and remote get image request rules. In addition, it checks if the image from a possible response is 
+ 	//properly created and returned by the "send" method
+	@Test
+	public void testSend() throws Exception {
+		//set up
+		Image image = new Image("image-id", "image-name", 10, 20, 30, "status");
+		IQ iqResponse = getImageIqResponse(image);
+		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(argIQ.capture());
+ 		String federationUserJson = new Gson().toJson(this.federationUser);
+
+ 		//exercise
+		Image responseImage = this.remoteGetImageRequest.send();
+		
+ 		//verify
+		IQ iq = argIQ.getValue();
+		Assert.assertEquals(IQ.Type.get.toString(), iq.getType().toString());
+		Assert.assertEquals(this.provider, iq.getTo().toString());
+		
+		Element iqElementQuery = iq.getElement().element(IqElement.QUERY.toString());
+		Assert.assertEquals(RemoteMethod.REMOTE_GET_IMAGE.toString(), iqElementQuery.getNamespaceURI());
+		
+		String iqQueryMemberId = iqElementQuery.element(IqElement.MEMBER_ID.toString()).getText();
+		Assert.assertEquals(this.provider, iqQueryMemberId);
+		
+		String iqQueryImageId = iqElementQuery.element(IqElement.IMAGE_ID.toString()).getText();
+		Assert.assertEquals(this.imageId, iqQueryImageId);
+		
+		String iqQueryUser = iqElementQuery.element(IqElement.FEDERATION_USER.toString()).getText();
+		Assert.assertEquals(federationUserJson, iqQueryUser);
+		
+		Assert.assertEquals(image, responseImage);
+	}
+	
+	//test case: Check if "send" is properly forwading UnavailableProviderException thrown by 
+	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response is null
+	@Test (expected = UnavailableProviderException.class)
+	public void testSendWhenResponseIsNull() throws Exception {
+		//set up
+		Mockito.doReturn(null).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+ 		
+		//exercise/verify
+		this.remoteGetImageRequest.send();
+	}
+	
+	//test case: Check if "send" is properly forwading UnauthorizedRequestException thrown by 
+	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response status is forbidden
+	@Test (expected = UnauthorizedRequestException.class)
+	public void testSendWhenResponseReturnsForbidden() throws Exception {
+		//set up
+		IQ iqResponse = new IQ();
+		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+		iqResponse.setError(new PacketError(PacketError.Condition.forbidden));
+		
+		//exercise/verify
+		this.remoteGetImageRequest.send();
+	}
+	
+	private IQ getImageIqResponse(Image image) {
+		IQ iqResponse = new IQ();
+        Element queryEl = iqResponse.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_IMAGE.toString());
+        Element imageElement = queryEl.addElement(IqElement.IMAGE.toString());
+        Element imageClassNameElement = queryEl.addElement(IqElement.IMAGE_CLASS_NAME.toString());
+        imageClassNameElement.setText(image.getClass().getName());
+        imageElement.setText(new Gson().toJson(image));
+		return iqResponse;
+	}
+}

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetOrderRequestTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetOrderRequestTest.java
@@ -1,0 +1,142 @@
+package org.fogbowcloud.manager.core.intercomponent.xmpp.requesters;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dom4j.Element;
+import org.fogbowcloud.manager.core.exceptions.InvalidParameterException;
+import org.fogbowcloud.manager.core.exceptions.UnauthorizedRequestException;
+import org.fogbowcloud.manager.core.exceptions.UnavailableProviderException;
+import org.fogbowcloud.manager.core.exceptions.UnexpectedException;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.IqElement;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.PacketSenderHolder;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.RemoteMethod;
+import org.fogbowcloud.manager.core.models.instances.ComputeInstance;
+import org.fogbowcloud.manager.core.models.instances.Instance;
+import org.fogbowcloud.manager.core.models.orders.ComputeOrder;
+import org.fogbowcloud.manager.core.models.orders.Order;
+import org.fogbowcloud.manager.core.models.tokens.FederationUser;
+import org.jamppa.component.PacketSender;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.PacketError;
+
+import com.google.gson.Gson;
+
+public class RemoteGetOrderRequestTest {
+	
+ 	private RemoteGetOrderRequest remoteGetOrderRequest;
+	private PacketSender packetSender;
+	private ArgumentCaptor<IQ> argIQ = ArgumentCaptor.forClass(IQ.class);
+	private FederationUser federationUser;
+	
+	private Instance instanceResponse;
+	private Order order;
+	
+ 	@Before
+	public void setUp() throws InvalidParameterException {
+		Map<String, String> attributes = new HashMap<String, String>();
+ 		attributes.put("user-name", "user-name");
+ 		this.federationUser = new FederationUser("federation-user-id", attributes);
+ 		this.order = new ComputeOrder(this.federationUser, "requesting-member", "providing-member", 10, 20, 30, "imageid", null,
+				"publicKey", null);
+		this.remoteGetOrderRequest = new RemoteGetOrderRequest(this.order);
+		this.packetSender = Mockito.mock(PacketSender.class);
+		PacketSenderHolder.init(packetSender);
+		this.instanceResponse = new ComputeInstance("compute-instance");
+	}
+ 	
+ 	//test case: checks if IQ attributes is according to both RemoteGetOrderRequest constructor parameters 
+ 	//and remote get order request rules. In addition, it checks if the instance from a possible response is 
+ 	//properly created and returned by the "send" method
+	@Test
+	public void testSend() throws Exception {
+		//set up
+ 		String federationUserJson = new Gson().toJson(this.federationUser);
+ 		IQ iqResponse = getInstanceIQResponse(this.instanceResponse);
+ 		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+
+ 		//exercise
+ 		Instance responseInstance = this.remoteGetOrderRequest.send();
+		
+ 		//verify
+		IQ iq = argIQ.getValue();
+		Assert.assertEquals(IQ.Type.get.toString(), iq.getType().toString());
+		Assert.assertEquals(this.order.getProvidingMember(), iq.getTo().toString());
+		
+		Element iqElementQuery = iq.getElement().element(IqElement.QUERY.toString());
+		Assert.assertEquals(RemoteMethod.REMOTE_GET_ORDER.toString(), iqElementQuery.getNamespaceURI());
+		
+		String iqOrderId = iqElementQuery.element(IqElement.ORDER_ID.toString()).getText();
+		Assert.assertEquals(this.order.getId(), iqOrderId);
+		
+		String iqInstanceId = iqElementQuery.element(IqElement.INSTANCE_TYPE.toString()).getText();
+		Assert.assertEquals(this.order.getType().toString(), iqInstanceId);
+		
+		String iqUser = iq.getElement().element(IqElement.FEDERATION_USER.toString()).getText();
+		Assert.assertEquals(federationUserJson, iqUser);
+		
+		Assert.assertEquals(this.instanceResponse, responseInstance);
+	}
+	
+	//test case: checks if "send" is properly forwading UnavailableProviderException thrown by 
+	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response is null
+	@Test (expected = UnavailableProviderException.class)
+	public void testSendWhenResponseIsNull() throws Exception {
+		//set up
+		Mockito.doReturn(null).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+ 		
+		//exercise/verify
+		this.remoteGetOrderRequest.send();
+	}
+	
+	//test case: checks if "send" is properly forwading UnauthorizedRequestException thrown by 
+	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response status is forbidden
+	@Test (expected = UnauthorizedRequestException.class)
+	public void testSendWhenResponseReturnsForbidden() throws Exception {
+		//set up
+		IQ iqResponse = new IQ();
+		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+		iqResponse.setError(new PacketError(PacketError.Condition.forbidden));
+		
+		//exercise/verify
+		this.remoteGetOrderRequest.send();
+	}
+	
+	//test case: checks if "send" is properly forwading UnexpectedException thrown by 
+	//"getImageFromResponse" when the image class name from the IQ response is undefined (wrong or not found)
+	@Test(expected = UnexpectedException.class)
+	public void testSendWhenImageClassIsUndefined() throws Exception {
+		//set up
+		Instance instanceResponse = new ComputeInstance("compute-instance");
+		IQ iqResponse = getInstanceIQResponseWithWrongClass(instanceResponse);
+		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+
+ 		//exercise/verify
+		this.remoteGetOrderRequest.send();
+	}
+	
+	private IQ getInstanceIQResponse(Instance instance) {
+        IQ iqResponse = new IQ();
+        Element queryEl = iqResponse.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_ORDER.toString());
+        Element instanceElement = queryEl.addElement(IqElement.INSTANCE.toString());
+        instanceElement.setText(new Gson().toJson(instance));
+        Element instanceClassNameElement = queryEl.addElement(IqElement.INSTANCE_CLASS_NAME.toString());
+        instanceClassNameElement.setText(instance.getClass().getName());
+        return iqResponse;
+	}
+	
+	private IQ getInstanceIQResponseWithWrongClass(Instance instance) {
+        IQ iqResponse = new IQ();
+        Element queryEl = iqResponse.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_ORDER.toString());
+        Element instanceElement = queryEl.addElement(IqElement.INSTANCE.toString());
+        instanceElement.setText(new Gson().toJson(instance));
+        Element instanceClassNameElement = queryEl.addElement(IqElement.INSTANCE_CLASS_NAME.toString());
+        instanceClassNameElement.setText("wrong-class-name");
+        return iqResponse;
+	}
+}

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetOrderRequestTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetOrderRequestTest.java
@@ -34,7 +34,7 @@ public class RemoteGetOrderRequestTest {
 	private ArgumentCaptor<IQ> argIQ = ArgumentCaptor.forClass(IQ.class);
 	private FederationUser federationUser;
 	
-	private Instance instanceResponse;
+	private Instance instance;
 	private Order order;
 	
  	@Before
@@ -47,7 +47,7 @@ public class RemoteGetOrderRequestTest {
 		this.remoteGetOrderRequest = new RemoteGetOrderRequest(this.order);
 		this.packetSender = Mockito.mock(PacketSender.class);
 		PacketSenderHolder.init(packetSender);
-		this.instanceResponse = new ComputeInstance("compute-instance");
+		this.instance = new ComputeInstance("compute-instance");
 	}
  	
  	//test case: checks if IQ attributes is according to both RemoteGetOrderRequest constructor parameters 
@@ -57,7 +57,7 @@ public class RemoteGetOrderRequestTest {
 	public void testSend() throws Exception {
 		//set up
  		String federationUserJson = new Gson().toJson(this.federationUser);
- 		IQ iqResponse = getInstanceIQResponse(this.instanceResponse);
+ 		IQ iqResponse = getInstanceIQResponse(this.instance);
  		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
 
  		//exercise
@@ -80,7 +80,7 @@ public class RemoteGetOrderRequestTest {
 		String iqUser = iq.getElement().element(IqElement.FEDERATION_USER.toString()).getText();
 		Assert.assertEquals(federationUserJson, iqUser);
 		
-		Assert.assertEquals(this.instanceResponse, responseInstance);
+		Assert.assertEquals(this.instance, responseInstance);
 	}
 	
 	//test case: checks if "send" is properly forwading UnavailableProviderException thrown by 
@@ -108,7 +108,7 @@ public class RemoteGetOrderRequestTest {
 	}
 	
 	//test case: checks if "send" is properly forwading UnexpectedException thrown by 
-	//"getImageFromResponse" when the image class name from the IQ response is undefined (wrong or not found)
+	//"getInstanceFromResponse" when the instance class name from the IQ response is undefined (wrong or not found)
 	@Test(expected = UnexpectedException.class)
 	public void testSendWhenImageClassIsUndefined() throws Exception {
 		//set up

--- a/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetUserQuotaRequestTest.java
+++ b/src/test/java/org/fogbowcloud/manager/core/intercomponent/xmpp/requesters/RemoteGetUserQuotaRequestTest.java
@@ -1,0 +1,161 @@
+package org.fogbowcloud.manager.core.intercomponent.xmpp.requesters;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dom4j.Element;
+import org.fogbowcloud.manager.core.exceptions.InvalidParameterException;
+import org.fogbowcloud.manager.core.exceptions.UnauthorizedRequestException;
+import org.fogbowcloud.manager.core.exceptions.UnavailableProviderException;
+import org.fogbowcloud.manager.core.exceptions.UnexpectedException;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.IqElement;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.PacketSenderHolder;
+import org.fogbowcloud.manager.core.intercomponent.xmpp.RemoteMethod;
+import org.fogbowcloud.manager.core.models.ResourceType;
+import org.fogbowcloud.manager.core.models.quotas.ComputeQuota;
+import org.fogbowcloud.manager.core.models.quotas.Quota;
+import org.fogbowcloud.manager.core.models.quotas.allocation.ComputeAllocation;
+import org.fogbowcloud.manager.core.models.tokens.FederationUser;
+import org.jamppa.component.PacketSender;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.xmpp.packet.IQ;
+import org.xmpp.packet.PacketError;
+
+import com.google.gson.Gson;
+
+public class RemoteGetUserQuotaRequestTest {
+	
+ 	private RemoteGetUserQuotaRequest remoteGetUserQuotaRequest;
+	private PacketSender packetSender;
+	private ArgumentCaptor<IQ> argIQ = ArgumentCaptor.forClass(IQ.class);
+	
+	private Quota quota;
+	private String provider;
+	private FederationUser federationUser;
+	private ResourceType resourceType;
+	
+ 	@Before
+	public void setUp() throws InvalidParameterException {
+		Map<String, String> attributes = new HashMap<String, String>();
+ 		attributes.put("user-name", "user-name");
+ 		this.federationUser = new FederationUser("federation-user-id", attributes);
+ 		this.provider = "provider";
+ 		this.resourceType = ResourceType.COMPUTE;
+		this.remoteGetUserQuotaRequest = new RemoteGetUserQuotaRequest(this.provider, this.federationUser, this.resourceType);
+		this.packetSender = Mockito.mock(PacketSender.class);
+		PacketSenderHolder.init(packetSender);
+		ComputeAllocation computeAllocation = new ComputeAllocation(10,  20,  30);
+		ComputeAllocation usedQuota = new ComputeAllocation(40, 50, 60);
+		this.quota = new ComputeQuota(computeAllocation, usedQuota);
+	}
+ 	
+ 	//test case: checks if IQ attributes is according to both RemoteGetUserQuotaRequest constructor parameters 
+ 	//and remote get user quota request rules. In addition, it checks if the instance from a possible response is 
+ 	//properly created and returned by the "send" method
+	@Test
+	public void testSend() throws Exception {
+		//set up
+ 		String federationUserJson = new Gson().toJson(this.federationUser);
+ 		IQ iqResponse = getQuotaIQResponse(this.quota);
+ 		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+
+ 		//exercise
+ 		Quota responseQuota = this.remoteGetUserQuotaRequest.send();
+		
+ 		//verify
+		IQ iq = argIQ.getValue();
+		Assert.assertEquals(IQ.Type.get.toString(), iq.getType().toString());
+		Assert.assertEquals(this.provider, iq.getTo().toString());
+		
+		Element iqElementQuery = iq.getElement().element(IqElement.QUERY.toString());
+		Assert.assertEquals(RemoteMethod.REMOTE_GET_USER_QUOTA.toString(), iqElementQuery.getNamespaceURI());
+		
+		String iqFederationUser = iq.getElement().element(IqElement.FEDERATION_USER.toString()).getText();
+		Assert.assertEquals(federationUserJson, iqFederationUser);
+		
+		String iqInstanceType = iqElementQuery.element(IqElement.INSTANCE_TYPE.toString()).getText();
+		Assert.assertEquals(this.resourceType.toString(), iqInstanceType);
+		
+		ComputeAllocation expectedComputeAvailableQuota = (ComputeAllocation) this.quota.getAvailableQuota();
+		ComputeAllocation actualComputeAvailableQuota = (ComputeAllocation) responseQuota.getAvailableQuota();
+		Assert.assertEquals(expectedComputeAvailableQuota.getRam(), actualComputeAvailableQuota.getRam());
+		Assert.assertEquals(expectedComputeAvailableQuota.getInstances(), actualComputeAvailableQuota.getInstances());
+		Assert.assertEquals(expectedComputeAvailableQuota.getvCPU(), actualComputeAvailableQuota.getvCPU());
+		
+		ComputeAllocation expectedComputeUsedQuota = (ComputeAllocation) this.quota.getUsedQuota();
+		ComputeAllocation actualComputeUsedQuota = (ComputeAllocation) responseQuota.getUsedQuota();
+		Assert.assertEquals(expectedComputeUsedQuota.getRam(), actualComputeUsedQuota.getRam());
+		Assert.assertEquals(expectedComputeUsedQuota.getInstances(), actualComputeUsedQuota.getInstances());
+		Assert.assertEquals(expectedComputeUsedQuota.getvCPU(), actualComputeUsedQuota.getvCPU());
+		
+		ComputeAllocation expectedComputeTotalQuota = (ComputeAllocation) this.quota.getTotalQuota();
+		ComputeAllocation actualComputeTotalQuota = (ComputeAllocation) responseQuota.getTotalQuota();
+		Assert.assertEquals(expectedComputeTotalQuota.getRam(), actualComputeTotalQuota.getRam());
+		Assert.assertEquals(expectedComputeTotalQuota.getInstances(), actualComputeTotalQuota.getInstances());
+		Assert.assertEquals(expectedComputeTotalQuota.getvCPU(), actualComputeTotalQuota.getvCPU());
+	}
+	
+	//test case: checks if "send" is properly forwading UnavailableProviderException thrown by 
+	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response is null
+	@Test (expected = UnavailableProviderException.class)
+	public void testSendWhenResponseIsNull() throws Exception {
+		//set up
+		Mockito.doReturn(null).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+ 		
+		//exercise/verify
+		this.remoteGetUserQuotaRequest.send();
+	}
+	
+	//test case: checks if "send" is properly forwading UnauthorizedRequestException thrown by 
+	//"XmppErrorConditionToExceptionTranslator.handleError" when the IQ response status is forbidden
+	@Test (expected = UnauthorizedRequestException.class)
+	public void testSendWhenResponseReturnsForbidden() throws Exception {
+		//set up
+		IQ iqResponse = new IQ();
+		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+		iqResponse.setError(new PacketError(PacketError.Condition.forbidden));
+		
+		//exercise/verify
+		this.remoteGetUserQuotaRequest.send();
+	}
+	
+	//test case: checks if "send" is properly forwading UnexpectedException thrown by 
+	//"getUserQuotaFromResponse" when the user quota class name from the IQ response is undefined (wrong or not found)
+	@Test(expected = UnexpectedException.class)
+	public void testSendWhenImageClassIsUndefined() throws Exception {
+		//set up
+		IQ iqResponse = getQuotaIQResponseWithWrongClass(this.quota);
+		Mockito.doReturn(iqResponse).when(this.packetSender).syncSendPacket(this.argIQ.capture());
+
+ 		//exercise/verify
+		this.remoteGetUserQuotaRequest.send();
+	}
+	
+	private IQ getQuotaIQResponse(Quota userQuota) {
+		IQ responseIq = new IQ();
+        Element queryEl = responseIq.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_USER_QUOTA.toString());
+        Element instanceElement = queryEl.addElement(IqElement.USER_QUOTA.toString());
+
+        Element instanceClassNameElement = queryEl.addElement(IqElement.USER_QUOTA_CLASS_NAME.toString());
+        instanceClassNameElement.setText(userQuota.getClass().getName());
+
+        instanceElement.setText(new Gson().toJson(userQuota));
+        return responseIq;
+	}
+	
+	private IQ getQuotaIQResponseWithWrongClass(Quota userQuota) {
+		IQ responseIq = new IQ();
+        Element queryEl = responseIq.getElement().addElement(IqElement.QUERY.toString(), RemoteMethod.REMOTE_GET_USER_QUOTA.toString());
+        Element instanceElement = queryEl.addElement(IqElement.USER_QUOTA.toString());
+
+        Element instanceClassNameElement = queryEl.addElement(IqElement.USER_QUOTA_CLASS_NAME.toString());
+        instanceClassNameElement.setText("wrong-class-name");
+
+        instanceElement.setText(new Gson().toJson(userQuota));
+        return responseIq;
+	}
+}


### PR DESCRIPTION
**Tests for:**
* RemoteGetAllImagesRequest
* RemoteGetImageRequest
* RemoteGetOrderRequest
* RemoteGetUserQuotaRequest

**logs added to gitignore**

**RemoteGetUserQuota Handler/Requester:** unnecessary member Id field removed
**RemoteGetUserQuotaRequest:** changing exception type when class name was not found