### PR TITLE
Add resource type to order

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ras/core/ApplicationFacade.java
@@ -126,7 +126,7 @@ public class ApplicationFacade {
             }
         }
 
-        return activateOrder(order, userToken, ResourceType.COMPUTE);
+        return activateOrder(order, userToken);
     }
 
     public ComputeInstance getCompute(String orderId, String userToken) throws FogbowException {
@@ -148,7 +148,7 @@ public class ApplicationFacade {
     }
 
     public String createVolume(VolumeOrder volumeOrder, String userToken) throws FogbowException {
-        return activateOrder(volumeOrder, userToken, ResourceType.VOLUME);
+        return activateOrder(volumeOrder, userToken);
     }
 
     public VolumeInstance getVolume(String orderId, String userToken) throws FogbowException {
@@ -160,7 +160,7 @@ public class ApplicationFacade {
     }
 
     public String createNetwork(NetworkOrder networkOrder, String userToken) throws FogbowException {
-        return activateOrder(networkOrder, userToken, ResourceType.NETWORK);
+        return activateOrder(networkOrder, userToken);
     }
 
     public NetworkInstance getNetwork(String orderId, String userToken) throws FogbowException {
@@ -172,7 +172,7 @@ public class ApplicationFacade {
     }
 
     public String createAttachment(AttachmentOrder attachmentOrder, String userToken) throws FogbowException {
-        String attachmentOrderId = activateOrder(attachmentOrder, userToken, ResourceType.ATTACHMENT);
+        String attachmentOrderId = activateOrder(attachmentOrder, userToken);
         return attachmentOrderId;
     }
 
@@ -185,7 +185,7 @@ public class ApplicationFacade {
     }
 
     public String createPublicIp(PublicIpOrder publicIpOrder, String userToken) throws FogbowException {
-        String publicIpOrderId = activateOrder(publicIpOrder, userToken, ResourceType.PUBLIC_IP);
+        String publicIpOrderId = activateOrder(publicIpOrder, userToken);
         return publicIpOrderId;
     }
 
@@ -275,10 +275,9 @@ public class ApplicationFacade {
         return cloudConnector.genericRequest(genericRequest, requester);
     }
 
-    private String activateOrder(Order order, String userToken, ResourceType resourceType) throws FogbowException {
+    private String activateOrder(Order order, String userToken) throws FogbowException {
         // Set order fields that have not been provided by the requester in the body of the HTTP request
         order.setRequester(this.memberId);
-        order.setType(resourceType);
         if (order.getProvider() == null || order.getProvider().isEmpty()) order.setProvider(this.memberId);
         if (order.getCloudName() == null || order.getCloudName().isEmpty())
             order.setCloudName(this.cloudListController.getDefaultCloudName());

--- a/src/main/java/cloud/fogbow/ras/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ras/core/ApplicationFacade.java
@@ -126,7 +126,7 @@ public class ApplicationFacade {
             }
         }
 
-        return activateOrder(order, userToken);
+        return activateOrder(order, userToken, ResourceType.COMPUTE);
     }
 
     public ComputeInstance getCompute(String orderId, String userToken) throws FogbowException {
@@ -148,7 +148,7 @@ public class ApplicationFacade {
     }
 
     public String createVolume(VolumeOrder volumeOrder, String userToken) throws FogbowException {
-        return activateOrder(volumeOrder, userToken);
+        return activateOrder(volumeOrder, userToken, ResourceType.VOLUME);
     }
 
     public VolumeInstance getVolume(String orderId, String userToken) throws FogbowException {
@@ -160,7 +160,7 @@ public class ApplicationFacade {
     }
 
     public String createNetwork(NetworkOrder networkOrder, String userToken) throws FogbowException {
-        return activateOrder(networkOrder, userToken);
+        return activateOrder(networkOrder, userToken, ResourceType.NETWORK);
     }
 
     public NetworkInstance getNetwork(String orderId, String userToken) throws FogbowException {
@@ -172,7 +172,7 @@ public class ApplicationFacade {
     }
 
     public String createAttachment(AttachmentOrder attachmentOrder, String userToken) throws FogbowException {
-        String attachmentOrderId = activateOrder(attachmentOrder, userToken);
+        String attachmentOrderId = activateOrder(attachmentOrder, userToken, ResourceType.ATTACHMENT);
         return attachmentOrderId;
     }
 
@@ -185,7 +185,7 @@ public class ApplicationFacade {
     }
 
     public String createPublicIp(PublicIpOrder publicIpOrder, String userToken) throws FogbowException {
-        String publicIpOrderId = activateOrder(publicIpOrder, userToken);
+        String publicIpOrderId = activateOrder(publicIpOrder, userToken, ResourceType.PUBLIC_IP);
         return publicIpOrderId;
     }
 
@@ -275,9 +275,10 @@ public class ApplicationFacade {
         return cloudConnector.genericRequest(genericRequest, requester);
     }
 
-    private String activateOrder(Order order, String userToken) throws FogbowException {
+    private String activateOrder(Order order, String userToken, ResourceType resourceType) throws FogbowException {
         // Set order fields that have not been provided by the requester in the body of the HTTP request
         order.setRequester(this.memberId);
+        order.setType(resourceType);
         if (order.getProvider() == null || order.getProvider().isEmpty()) order.setProvider(this.memberId);
         if (order.getCloudName() == null || order.getCloudName().isEmpty())
             order.setCloudName(this.cloudListController.getDefaultCloudName());

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/AttachmentOrder.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/AttachmentOrder.java
@@ -74,11 +74,6 @@ public class AttachmentOrder extends Order {
     }
 
     @Override
-    public ResourceType getType() {
-        return ResourceType.ATTACHMENT;
-    }
-
-    @Override
     public String getSpec() {
         // TODO
         return "";

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/AttachmentOrder.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/AttachmentOrder.java
@@ -35,14 +35,17 @@ public class AttachmentOrder extends Order {
 
     public AttachmentOrder() {
         this(UUID.randomUUID().toString());
+        this.type = ResourceType.ATTACHMENT;
     }
 
     public AttachmentOrder(String id) {
         super(id);
+        this.type = ResourceType.ATTACHMENT;
     }
 
     public AttachmentOrder(String providingMember, String cloudName, String computeId, String volumeId, String device) {
         this(null, null, providingMember, cloudName, computeId, volumeId, device);
+        this.type = ResourceType.ATTACHMENT;
     }
 
     public AttachmentOrder(SystemUser systemUser, String requestingMember,
@@ -51,6 +54,7 @@ public class AttachmentOrder extends Order {
         this.computeId = computeId;
         this.volumeId = volumeId;
         this.device = device;
+        this.type = ResourceType.ATTACHMENT;
     }
 
     public String getComputeId() {

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/ComputeOrder.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/ComputeOrder.java
@@ -133,11 +133,6 @@ public class ComputeOrder extends Order {
         this.userData = userData;
     }
 
-    @Override
-    public ResourceType getType() {
-        return ResourceType.COMPUTE;
-    }
-
     public String getPublicKey() {
         return publicKey;
     }

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/ComputeOrder.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/ComputeOrder.java
@@ -59,10 +59,12 @@ public class ComputeOrder extends Order {
 
     public ComputeOrder() {
         this(UUID.randomUUID().toString());
+        this.type = ResourceType.COMPUTE;
     }
 
     public ComputeOrder(String id) {
         super(id);
+        this.type = ResourceType.COMPUTE;
     }
 
     public ComputeOrder(String id, SystemUser systemUser, String requestingMember, String providingMember,
@@ -78,12 +80,14 @@ public class ComputeOrder extends Order {
         this.publicKey = publicKey;
         this.networkIds = networkIds;
         this.actualAllocation = new ComputeAllocation();
+        this.type = ResourceType.COMPUTE;
     }
 
     public ComputeOrder(String providingMember, String cloudName, String name, int vCPU, int memory, int disk, String imageId,
                         ArrayList<UserData> userData, String publicKey, List<String> networkIds) {
         this(null, null, providingMember, cloudName, name, vCPU, memory, disk, imageId,
                 userData, publicKey, networkIds);
+        this.type = ResourceType.COMPUTE;
     }
 
     public ComputeOrder(SystemUser systemUser, String requestingMember, String providingMember,
@@ -91,6 +95,7 @@ public class ComputeOrder extends Order {
                         List<String> networkIds) {
         this(UUID.randomUUID().toString(), systemUser, requestingMember, providingMember, cloudName, name, vCPU, memory,
                 disk, imageId, userData, publicKey, networkIds);
+        this.type = ResourceType.COMPUTE;
     }
 
     public ComputeAllocation getActualAllocation() {

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/NetworkOrder.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/NetworkOrder.java
@@ -38,15 +38,18 @@ public class NetworkOrder extends Order {
 
     public NetworkOrder() {
         this(UUID.randomUUID().toString());
+        this.type = ResourceType.NETWORK;
     }
 
     public NetworkOrder(String id) {
         super(id);
+        this.type = ResourceType.NETWORK;
     }
 
     public NetworkOrder(String providingMember, String cloudName, String name, String gateway, String cidr,
                         NetworkAllocationMode allocationMode) {
         this(null, null, providingMember, cloudName, name, gateway, cidr, allocationMode);
+        this.type = ResourceType.NETWORK;
     }
 
     public NetworkOrder(SystemUser systemUser, String requestingMember, String providingMember,
@@ -56,6 +59,7 @@ public class NetworkOrder extends Order {
         this.gateway = gateway;
         this.cidr = cidr;
         this.allocationMode = allocationMode;
+        this.type = ResourceType.NETWORK;
     }
 
     public String getName() {

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/NetworkOrder.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/NetworkOrder.java
@@ -75,11 +75,6 @@ public class NetworkOrder extends Order {
     }
 
     @Override
-    public ResourceType getType() {
-        return ResourceType.NETWORK;
-    }
-
-    @Override
     public String getSpec() {
         return "";
     }

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
@@ -70,7 +70,7 @@ public abstract class Order implements Serializable {
     private SystemUser systemUser;
 
     @Column
-    @Size(max = 4)
+    @Size(max = FIELDS_MAX_SIZE)
     private String userId;
 
     @Column

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
@@ -70,7 +70,7 @@ public abstract class Order implements Serializable {
     private SystemUser systemUser;
 
     @Column
-    @Size(max = FIELDS_MAX_SIZE)
+    @Size(max = 4)
     private String userId;
 
     @Column
@@ -80,6 +80,10 @@ public abstract class Order implements Serializable {
     @Column
     @Size(max = FIELDS_MAX_SIZE)
     private String providerId;
+
+    @Column
+    @Size(max = FIELDS_MAX_SIZE)
+    private ResourceType type;
 
     public Order() {
     }
@@ -263,7 +267,13 @@ public abstract class Order implements Serializable {
                 + this.provider + ", instanceId=" + this.instanceId + "]";
     }
 
-    public abstract ResourceType getType();
+    public ResourceType getType() {
+        return this.type;
+    }
+
+    public void setType(ResourceType type) {
+        this.type = type;
+    }
 
     public abstract String getSpec();
 }

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
@@ -82,8 +82,8 @@ public abstract class Order implements Serializable {
     private String providerId;
 
     @Column
-    @Size(max = FIELDS_MAX_SIZE)
-    private ResourceType type;
+    @Enumerated(EnumType.STRING)
+    protected ResourceType type;
 
     public Order() {
     }

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/PublicIpOrder.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/PublicIpOrder.java
@@ -41,11 +41,6 @@ public class PublicIpOrder extends Order {
         this.computeOrderId = computeOrderId;
     }
 
-    @Override
-    public ResourceType getType() {
-        return ResourceType.PUBLIC_IP;
-    }
-
     public String getComputeOrderId() {
         return computeOrderId;
     }

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/PublicIpOrder.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/PublicIpOrder.java
@@ -25,20 +25,24 @@ public class PublicIpOrder extends Order {
 
     public PublicIpOrder() {
         this(UUID.randomUUID().toString());
+        this.type = ResourceType.PUBLIC_IP;
     }
 
     public PublicIpOrder(String id) {
         super(id);
+        this.type = ResourceType.PUBLIC_IP;
     }
 
     public PublicIpOrder(String providingMember, String cloudName, String computeOrderId) {
         this(null, null, providingMember, cloudName, computeOrderId);
+        this.type = ResourceType.PUBLIC_IP;
     }
 
     public PublicIpOrder(SystemUser systemUser, String requestingMember,
                          String providingMember, String cloudName, String computeOrderId) {
         super(UUID.randomUUID().toString(), providingMember, cloudName, systemUser, requestingMember);
         this.computeOrderId = computeOrderId;
+        this.type = ResourceType.PUBLIC_IP;
     }
 
     public String getComputeOrderId() {

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/VolumeOrder.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/VolumeOrder.java
@@ -53,11 +53,6 @@ public class VolumeOrder extends Order {
     }
 
     @Override
-    public ResourceType getType() {
-        return ResourceType.VOLUME;
-    }
-
-    @Override
     public String getSpec() {
         return String.valueOf(this.volumeSize);
     }

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/VolumeOrder.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/VolumeOrder.java
@@ -27,14 +27,17 @@ public class VolumeOrder extends Order {
 
     public VolumeOrder() {
         this(UUID.randomUUID().toString());
+        this.type = ResourceType.VOLUME;
     }
 
     public VolumeOrder(String id) {
         super(id);
+        this.type = ResourceType.VOLUME;
     }
 
     public VolumeOrder(String providingMember, String cloudName, String name, int volumeSize) {
         this(null, null, providingMember, cloudName, name, volumeSize);
+        this.type = ResourceType.VOLUME;
     }
 
     public VolumeOrder(SystemUser systemUser, String requestingMember, String providingMember,
@@ -42,6 +45,7 @@ public class VolumeOrder extends Order {
         super(UUID.randomUUID().toString(), providingMember, cloudName, systemUser, requestingMember);
         this.name = name;
         this.volumeSize = volumeSize;
+        this.type = ResourceType.VOLUME;
     }
 
     public int getVolumeSize() {


### PR DESCRIPTION
The way the resourceType was available didn't allow the field to be saved in the db. I've added a regular attribute called type into order and set it in each order's constructor (by order I mean Order and its children).