### PR TITLE
Refact system user persistence

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/datastore/services/RecoveryService.java
+++ b/src/main/java/cloud/fogbow/ras/core/datastore/services/RecoveryService.java
@@ -27,6 +27,7 @@ public class RecoveryService extends FogbowDatabaseService<Order> {
         if (this.orderRepository.exists(order.getId())) {
             throw new UnexpectedException(Messages.Exception.REQUEST_ALREADY_EXIST);
         }
+        order.serializeSystemUser();
         safeSave(order, this.orderRepository);
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
@@ -5,6 +5,7 @@ import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.ras.api.http.response.InstanceState;
 import cloud.fogbow.ras.core.datastore.DatabaseManager;
 import cloud.fogbow.ras.core.models.ResourceType;
+import com.google.gson.Gson;
 
 import javax.persistence.*;
 import javax.validation.constraints.Size;
@@ -65,6 +66,15 @@ public abstract class Order implements Serializable {
     // TODO: check if this is correct; we need to save the user.
     @Transient
     private SystemUser systemUser;
+
+    @Column
+    private String userId;
+
+    @Column
+    private String serializedSystemUser;
+
+    @Column
+    private String providerId;
 
     public Order() {
     }
@@ -168,6 +178,45 @@ public abstract class Order implements Serializable {
 
     public void setRequirements(Map<String, String> requirements) {
         this.requirements = requirements;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserId() {
+        return this.userId;
+    }
+
+    public void setSerializedSystemUser(String serializedSystemUser) {
+        this.serializedSystemUser = serializedSystemUser;
+    }
+
+    public String getSerializedSystemUser() {
+        return this.serializedSystemUser;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    public String getProviderId() {
+        return this.providerId;
+    }
+
+    @PrePersist
+    private void serializeSystemUser() {
+        Gson gson = new Gson();
+        this.serializedSystemUser = gson.toJson(this.systemUser);
+        System.out.println(serializedSystemUser);
+    }
+
+    @PostLoad
+    private void deserializeSystemUser() {
+        Gson gson = new Gson();
+        this.systemUser = gson.fromJson(this.serializedSystemUser, SystemUser.class);
+        System.out.println(systemUser);
+        System.out.println("blaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     }
 
     public boolean isProviderLocal(String localMemberId) {

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
@@ -68,12 +68,15 @@ public abstract class Order implements Serializable {
     private SystemUser systemUser;
 
     @Column
+    @Size(max = FIELDS_MAX_SIZE)
     private String userId;
 
     @Column
+    @Size(max = 1024)
     private String serializedSystemUser;
 
     @Column
+    @Size(max = FIELDS_MAX_SIZE)
     private String providerId;
 
     public Order() {
@@ -204,19 +207,17 @@ public abstract class Order implements Serializable {
         return this.providerId;
     }
 
-    @PrePersist
-    private void serializeSystemUser() {
+    public void serializeSystemUser() {
         Gson gson = new Gson();
-        this.serializedSystemUser = gson.toJson(this.systemUser);
-        System.out.println(serializedSystemUser);
+        this.setSerializedSystemUser(gson.toJson(this.getSystemUser()));
+        this.setUserId(this.getSystemUser().getId());
+        this.setProviderId(this.getSystemUser().getIdentityProviderId());
     }
 
     @PostLoad
     private void deserializeSystemUser() {
         Gson gson = new Gson();
-        this.systemUser = gson.fromJson(this.serializedSystemUser, SystemUser.class);
-        System.out.println(systemUser);
-        System.out.println("blaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        this.setSystemUser(gson.fromJson(this.getSerializedSystemUser(), SystemUser.class));
     }
 
     public boolean isProviderLocal(String localMemberId) {

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
@@ -3,6 +3,7 @@ package cloud.fogbow.ras.core.models.orders;
 import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.util.GsonHolder;
+import cloud.fogbow.common.util.SystemUserUtil;
 import cloud.fogbow.ras.api.http.response.InstanceState;
 import cloud.fogbow.ras.core.datastore.DatabaseManager;
 import cloud.fogbow.ras.core.models.ResourceType;
@@ -63,7 +64,6 @@ public abstract class Order implements Serializable {
     @Column
     private Map<String, String> requirements = new HashMap<>();
 
-    // TODO: check if this is correct; we need to save the user.
     @Transient
     private SystemUser systemUser;
 
@@ -72,7 +72,7 @@ public abstract class Order implements Serializable {
     private String userId;
 
     @Column
-    @Size(max = 1024)
+    @Size(max = SystemUserUtil.SERIALIZED_SYSTEM_USER_MAX_SIZE)
     private String serializedSystemUser;
 
     @Column
@@ -207,6 +207,8 @@ public abstract class Order implements Serializable {
         return this.providerId;
     }
 
+    // Cannot be called at @PrePersist because the transient field systemUser is set to null at this stage
+    // Instead, the systemUser is explicitly serialized before being save by RecoveryService.save().
     public void serializeSystemUser() {
         SerializableSystemUser serializableSystemUser = new SerializableSystemUser(this.getSystemUser());
         this.setSerializedSystemUser(GsonHolder.getInstance().toJson(serializableSystemUser));

--- a/src/test/java/cloud/fogbow/ras/core/datastore/RecoveryServiceTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/datastore/RecoveryServiceTest.java
@@ -203,15 +203,18 @@ public class RecoveryServiceTest extends BaseUnitTests {
         computeOrder.setOrderStateInTestMode(OrderState.OPEN);
 
         // creating attachment order with open state
-        Order attachmentOrder = new AttachmentOrder();
+        Order attachmentOrder = new AttachmentOrder(systemUser, FAKE_REQUESTING_MEMBER, FAKE_PROVIDING_MEMBER,
+                FAKE_CLOUD_NAME, FAKE_ID_1, FAKE_ID_1, null);
         attachmentOrder.setOrderStateInTestMode(OrderState.OPEN);
 
         // creating network order with fulfilled state
-        Order networkOrder = new NetworkOrder();
+        Order networkOrder = new NetworkOrder(systemUser, FAKE_REQUESTING_MEMBER, FAKE_PROVIDING_MEMBER,
+                FAKE_CLOUD_NAME, null, null, null, null);
         networkOrder.setOrderStateInTestMode(OrderState.FULFILLED);
 
         // creating volume order with fulfilled state
-        Order volumeOrder = new VolumeOrder();
+        Order volumeOrder = new VolumeOrder(systemUser, FAKE_REQUESTING_MEMBER, FAKE_PROVIDING_MEMBER,
+                FAKE_CLOUD_NAME, null, 0);
         volumeOrder.setOrderStateInTestMode(OrderState.FULFILLED);
 
         // exercise


### PR DESCRIPTION
The systemUser as a transient property in Order model was a big problem. The system needed the user saved to recovery from a possible crash, for example.
To solve this problem, and trying to avoid others, I've serialized the user with GSON and saved it before the order gets saved. On the other hand, when the order is retrieved, the user is reconstructed. For that, the private class SerializableSystemUser has been created to keep the information about what child class the user's instance was.