### PR TITLE
Adding domain name to CloudStackUser object in tests

### DIFF
--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/attachment/v4_9/CloudStackAttachmentPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/attachment/v4_9/CloudStackAttachmentPluginTest.java
@@ -34,6 +34,7 @@ public class CloudStackAttachmentPluginTest {
     private static final String JSON_FORMAT = "json";
     private static final String FAKE_USER_ID = "fake-user-id";
     private static final String FAKE_USERNAME = "fake-username";
+    private static final String FAKE_DOMAIN = "fake-domain";
     private static final String FAKE_TOKEN_VALUE = "fake-api-key:fake-secret-key";
     private static final HashMap<String, String> FAKE_COOKIE_HEADER = new HashMap<>();
     private static final String REQUEST_FORMAT = "%s?command=%s";
@@ -75,7 +76,7 @@ public class CloudStackAttachmentPluginTest {
         this.client = Mockito.mock(CloudStackHttpClient.class);
         this.plugin = new CloudStackAttachmentPlugin(cloudStackConfFilePath);
         this.plugin.setClient(this.client);
-        this.cloudUser =  new CloudStackUser(FAKE_USER_ID, FAKE_USERNAME, FAKE_TOKEN_VALUE, FAKE_COOKIE_HEADER);
+        this.cloudUser =  new CloudStackUser(FAKE_USER_ID, FAKE_USERNAME, FAKE_TOKEN_VALUE, FAKE_DOMAIN, FAKE_COOKIE_HEADER);
     }
 
     // test case: When calling the requestInstance method a HTTP GET request must be made with a

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/CloudStackComputePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/CloudStackComputePluginTest.java
@@ -59,9 +59,10 @@ public class CloudStackComputePluginTest {
 
     private static final String FAKE_USER_ID = "fake-user-id";
     private static final String FAKE_USERNAME = "fake-name";
+    private static final String FAKE_DOMAIN = "fake-domain";
     private static final String FAKE_TOKEN_VALUE = "fake-api-key:fake-secret-key";
 
-    public static final CloudStackUser FAKE_TOKEN =  new CloudStackUser(FAKE_USER_ID, FAKE_USERNAME, FAKE_TOKEN_VALUE, FAKE_COOKIE_HEADER);
+    public static final CloudStackUser FAKE_TOKEN =  new CloudStackUser(FAKE_USER_ID, FAKE_USERNAME, FAKE_TOKEN_VALUE, FAKE_DOMAIN, FAKE_COOKIE_HEADER);
 
     public static final String JSON = "json";
     public static final String RESPONSE_KEY = "response";

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/genericrequest/v4_9/CloudStackFogbowGenericRequestPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/genericrequest/v4_9/CloudStackFogbowGenericRequestPluginTest.java
@@ -27,6 +27,7 @@ public class CloudStackFogbowGenericRequestPluginTest {
     public static final String FAKE_TOKEN_VALUE = "foo" + CLOUDSTACK_SEPARATOR + "bar";
     public static final String FAKE_USER_ID = "fake-user-id";
     public static final String FAKE_NAME = "fake-name";
+    public static final String FAKE_DOMAIN = "fake-domain";
     private static final HashMap<String, String> FAKE_COOKIE_HEADER = new HashMap<>();
 
     private CloudStackUser fakeToken;
@@ -35,7 +36,7 @@ public class CloudStackFogbowGenericRequestPluginTest {
 
     @Before
     public void setUp() {
-        this.fakeToken = new CloudStackUser(FAKE_USER_ID, FAKE_NAME, FAKE_TOKEN_VALUE, FAKE_COOKIE_HEADER);
+        this.fakeToken = new CloudStackUser(FAKE_USER_ID, FAKE_NAME, FAKE_TOKEN_VALUE, FAKE_DOMAIN, FAKE_COOKIE_HEADER);
         this.client = Mockito.mock(CloudStackHttpClient.class);
 
         this.plugin = new CloudStackGenericRequestPlugin();

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/image/v4_9/CloudStackImagePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/image/v4_9/CloudStackImagePluginTest.java
@@ -38,6 +38,7 @@ public class CloudStackImagePluginTest {
 
     private static final String FAKE_USER_ID = "fake-user-id";
     private static final String FAKE_USERNAME = "fake-username";
+    private static final String FAKE_DOMAIN = "fake-domain";
     private static final String FAKE_TOKEN_VALUE = "fake-api-key:fake-secret-key";
     private static final String JSON = "json";
     private static final String RESPONSE_KEY = "response";
@@ -45,7 +46,7 @@ public class CloudStackImagePluginTest {
     public static final String CLOUD_NAME = "cloudstack";
     private static final HashMap<String, String> FAKE_COOKIE_HEADER = new HashMap<>();
 
-    public static final CloudStackUser FAKE_TOKEN =  new CloudStackUser(FAKE_USER_ID, FAKE_USERNAME, FAKE_TOKEN_VALUE, FAKE_COOKIE_HEADER);
+    public static final CloudStackUser FAKE_TOKEN =  new CloudStackUser(FAKE_USER_ID, FAKE_USERNAME, FAKE_TOKEN_VALUE, FAKE_DOMAIN, FAKE_COOKIE_HEADER);
 
     public static final String FAKE_ID = "fake-id";
     public static final String FAKE_NAME = "fake-name";

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/network/v4_9/CloudStackNetworkPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/network/v4_9/CloudStackNetworkPluginTest.java
@@ -44,6 +44,7 @@ public class CloudStackNetworkPluginTest {
 
     public static final String FAKE_ID = "fake-id";
     public static final String FAKE_NAME = "fake-name";
+    public static final String FAKE_DOMAIN = "fake-domain";
     public static final String FAKE_GATEWAY = "10.0.0.1";
     public static final String FAKE_ADDRESS = "10.0.0.0/24";
     public static final String FAKE_STATE = "Allocated";
@@ -53,7 +54,7 @@ public class CloudStackNetworkPluginTest {
     private static final String FAKE_TOKEN_VALUE = "fake-api-key:fake-secret-key";
     private static final HashMap<String, String> FAKE_COOKIE_HEADER = new HashMap<>();
 
-    public static final CloudStackUser FAKE_CLOUD_USER = new CloudStackUser(FAKE_USER_ID, FAKE_NAME, FAKE_TOKEN_VALUE, FAKE_COOKIE_HEADER);
+    public static final CloudStackUser FAKE_CLOUD_USER = new CloudStackUser(FAKE_USER_ID, FAKE_NAME, FAKE_TOKEN_VALUE, FAKE_DOMAIN, FAKE_COOKIE_HEADER);
     public static final String CLOUDSTACK_URL = "cloudstack_api_url";
     public static final String CLOUD_NAME = "cloudstack";
 

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/quota/v4_9/CloudStackComputeQuotaPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/quota/v4_9/CloudStackComputeQuotaPluginTest.java
@@ -39,6 +39,7 @@ public class CloudStackComputeQuotaPluginTest {
     private static final String CLOUDSTACK_URL = "cloudstack_api_url";
     private static final String FAKE_USER_ID = "fake-user-id";
     private static final String FAKE_NAME = "fake-name";
+    private static final String FAKE_DOMAIN = "fake-domain";
     private static final String FAKE_TOKEN_VALUE = "fake-api-key:fake-secret-key";
     private static final HashMap<String, String> FAKE_COOKIE_HEADER = new HashMap<>();
     private static final String FAKE_DOMAIN_ID = "fake-domain-id";
@@ -79,7 +80,7 @@ public class CloudStackComputeQuotaPluginTest {
         this.client = Mockito.mock(CloudStackHttpClient.class);
         this.plugin = new CloudStackComputeQuotaPlugin(cloudStackConfFilePath);
         this.plugin.setClient(this.client);
-        this.cloudUser = new CloudStackUser(FAKE_USER_ID, FAKE_NAME, FAKE_TOKEN_VALUE, FAKE_COOKIE_HEADER);
+        this.cloudUser = new CloudStackUser(FAKE_USER_ID, FAKE_NAME, FAKE_TOKEN_VALUE, FAKE_DOMAIN, FAKE_COOKIE_HEADER);
     }
 
     // test case: When calling the getUserQuota method, HTTP GET requests must be

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -52,9 +52,10 @@ public class CloudStackSecurityRulePluginTest {
 
     private static final String FAKE_USER_ID = "fake-user-id";
     private static final String FAKE_USERNAME = "fake-username";
+    private static final String FAKE_DOMAIN = "fake-domain";
     private static final String FAKE_TOKEN_VALUE = "x" + CloudStackConstants.KEY_VALUE_SEPARATOR + "y";
 
-    private static final CloudStackUser FAKE_CLOUD_USER = new CloudStackUser(FAKE_USER_ID, FAKE_USERNAME, FAKE_TOKEN_VALUE, FAKE_COOKIE_HEADER);
+    private static final CloudStackUser FAKE_CLOUD_USER = new CloudStackUser(FAKE_USER_ID, FAKE_USERNAME, FAKE_TOKEN_VALUE, FAKE_DOMAIN, FAKE_COOKIE_HEADER);
 
     private CloudStackSecurityRulePlugin plugin;
     private CloudStackHttpClient client;

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/volume/v4_9/CloudStackVolumePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/volume/v4_9/CloudStackVolumePluginTest.java
@@ -52,6 +52,7 @@ public class CloudStackVolumePluginTest {
     private static final String FAKE_ID = "fake-id";
     private static final String FAKE_JOB_ID = "fake-job-id";
     private static final String FAKE_NAME = "fake-name";
+    private static final String FAKE_DOMAIN = "fake-domain";
     private static final String FAKE_TAGS = "tag1:value1,tag2:value2";
     private static final HashMap<String, String> FAKE_COOKIE_HEADER = new HashMap<>();
     private static final String FAKE_USER_ID = "fake-user-id";
@@ -84,7 +85,7 @@ public class CloudStackVolumePluginTest {
         this.client = Mockito.mock(CloudStackHttpClient.class);
         this.plugin = new CloudStackVolumePlugin(cloudStackConfFilePath);
         this.plugin.setClient(this.client);
-        this.cloudUser = new CloudStackUser(FAKE_USER_ID, FAKE_NAME, FAKE_TOKEN_VALUE, FAKE_COOKIE_HEADER);
+        this.cloudUser = new CloudStackUser(FAKE_USER_ID, FAKE_NAME, FAKE_TOKEN_VALUE, FAKE_DOMAIN, FAKE_COOKIE_HEADER);
     }
 
     // test case: When calling the requestInstance method with a size compatible with the

--- a/src/test/java/cloud/fogbow/ras/core/plugins/mapper/all2one/CloudStackAllToOneMapperTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/mapper/all2one/CloudStackAllToOneMapperTest.java
@@ -28,6 +28,7 @@ public class CloudStackAllToOneMapperTest {
     private static final String FAKE_LOGIN2 = "fake-login2";
     private static final String FAKE_USER_ID = "fake-user-id";
     private static final String FAKE_USER_NAME = "fake-user-name";
+    private static final String FAKE_DOMAIN = "fake-domain";
     private static final String FAKE_TOKEN_VALUE = "fake-api-key:fake-secret-key";
     private static final HashMap<String, String> FAKE_COOKIE_HEADER = new HashMap<>();
 
@@ -54,7 +55,7 @@ public class CloudStackAllToOneMapperTest {
         SystemUser user1 = new SystemUser(FAKE_LOGIN1, FAKE_LOGIN1, this.memberId);
         SystemUser user2 = new SystemUser(FAKE_LOGIN2, FAKE_LOGIN2, this.memberId);
 
-        CloudStackUser systemUser = new CloudStackUser(FAKE_USER_ID, FAKE_USER_NAME, FAKE_TOKEN_VALUE, FAKE_COOKIE_HEADER);
+        CloudStackUser systemUser = new CloudStackUser(FAKE_USER_ID, FAKE_USER_NAME, FAKE_TOKEN_VALUE, FAKE_DOMAIN, FAKE_COOKIE_HEADER);
 
         Mockito.doReturn(systemUser).when(this.cloudStackIdentityProviderPlugin).getCloudUser(Mockito.anyMap());
 


### PR DESCRIPTION
The domain name is needed to properly authenticate using CloudStack
plugin. Not sure why or when it was removed from our CloudStackUser
code. I refactored common/as code to include the domain name.