### PR TITLE
Processors cover tests

### DIFF
--- a/src/main/java/cloud/fogbow/ras/api/http/response/quotas/allocation/ComputeAllocation.java
+++ b/src/main/java/cloud/fogbow/ras/api/http/response/quotas/allocation/ComputeAllocation.java
@@ -1,6 +1,5 @@
 package cloud.fogbow.ras.api.http.response.quotas.allocation;
 
-import cloud.fogbow.ras.constants.ApiDocumentation;
 import io.swagger.annotations.ApiModelProperty;
 
 import javax.persistence.Column;

--- a/src/main/java/cloud/fogbow/ras/core/OrderController.java
+++ b/src/main/java/cloud/fogbow/ras/core/OrderController.java
@@ -145,8 +145,9 @@ public class OrderController {
     }
 
     public Instance getResourceInstance(Order order) throws FogbowException {
-        if (order == null)
-        	throw new UnexpectedException(Messages.Exception.CORRUPTED_INSTANCE);
+        if (order == null) {
+            throw new UnexpectedException(Messages.Exception.CORRUPTED_INSTANCE);
+        }
 
         synchronized (order) {
             if ((!this.localProviderId.equals(order.getProvider())) && order.getOrderState().equals(OrderState.OPEN)) {
@@ -429,7 +430,7 @@ public class OrderController {
         }
     }
 
-    private void checkOrderDependencies(String orderId) throws DependencyDetectedException {
+    protected void checkOrderDependencies(String orderId) throws DependencyDetectedException {
         Order order = SharedOrderHolders.getInstance().getActiveOrdersMap().get(orderId);
         synchronized (order) {
             if (this.orderDependencies.containsKey(orderId) &&

--- a/src/main/java/cloud/fogbow/ras/core/OrderController.java
+++ b/src/main/java/cloud/fogbow/ras/core/OrderController.java
@@ -307,7 +307,7 @@ public class OrderController {
         }
     }
 
-    private Instance updateInstanceUsingOrderData(Instance instance, Order order) throws FogbowException {
+    private Instance updateInstanceUsingOrderData(Instance instance, Order order) {
         switch (order.getType()) {
             case COMPUTE:
                 updateComputeInstanceUsingOrderData(((ComputeInstance) instance), ((ComputeOrder) order));
@@ -332,7 +332,7 @@ public class OrderController {
         return instance;
     }
 
-    private void updateComputeInstanceUsingOrderData(ComputeInstance instance, ComputeOrder order) throws FogbowException {
+    private void updateComputeInstanceUsingOrderData(ComputeInstance instance, ComputeOrder order) {
         String publicKey = order.getPublicKey();
         instance.setImageId(order.getImageId());
         List<UserData> userData = order.getUserData();
@@ -431,7 +431,7 @@ public class OrderController {
         }
     }
 
-    protected boolean hasOrderDependencies(String orderId) throws DependencyDetectedException {
+    protected boolean hasOrderDependencies(String orderId) {
         Order order = SharedOrderHolders.getInstance().getActiveOrdersMap().get(orderId);
         synchronized (order) {
             if (this.orderDependencies.containsKey(orderId) && !this.orderDependencies.get(orderId).isEmpty()) {

--- a/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
+++ b/src/main/java/cloud/fogbow/ras/core/models/orders/Order.java
@@ -111,6 +111,7 @@ public abstract class Order<T extends Order> implements Serializable {
         return this.orderState;
     }
 
+    // TODO remove this method when it's no longer used
     public void setOrderStateInTestMode(OrderState state) {
         this.orderState = state;
     }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/genericrequest/v4_9/CloudStackGenericRequestPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/genericrequest/v4_9/CloudStackGenericRequestPlugin.java
@@ -13,7 +13,7 @@ import com.google.gson.Gson;
 import org.apache.http.client.utils.URIBuilder;
 
 import java.net.URISyntaxException;
-import java.util.HashMap;
+import java.util.Map;
 
 public class CloudStackGenericRequestPlugin implements GenericRequestPlugin<CloudStackUser> {
 
@@ -31,8 +31,8 @@ public class CloudStackGenericRequestPlugin implements GenericRequestPlugin<Clou
             CloudStackUrlUtil.sign(uriBuilder, cloudUser.getToken());
 
             String url = uriBuilder.toString();
-            HashMap<String, String> headers = httpRequest.getHeaders();
-            HashMap<String, String> body = httpRequest.getBody();
+            Map<String, String> headers = httpRequest.getHeaders();
+            Map<String, String> body = httpRequest.getBody();
             return client.doGenericRequest(HttpMethod.GET, url, headers, body, cloudUser);
         } catch (URISyntaxException e) {
             throw new FogbowException(String.format(Messages.Exception.MALFORMED_GENERIC_REQUEST_URL, httpRequest.getUrl()));

--- a/src/test/java/cloud/fogbow/ras/core/BaseUnitTests.java
+++ b/src/test/java/cloud/fogbow/ras/core/BaseUnitTests.java
@@ -34,24 +34,23 @@ import cloud.fogbow.ras.core.models.orders.VolumeOrder;
 @PrepareForTest({ CloudConnectorFactory.class, DatabaseManager.class })
 public class BaseUnitTests {
 
-    public static final int CPU_VALUE = 8;
-    public static final int DISK_VALUE = 30;
-    public static final int MEMORY_VALUE = 1024;
+    protected static final int CPU_VALUE = 8;
+    protected static final int DISK_VALUE = 30;
+    protected static final int MEMORY_VALUE = 1024;
 
-    public static final long DEFAULT_SLEEP_TIME = 500;
+    protected static final long DEFAULT_SLEEP_TIME = 500;
     
-    public static final String DEFAULT_CLOUD_NAME = "default";
-    public static final String FAKE_DEVICE = "fake-device";
-    public static final String FAKE_IMAGE_NAME = "fake-image-name";
-    public static final String FAKE_INSTANCE_ID = "fake-instance-id";
-    public static final String FAKE_INSTANCE_NAME = "fake-instance-name";
-    public static final String FAKE_ORDER_NAME = "fake-order-name";
-    public static final String FAKE_PUBLIC_KEY= "fake-public-key";
-    public static final String FAKE_REMOTE_MEMBER_ID = "fake-intercomponent-member";
-    public static final String FAKE_USER_ID = "fake-user-id";
-    public static final String FAKE_USER_NAME = "fake-user-name";
-    public static final String RESOURCES_PATH_TEST = "src/test/resources/private";
-    public static final String LOCAL_MEMBER_ID =
+    protected static final String DEFAULT_CLOUD_NAME = "default";
+    protected static final String FAKE_DEVICE = "fake-device";
+    protected static final String FAKE_IMAGE_NAME = "fake-image-name";
+    protected static final String FAKE_INSTANCE_ID = "fake-instance-id";
+    protected static final String FAKE_INSTANCE_NAME = "fake-instance-name";
+    protected static final String FAKE_ORDER_NAME = "fake-order-name";
+    protected static final String FAKE_PUBLIC_KEY= "fake-public-key";
+    protected static final String FAKE_REMOTE_MEMBER_ID = "fake-intercomponent-member";
+    protected static final String FAKE_USER_ID = "fake-user-id";
+    protected static final String FAKE_USER_NAME = "fake-user-name";
+    protected static final String LOCAL_MEMBER_ID =
             PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.LOCAL_PROVIDER_ID_KEY);
     
     protected LocalCloudConnector localCloudConnector;
@@ -121,9 +120,9 @@ public class BaseUnitTests {
                         providingMember,
                         DEFAULT_CLOUD_NAME, 
                         instanceName,
-                        8,
-                        1024,
-                        30,
+                        CPU_VALUE,
+                        MEMORY_VALUE,
+                        DISK_VALUE,
                         imageName,
                         mockUserData(),
                         publicKey,

--- a/src/test/java/cloud/fogbow/ras/core/BaseUnitTests.java
+++ b/src/test/java/cloud/fogbow/ras/core/BaseUnitTests.java
@@ -21,21 +21,25 @@ import java.util.Map;
 @PrepareForTest(DatabaseManager.class)
 public class BaseUnitTests {
 
+    public static final int CPU_VALUE = 8;
+    public static final int DISK_VALUE = 30;
+    public static final int MEMORY_VALUE = 1024;
+
+    public static final long DEFAULT_SLEEP_TIME = 500;
+    
+    public static final String DEFAULT_CLOUD_NAME = "default";
+    public static final String FAKE_DEVICE = "fake-device";
+    public static final String FAKE_IMAGE_NAME = "fake-image-name";
+    public static final String FAKE_INSTANCE_ID = "fake-instance-id";
+    public static final String FAKE_INSTANCE_NAME = "fake-instance-name";
+    public static final String FAKE_ORDER_NAME = "fake-order-name";
+    public static final String FAKE_PUBLIC_KEY= "fake-public-key";
+    public static final String FAKE_REMOTE_MEMBER_ID = "fake-intercomponent-member";
+    public static final String FAKE_USER_ID = "fake-user-id";
+    public static final String FAKE_USER_NAME = "fake-user-name";
+    public static final String RESOURCES_PATH_TEST = "src/test/resources/private";
     public static final String LOCAL_MEMBER_ID =
             PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.LOCAL_PROVIDER_ID_KEY);
-
-    public static final String FAKE_CLOUD_NAME = "fake-cloud";
-    public static final String FAKE_DEVICE = "fake-device";
-    public static final String FAKE_ID = "fake-id";
-    public static final String FAKE_IMAGE_NAME = "fake-image-name";
-    public static final String FAKE_INSTANCE_NAME = "fake-instance-name";
-    public static final String FAKE_NAME = "fake-name";
-    public static final String FAKE_PUBLIC_KEY= "fake-public-key";
-    public static final String FAKE_USER = "fake-user";
-    public static final int FAKE_VOLUME_SIZE = 42;
-    public static final String REMOTE_MEMBER_ID = "remote-member-id";
-    public static final String RESOURCES_PATH_TEST = "src/test/resources/private";
-
 
     /**
      * Clears the orders from the lists on the SharedOrderHolders instance.
@@ -81,7 +85,7 @@ public class BaseUnitTests {
     }
 
     protected Order createRemoteOrder(String requestingMember) {
-        String providingMember = REMOTE_MEMBER_ID;
+        String providingMember = FAKE_REMOTE_MEMBER_ID;
         return createOrder(requestingMember, providingMember);
     }
 
@@ -91,21 +95,22 @@ public class BaseUnitTests {
 
     protected ComputeOrder createLocalComputeOrder(String requestingMember, String providingMember) {
         SystemUser systemUser = Mockito.mock(SystemUser.class);
-        String imageName = "fake-image-name";
-        String publicKey = "fake-public-key";
-        String instanceName = "fake-instance-name";
+        String imageName = FAKE_IMAGE_NAME;
+        String publicKey = FAKE_PUBLIC_KEY;
+        String instanceName = FAKE_INSTANCE_NAME;
 
         ComputeOrder localOrder =
                 new ComputeOrder(
                         systemUser,
                         requestingMember,
                         providingMember,
-                        "default", instanceName,
+                        DEFAULT_CLOUD_NAME, 
+                        instanceName,
                         8,
                         1024,
                         30,
                         imageName,
-                        null,
+                        mockUserData(),
                         publicKey,
                         null);
 
@@ -120,9 +125,9 @@ public class BaseUnitTests {
                         systemUser,
                         providingMember,
                         requestingMember,
-                        FAKE_CLOUD_NAME,
-                        FAKE_NAME,
-                        FAKE_VOLUME_SIZE);
+                        DEFAULT_CLOUD_NAME,
+                        FAKE_ORDER_NAME,
+                        DISK_VALUE);
 
         return volumeOrder;
     }
@@ -132,30 +137,27 @@ public class BaseUnitTests {
         String computeId = computeOrder.getId();
         String volumeId = volumeOrder.getId();
 
-        String device = FAKE_DEVICE;
-
         AttachmentOrder attachmentOrder =
                 new AttachmentOrder(
                         systemUser,
                         LOCAL_MEMBER_ID,
                         LOCAL_MEMBER_ID,
-                        FAKE_CLOUD_NAME,
+                        DEFAULT_CLOUD_NAME,
                         computeId,
                         volumeId,
-                        device);
+                        FAKE_DEVICE);
 
         return attachmentOrder;
     }
 
     protected PublicIpOrder createLocalPublicIpOrder(String computeOrderId) {
-        SystemUser systemUser = Mockito.mock(SystemUser.class);
-        String cloudName = "fake-cloudio";
+        SystemUser systemUser = createSystemUser();
         PublicIpOrder publicIpOrder =
                 new PublicIpOrder(
                         systemUser,
                         LOCAL_MEMBER_ID,
                         LOCAL_MEMBER_ID,
-                        cloudName,
+                        DEFAULT_CLOUD_NAME,
                         computeOrderId);
 
         return publicIpOrder;
@@ -166,6 +168,11 @@ public class BaseUnitTests {
         UserData userDataScript = Mockito.mock(UserData.class);
         userDataScripts.add(userDataScript);
         return userDataScripts;
+    }
+    
+    protected SystemUser createSystemUser() {
+        SystemUser systemUser = new SystemUser(FAKE_USER_ID, FAKE_USER_NAME, LOCAL_MEMBER_ID);
+        return systemUser;
     }
 
     /**

--- a/src/test/java/cloud/fogbow/ras/core/BaseUnitTests.java
+++ b/src/test/java/cloud/fogbow/ras/core/BaseUnitTests.java
@@ -7,9 +7,7 @@ import cloud.fogbow.common.models.linkedlists.SynchronizedDoublyLinkedList;
 import cloud.fogbow.ras.constants.ConfigurationPropertyKeys;
 import cloud.fogbow.ras.core.datastore.DatabaseManager;
 import cloud.fogbow.ras.core.models.UserData;
-import cloud.fogbow.ras.core.models.orders.ComputeOrder;
-import cloud.fogbow.ras.core.models.orders.Order;
-import cloud.fogbow.ras.core.models.orders.OrderState;
+import cloud.fogbow.ras.core.models.orders.*;
 import org.junit.After;
 import org.mockito.BDDMockito;
 import org.mockito.Matchers;
@@ -25,6 +23,19 @@ public class BaseUnitTests {
 
     public static final String LOCAL_MEMBER_ID =
             PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.LOCAL_PROVIDER_ID_KEY);
+
+    public static final String FAKE_CLOUD_NAME = "fake-cloud";
+    public static final String FAKE_DEVICE = "fake-device";
+    public static final String FAKE_ID = "fake-id";
+    public static final String FAKE_IMAGE_NAME = "fake-image-name";
+    public static final String FAKE_INSTANCE_NAME = "fake-instance-name";
+    public static final String FAKE_NAME = "fake-name";
+    public static final String FAKE_PUBLIC_KEY= "fake-public-key";
+    public static final String FAKE_USER = "fake-user";
+    public static final int FAKE_VOLUME_SIZE = 42;
+    public static final String REMOTE_MEMBER_ID = "remote-member-id";
+    public static final String RESOURCES_PATH_TEST = "src/test/resources/private";
+
 
     /**
      * Clears the orders from the lists on the SharedOrderHolders instance.
@@ -70,20 +81,21 @@ public class BaseUnitTests {
     }
 
     protected Order createRemoteOrder(String requestingMember) {
-        String providingMember = "remote-member-id";
+        String providingMember = REMOTE_MEMBER_ID;
         return createOrder(requestingMember, providingMember);
     }
 
     protected Order createOrder(String requestingMember, String providingMember) {
+        return createLocalComputeOrder(requestingMember, providingMember);
+    }
+
+    protected ComputeOrder createLocalComputeOrder(String requestingMember, String providingMember) {
         SystemUser systemUser = Mockito.mock(SystemUser.class);
-
-        ArrayList<UserData> userDataScripts = mockUserData();
-
         String imageName = "fake-image-name";
         String publicKey = "fake-public-key";
         String instanceName = "fake-instance-name";
 
-        Order localOrder =
+        ComputeOrder localOrder =
                 new ComputeOrder(
                         systemUser,
                         requestingMember,
@@ -93,10 +105,60 @@ public class BaseUnitTests {
                         1024,
                         30,
                         imageName,
-                        userDataScripts,
+                        null,
                         publicKey,
                         null);
+
         return localOrder;
+    }
+
+    protected VolumeOrder createLocalVolumeOrder(String requestingMember, String providingMember) {
+        SystemUser systemUser = Mockito.mock(SystemUser.class);
+
+        VolumeOrder volumeOrder =
+                new VolumeOrder(
+                        systemUser,
+                        providingMember,
+                        requestingMember,
+                        FAKE_CLOUD_NAME,
+                        FAKE_NAME,
+                        FAKE_VOLUME_SIZE);
+
+        return volumeOrder;
+    }
+
+    protected AttachmentOrder createLocalAttachmentOrder(ComputeOrder computeOrder, VolumeOrder volumeOrder) {
+        SystemUser systemUser = Mockito.mock(SystemUser.class);
+        String computeId = computeOrder.getId();
+        String volumeId = volumeOrder.getId();
+
+        String device = FAKE_DEVICE;
+
+        AttachmentOrder attachmentOrder =
+                new AttachmentOrder(
+                        systemUser,
+                        LOCAL_MEMBER_ID,
+                        LOCAL_MEMBER_ID,
+                        FAKE_CLOUD_NAME,
+                        computeId,
+                        volumeId,
+                        device);
+
+        return attachmentOrder;
+    }
+
+    protected PublicIpOrder createLocalPublicIpOrder(String computeOrderId) {
+        SystemUser systemUser = Mockito.mock(SystemUser.class);
+        String cloudName = "fake-cloudio";
+        PublicIpOrder publicIpOrder =
+                new PublicIpOrder(
+                        systemUser,
+                        LOCAL_MEMBER_ID,
+                        LOCAL_MEMBER_ID,
+                        cloudName,
+                        computeOrderId);
+
+        return publicIpOrder;
     }
 
     protected ArrayList<UserData> mockUserData() {

--- a/src/test/java/cloud/fogbow/ras/core/BaseUnitTests.java
+++ b/src/test/java/cloud/fogbow/ras/core/BaseUnitTests.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
 import org.mockito.Matchers;
@@ -28,6 +29,7 @@ import cloud.fogbow.ras.core.models.orders.OrderState;
 import cloud.fogbow.ras.core.models.orders.PublicIpOrder;
 import cloud.fogbow.ras.core.models.orders.VolumeOrder;
 
+@Ignore
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ CloudConnectorFactory.class, DatabaseManager.class })
 public class BaseUnitTests {

--- a/src/test/java/cloud/fogbow/ras/core/BaseUnitTests.java
+++ b/src/test/java/cloud/fogbow/ras/core/BaseUnitTests.java
@@ -29,6 +29,11 @@ import cloud.fogbow.ras.core.models.orders.OrderState;
 import cloud.fogbow.ras.core.models.orders.PublicIpOrder;
 import cloud.fogbow.ras.core.models.orders.VolumeOrder;
 
+/*
+ * This class is intended to reuse code components to assist other unit test classes 
+ * but does not contemplate performing any tests. The @Ignore annotation is being used 
+ * in this context to prevent it from being initialized as a test class.
+ */
 @Ignore
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ CloudConnectorFactory.class, DatabaseManager.class })
@@ -42,7 +47,7 @@ public class BaseUnitTests {
     
     protected static final String DEFAULT_CLOUD_NAME = "default";
     protected static final String FAKE_DEVICE = "fake-device";
-    protected static final String FAKE_IMAGE_NAME = "fake-image-name";
+    protected static final String FAKE_IMAGE_ID = "fake-image-id";
     protected static final String FAKE_INSTANCE_ID = "fake-instance-id";
     protected static final String FAKE_INSTANCE_NAME = "fake-instance-name";
     protected static final String FAKE_ORDER_NAME = "fake-order-name";
@@ -84,11 +89,6 @@ public class BaseUnitTests {
         list.resetPointer();
     }
 
-    protected boolean isEmpty(ChainedList<Order> list) {
-        list.resetPointer();
-        return list.getNext() == null;
-    }
-
     protected String getLocalMemberId() {
         return LOCAL_MEMBER_ID;
     }
@@ -108,24 +108,19 @@ public class BaseUnitTests {
     }
     
     protected ComputeOrder createComputeOrder(String requestingMember, String providingMember) {
-        SystemUser systemUser = createSystemUser();
-        String imageName = FAKE_IMAGE_NAME;
-        String publicKey = FAKE_PUBLIC_KEY;
-        String instanceName = FAKE_INSTANCE_NAME;
-
         ComputeOrder computeOrder =
                 new ComputeOrder(
-                        systemUser,
+                        createSystemUser(),
                         requestingMember,
                         providingMember,
                         DEFAULT_CLOUD_NAME, 
-                        instanceName,
+                        FAKE_INSTANCE_NAME,
                         CPU_VALUE,
                         MEMORY_VALUE,
                         DISK_VALUE,
-                        imageName,
+                        FAKE_IMAGE_ID,
                         mockUserData(),
-                        publicKey,
+                        FAKE_PUBLIC_KEY,
                         null);
 
         return computeOrder;

--- a/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
@@ -35,9 +35,8 @@ import cloud.fogbow.ras.core.models.orders.VolumeOrder;
 
 public class OrderControllerTest extends BaseUnitTests {
 
-    private static final String ANY_VALUE = "anything";
+    private static final String AVAILABLE_STATE = "available";
     private static final String FAKE_IP_ADDRESS = "0.0.0.0";
-    private static final String FAKE_TOKEN_VALUE = "fake-token-value";
     private static final String INVALID_ORDER_ID = "invalid-order-id";
     
     private OrderController ordersController;
@@ -345,8 +344,8 @@ public class OrderControllerTest extends BaseUnitTests {
         volumeOrder.setInstanceId(instanceId);
 
         attachmentOrder.setInstanceId(instanceId);
-        String cloudState = ANY_VALUE;
-        String device = FAKE_DEVICE;
+        String cloudState = AVAILABLE_STATE;
+        String device = BaseUnitTests.FAKE_DEVICE;
         AttachmentInstance attachmentInstance =
                 new AttachmentInstance(
                         instanceId,
@@ -378,7 +377,7 @@ public class OrderControllerTest extends BaseUnitTests {
         computeOrder.setInstanceId(instanceId);
         publicIpOrder.setInstanceId(instanceId);
 
-        String cloudState = ANY_VALUE;
+        String cloudState = AVAILABLE_STATE;
         String ip = FAKE_IP_ADDRESS;
         PublicIpInstance publicIpInstance =
                 new PublicIpInstance(

--- a/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
@@ -1,36 +1,42 @@
 package cloud.fogbow.ras.core;
 
-import cloud.fogbow.common.constants.FogbowConstants;
-import cloud.fogbow.common.exceptions.*;
-import cloud.fogbow.common.models.SystemUser;
-import cloud.fogbow.common.models.linkedlists.ChainedList;
-import cloud.fogbow.ras.api.http.response.*;
-import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
-import cloud.fogbow.ras.core.cloudconnector.LocalCloudConnector;
-import cloud.fogbow.ras.core.datastore.DatabaseManager;
-import cloud.fogbow.ras.core.models.ResourceType;
-import cloud.fogbow.ras.core.models.orders.*;
-import cloud.fogbow.ras.api.http.response.quotas.allocation.ComputeAllocation;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({DatabaseManager.class, CloudConnectorFactory.class})
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import cloud.fogbow.common.exceptions.DependencyDetectedException;
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.exceptions.InstanceNotFoundException;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.exceptions.RequestStillBeingDispatchedException;
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.SystemUser;
+import cloud.fogbow.common.models.linkedlists.ChainedList;
+import cloud.fogbow.ras.api.http.response.AttachmentInstance;
+import cloud.fogbow.ras.api.http.response.ComputeInstance;
+import cloud.fogbow.ras.api.http.response.Instance;
+import cloud.fogbow.ras.api.http.response.InstanceState;
+import cloud.fogbow.ras.api.http.response.InstanceStatus;
+import cloud.fogbow.ras.api.http.response.OrderInstance;
+import cloud.fogbow.ras.api.http.response.PublicIpInstance;
+import cloud.fogbow.ras.api.http.response.quotas.allocation.ComputeAllocation;
+import cloud.fogbow.ras.core.models.ResourceType;
+import cloud.fogbow.ras.core.models.orders.AttachmentOrder;
+import cloud.fogbow.ras.core.models.orders.ComputeOrder;
+import cloud.fogbow.ras.core.models.orders.NetworkOrder;
+import cloud.fogbow.ras.core.models.orders.Order;
+import cloud.fogbow.ras.core.models.orders.OrderState;
+import cloud.fogbow.ras.core.models.orders.PublicIpOrder;
+import cloud.fogbow.ras.core.models.orders.VolumeOrder;
+
 public class OrderControllerTest extends BaseUnitTests {
 
     private static final String ANY_VALUE = "anything";
-    private static final String FAKE_IP_ADDRESS = "10.42.16.18";
+    private static final String FAKE_IP_ADDRESS = "0.0.0.0";
     private static final String FAKE_TOKEN_VALUE = "fake-token-value";
     private static final String INVALID_ORDER_ID = "invalid-order-id";
     
@@ -43,26 +49,15 @@ public class OrderControllerTest extends BaseUnitTests {
     private ChainedList<Order> failedAfterSuccessfulRequestOrdersList;
     private ChainedList<Order> failedOnRequestOrdersList;
     private ChainedList<Order> closedOrdersList;
-    private LocalCloudConnector localCloudConnector;
 
     @Before
     public void setUp() throws UnexpectedException {
         // mocking database to return empty instances of SynchronizedDoublyLinkedList.
         super.mockReadOrdersFromDataBase();
+        super.mockLocalCloudConnectorFromFactory();
 
-        this.ordersController = new OrderController();
-
-        SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
-        this.localCloudConnector = Mockito.mock(LocalCloudConnector.class);
-
-        CloudConnectorFactory cloudConnectorFactory = Mockito.mock(CloudConnectorFactory.class);
-        Mockito.when(cloudConnectorFactory.getCloudConnector(Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(localCloudConnector);
-
-        PowerMockito.mockStatic(CloudConnectorFactory.class);
-        BDDMockito.given(CloudConnectorFactory.getInstance()).willReturn(cloudConnectorFactory);
-        
         // setting up the attributes.
+        SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
         this.activeOrdersMap = sharedOrderHolders.getActiveOrdersMap();
         this.openOrdersList = sharedOrderHolders.getOpenOrdersList();
         this.pendingOrdersList = sharedOrderHolders.getPendingOrdersList();
@@ -70,6 +65,7 @@ public class OrderControllerTest extends BaseUnitTests {
         this.fulfilledOrdersList = sharedOrderHolders.getFulfilledOrdersList();
         this.failedAfterSuccessfulRequestOrdersList = sharedOrderHolders.getFailedAfterSuccessfulRequestOrdersList();
         this.closedOrdersList = sharedOrderHolders.getClosedOrdersList();
+        this.ordersController = new OrderController();
     }
 
     // test case: when try to delete an Order closed, it must raise an InstanceNotFoundException.
@@ -85,36 +81,33 @@ public class OrderControllerTest extends BaseUnitTests {
         this.ordersController.deleteOrder(computeOrder);
     }
 
-    // test case: Checks if the getInstancesStatusmethod returns exactly the same list of instances that
+    // test case: Checks if the getInstancesStatusmethod returns exactly the same
+    // list of instances that
     // were added on the lists.
     @Test
     public void testGetAllInstancesStatus() throws InstanceNotFoundException {
         // set up
         SystemUser systemUser = createSystemUser();
 
-        ComputeOrder computeOrderFulfilled = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        ComputeOrder computeOrderFulfilled = createLocalComputeOrder();
         computeOrderFulfilled.setSystemUser(systemUser);
         computeOrderFulfilled.setOrderStateInTestMode(OrderState.FULFILLED);
 
-        ComputeOrder computeOrderFailed = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        ComputeOrder computeOrderFailed = createLocalComputeOrder();
         computeOrderFailed.setSystemUser(systemUser);
         computeOrderFailed.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
-        
+
         this.activeOrdersMap.put(computeOrderFulfilled.getId(), computeOrderFulfilled);
         this.fulfilledOrdersList.addItem(computeOrderFulfilled);
 
         this.activeOrdersMap.put(computeOrderFailed.getId(), computeOrderFailed);
         this.failedAfterSuccessfulRequestOrdersList.addItem(computeOrderFailed);
 
-        InstanceStatus statusOrderFulfilled = new InstanceStatus(computeOrderFulfilled.getId(), computeOrderFulfilled.getProvider(),
-                computeOrderFulfilled.getCloudName(), InstanceStatus.mapInstanceStateFromOrderState(computeOrderFulfilled.getOrderState()));
-        
-        InstanceStatus statusOrderFailed = new InstanceStatus(computeOrderFailed.getId(), computeOrderFailed.getProvider(),
-                computeOrderFulfilled.getCloudName(), InstanceStatus.mapInstanceStateFromOrderState(computeOrderFailed.getOrderState()));
+        InstanceStatus statusOrderFulfilled = createInstanceStatus(computeOrderFulfilled);
+        InstanceStatus statusOrderFailed = createInstanceStatus(computeOrderFailed);
 
         // exercise
-        List<InstanceStatus> instances = this.ordersController.getInstancesStatus(systemUser,
-                ResourceType.COMPUTE);
+        List<InstanceStatus> instances = this.ordersController.getInstancesStatus(systemUser, ResourceType.COMPUTE);
 
         // verify
         Assert.assertTrue(instances.contains(statusOrderFulfilled));
@@ -140,7 +133,7 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test(expected = InstanceNotFoundException.class) // verify
     public void testGetInactiveOrder() throws InstanceNotFoundException {
         // set up
-        Order order = createLocalOrder(LOCAL_MEMBER_ID);
+        Order order = createLocalOrder(getLocalMemberId());
         String orderId = order.getId();
 
         // verify
@@ -172,7 +165,7 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test(expected = UnexpectedException.class)
     public void testActivateOrderTwice() throws FogbowException {
         // set up
-        Order order = createLocalOrder(LOCAL_MEMBER_ID);
+        Order order = createLocalOrder(getLocalMemberId());
 
         // exercise
         this.ordersController.activateOrder(order);
@@ -184,7 +177,7 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test(expected = UnexpectedException.class)
     public void testDeactivateOrderTwice() throws FogbowException {
         // set up
-        Order order = createLocalOrder(LOCAL_MEMBER_ID);
+        Order order = createLocalOrder(getLocalMemberId());
 
         // exercise
         this.ordersController.activateOrder(order);
@@ -196,7 +189,7 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test
     public void testDeactivateOrderSuccess() throws FogbowException {
         // set up
-        Order order = createLocalOrder(LOCAL_MEMBER_ID);
+        Order order = createLocalOrder(getLocalMemberId());
 
         // exercise
         this.ordersController.activateOrder(order);
@@ -211,9 +204,9 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test
     public void testCreateOrderWithDependencies() throws FogbowException {
         // set up
-        ComputeOrder computeOrder = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
-        VolumeOrder volumeOrder1 = createLocalVolumeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
-        VolumeOrder volumeOrder2 = createLocalVolumeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        ComputeOrder computeOrder = createLocalComputeOrder();
+        VolumeOrder volumeOrder1 = createLocalVolumeOrder();
+        VolumeOrder volumeOrder2 = createLocalVolumeOrder();
 
         this.ordersController.activateOrder(computeOrder);
         this.ordersController.activateOrder(volumeOrder1);
@@ -235,8 +228,8 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test(expected = DependencyDetectedException.class)
     public void testDeleteOrderWithoutRemovingDependenciesFirst() throws FogbowException {
         // set up
-        ComputeOrder computeOrder = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
-        VolumeOrder volumeOrder = createLocalVolumeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        ComputeOrder computeOrder = createLocalComputeOrder();
+        VolumeOrder volumeOrder = createLocalVolumeOrder();
 
         this.ordersController.activateOrder(computeOrder);
         this.ordersController.activateOrder(volumeOrder);
@@ -253,8 +246,8 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test
     public void testDeleteOrderWithDependencies() throws FogbowException {
         // set up
-        ComputeOrder computeOrder = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
-        VolumeOrder volumeOrder = createLocalVolumeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        ComputeOrder computeOrder = createLocalComputeOrder();
+        VolumeOrder volumeOrder = createLocalVolumeOrder();
 
         this.ordersController.activateOrder(computeOrder);
         this.ordersController.activateOrder(volumeOrder);
@@ -272,11 +265,12 @@ public class OrderControllerTest extends BaseUnitTests {
     // cloud connector deleteOrder
     @Test
     public void testDeleteOrderWithInstanceRunning() throws FogbowException {
-        Mockito.doNothing().when(this.localCloudConnector).deleteInstance(Mockito.any());
-        ComputeOrder computeOrder = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        ComputeOrder computeOrder = createLocalComputeOrder();
+        computeOrder.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
         this.ordersController.activateOrder(computeOrder);
-        computeOrder.setInstanceId(FAKE_INSTANCE_ID);
 
+        Mockito.doNothing().when(this.localCloudConnector).deleteInstance(Mockito.any());
+        
         // exercise
         this.ordersController.deleteOrder(computeOrder);
 
@@ -288,10 +282,11 @@ public class OrderControllerTest extends BaseUnitTests {
     // thrown an Exception
     @Test(expected = FogbowException.class)
     public void testDeleteOrderWithInstanceCloudConnectorFail() throws FogbowException {
-        Mockito.doThrow(FogbowException.class).when(this.localCloudConnector).deleteInstance(Mockito.any());
-        ComputeOrder computeOrder = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        ComputeOrder computeOrder = createLocalComputeOrder();
+        computeOrder.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
         this.ordersController.activateOrder(computeOrder);
-        computeOrder.setInstanceId(FAKE_INSTANCE_ID);
+        
+        Mockito.doThrow(FogbowException.class).when(this.localCloudConnector).deleteInstance(Mockito.any());
 
         // exercise
         this.ordersController.deleteOrder(computeOrder);
@@ -302,7 +297,7 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test(expected = RequestStillBeingDispatchedException.class)
     public void testGetResourceInstanceOfOpenOrder() throws FogbowException {
         // set up
-        Order order = createOrder(LOCAL_MEMBER_ID, FAKE_REMOTE_MEMBER_ID);
+        Order order = createRemoteOrder(getLocalMemberId());
         order.setOrderStateInTestMode(OrderState.OPEN);
 
         // exercise
@@ -313,14 +308,14 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test
     public void testGetResourceInstance() throws Exception {
         // set up
-        Order order = createOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        Order order = createLocalOrder(getLocalMemberId());
         order.setOrderStateInTestMode(OrderState.FULFILLED);
-        order.setInstanceId(FAKE_INSTANCE_ID);
+        order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
 
         this.fulfilledOrdersList.addItem(order);
         this.activeOrdersMap.put(order.getId(), order);
 
-        OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
+        OrderInstance orderInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
         orderInstance.setState(InstanceState.READY);
 
         Mockito.doReturn(orderInstance).when(this.localCloudConnector)
@@ -337,15 +332,15 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test
     public void testGetAttachmentInstance() throws Exception {
         // set up
-        ComputeOrder computeOrder = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
-        VolumeOrder volumeOrder = createLocalVolumeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
-        AttachmentOrder attachmentOrder = Mockito.spy(createLocalAttachmentOrder(computeOrder, volumeOrder));
+        ComputeOrder computeOrder = createLocalComputeOrder();
+        VolumeOrder volumeOrder = createLocalVolumeOrder();
+        AttachmentOrder attachmentOrder = createLocalAttachmentOrder(computeOrder, volumeOrder);
 
         this.ordersController.activateOrder(computeOrder);
         this.ordersController.activateOrder(volumeOrder);
         this.ordersController.activateOrder(attachmentOrder);
 
-        String instanceId = FAKE_INSTANCE_ID;
+        String instanceId = BaseUnitTests.FAKE_INSTANCE_ID;
         computeOrder.setInstanceId(instanceId);
         volumeOrder.setInstanceId(instanceId);
 
@@ -373,13 +368,13 @@ public class OrderControllerTest extends BaseUnitTests {
     @Test
     public void testGetPublicIpInstance() throws Exception {
         // set up
-        ComputeOrder computeOrder = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        ComputeOrder computeOrder = createLocalComputeOrder();
         PublicIpOrder publicIpOrder = createLocalPublicIpOrder(computeOrder.getId());
 
         this.ordersController.activateOrder(computeOrder);
         this.ordersController.activateOrder(publicIpOrder);
 
-        String instanceId = FAKE_INSTANCE_ID;
+        String instanceId = BaseUnitTests.FAKE_INSTANCE_ID;
         computeOrder.setInstanceId(instanceId);
         publicIpOrder.setInstanceId(instanceId);
 
@@ -403,13 +398,13 @@ public class OrderControllerTest extends BaseUnitTests {
     // test case: Checks if given an remote order in the getResourceInstance method returns its instance.
     @Test public void testRemoteGetResourceInstance() throws FogbowException {
         // set up
-        Order order = createOrder(LOCAL_MEMBER_ID, FAKE_REMOTE_MEMBER_ID);
+        Order order = createLocalOrder(getLocalMemberId());
         order.setOrderStateInTestMode(OrderState.FULFILLED);
 
         this.fulfilledOrdersList.addItem(order);
         this.activeOrdersMap.put(order.getId(), order);
 
-        String instanceId = FAKE_INSTANCE_ID;
+        String instanceId = BaseUnitTests.FAKE_INSTANCE_ID;
         OrderInstance orderInstance = new ComputeInstance(instanceId);
         orderInstance.setState(InstanceState.READY);
         order.setInstanceId(instanceId);
@@ -436,12 +431,7 @@ public class OrderControllerTest extends BaseUnitTests {
     public void testGetUserAllocation() throws UnexpectedException, InvalidParameterException {
         // set up
         SystemUser systemUser = createSystemUser();
-        ComputeOrder computeOrder = new ComputeOrder();
-        computeOrder.setSystemUser(systemUser);
-        computeOrder.setRequester(BaseUnitTests.LOCAL_MEMBER_ID);
-        computeOrder.setProvider(BaseUnitTests.LOCAL_MEMBER_ID);
-        computeOrder.setOrderStateInTestMode(OrderState.FULFILLED);
-
+        ComputeOrder computeOrder = createFulfilledComputeOrder(systemUser);
         computeOrder.setActualAllocation(new ComputeAllocation(1, 2, 3, 4));
 
         this.activeOrdersMap.put(computeOrder.getId(), computeOrder);
@@ -459,25 +449,14 @@ public class OrderControllerTest extends BaseUnitTests {
         Assert.assertEquals(computeOrder.getActualAllocation().getDisk(), allocation.getDisk());
     }
 
-
     // test case: Tests if the getUserAllocation method throws UnexpectedException when there is no order
     // with the ResourceType specified.
     @Test(expected = UnexpectedException.class)
     public void testGetUserAllocationWithInvalidInstanceType()
             throws UnexpectedException, InvalidParameterException {
         // set up
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put(FogbowConstants.PROVIDER_ID_KEY, LOCAL_MEMBER_ID);
-        attributes.put(FogbowConstants.USER_ID_KEY, FAKE_USER_ID);
-        attributes.put(FogbowConstants.USER_NAME_KEY, FAKE_USER_NAME);
-        attributes.put(FogbowConstants.TOKEN_VALUE_KEY, FAKE_TOKEN_VALUE);
         SystemUser systemUser = createSystemUser();
-        
-        NetworkOrder networkOrder = new NetworkOrder();
-        networkOrder.setSystemUser(systemUser);
-        networkOrder.setRequester(BaseUnitTests.LOCAL_MEMBER_ID);
-        networkOrder.setProvider(BaseUnitTests.LOCAL_MEMBER_ID);
-        networkOrder.setOrderStateInTestMode(OrderState.FULFILLED);
+        NetworkOrder networkOrder = createFulfilledNetworkOrder(systemUser);
 
         this.fulfilledOrdersList.addItem(networkOrder);
         this.activeOrdersMap.put(networkOrder.getId(), networkOrder);
@@ -624,11 +603,35 @@ public class OrderControllerTest extends BaseUnitTests {
     public void testGetOrderWithInvalidId() throws InstanceNotFoundException {
         this.ordersController.getOrder(INVALID_ORDER_ID);
     }
+    
+    private NetworkOrder createFulfilledNetworkOrder(SystemUser systemUser) {
+        NetworkOrder networkOrder = new NetworkOrder();
+        networkOrder.setSystemUser(systemUser);
+        networkOrder.setRequester(BaseUnitTests.LOCAL_MEMBER_ID);
+        networkOrder.setProvider(BaseUnitTests.LOCAL_MEMBER_ID);
+        networkOrder.setOrderStateInTestMode(OrderState.FULFILLED);
+        return networkOrder;
+    }
+    
+    private ComputeOrder createFulfilledComputeOrder(SystemUser systemUser) {
+        ComputeOrder computeOrder = new ComputeOrder();
+        computeOrder.setSystemUser(systemUser);
+        computeOrder.setRequester(BaseUnitTests.LOCAL_MEMBER_ID);
+        computeOrder.setProvider(BaseUnitTests.LOCAL_MEMBER_ID);
+        computeOrder.setOrderStateInTestMode(OrderState.FULFILLED);
+        return computeOrder;
+    }
+    
+    private InstanceStatus createInstanceStatus(ComputeOrder computeOrder) throws InstanceNotFoundException {
+        return new InstanceStatus(computeOrder.getId(),
+                computeOrder.getProvider(), computeOrder.getCloudName(),
+                InstanceStatus.mapInstanceStateFromOrderState(computeOrder.getOrderState()));
+    }
 
     private String getComputeOrderCreationId(OrderState orderState)
             throws InvalidParameterException, UnexpectedException {
         
-        ComputeOrder computeOrder = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        ComputeOrder computeOrder = createComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
         computeOrder.setOrderStateInTestMode(orderState);
 
         String orderId = computeOrder.getId();

--- a/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
@@ -450,22 +450,30 @@ public class OrderControllerTest extends BaseUnitTests {
     public void testGetUserAllocation() throws UnexpectedException {
         // set up
         SystemUser systemUser = createSystemUser();
-        ComputeOrder computeOrder = createFulfilledComputeOrder(systemUser);
-        computeOrder.setActualAllocation(new ComputeAllocation(1, 2, 3, 4));
+        
+        ComputeOrder computeOrder1 = createFulfilledComputeOrder(systemUser);
+        computeOrder1.setActualAllocation(new ComputeAllocation(1, 2, 3, 4));
+        
+        ComputeOrder computeOrder2 = createFulfilledComputeOrder(systemUser);
+        computeOrder2.setActualAllocation(new ComputeAllocation(4, 3, 2, 1));
 
-        this.activeOrdersMap.put(computeOrder.getId(), computeOrder);
-        this.fulfilledOrdersList.addItem(computeOrder);
+        this.activeOrdersMap.put(computeOrder1.getId(), computeOrder1);
+        this.activeOrdersMap.put(computeOrder2.getId(), computeOrder2);
+        
+        this.fulfilledOrdersList.addItem(computeOrder1);
+        this.fulfilledOrdersList.addItem(computeOrder2);
+        
+        int expectedValue = 5;
 
         // exercise
         ComputeAllocation allocation = (ComputeAllocation) this.ordersController.getUserAllocation(
                 BaseUnitTests.LOCAL_MEMBER_ID, systemUser, ResourceType.COMPUTE);
 
         // verify
-        Assert.assertEquals(computeOrder.getActualAllocation().getInstances(),
-                allocation.getInstances());
-        Assert.assertEquals(computeOrder.getActualAllocation().getRam(), allocation.getRam());
-        Assert.assertEquals(computeOrder.getActualAllocation().getvCPU(), allocation.getvCPU());
-        Assert.assertEquals(computeOrder.getActualAllocation().getDisk(), allocation.getDisk());
+        Assert.assertEquals(expectedValue, allocation.getInstances());
+        Assert.assertEquals(expectedValue, allocation.getRam());
+        Assert.assertEquals(expectedValue, allocation.getvCPU());
+        Assert.assertEquals(expectedValue, allocation.getDisk());
     }
 
     // test case: Tests if the getUserAllocation method throws UnexpectedException when there is no order

--- a/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
@@ -11,14 +11,12 @@ import org.mockito.Mockito;
 import cloud.fogbow.common.exceptions.DependencyDetectedException;
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.InstanceNotFoundException;
-import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.exceptions.RequestStillBeingDispatchedException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.models.linkedlists.ChainedList;
 import cloud.fogbow.ras.api.http.response.AttachmentInstance;
 import cloud.fogbow.ras.api.http.response.ComputeInstance;
-import cloud.fogbow.ras.api.http.response.Instance;
 import cloud.fogbow.ras.api.http.response.InstanceState;
 import cloud.fogbow.ras.api.http.response.InstanceStatus;
 import cloud.fogbow.ras.api.http.response.OrderInstance;
@@ -425,7 +423,7 @@ public class OrderControllerTest extends BaseUnitTests {
                 .getInstance(Mockito.any(Order.class));
 
         // exercise
-        Instance instance = this.ordersController.getResourceInstance(order);
+        this.ordersController.getResourceInstance(order);
 
         // verify
         Mockito.verify(this.ordersController, Mockito.times(1)).getCloudConnector(Mockito.eq(order));
@@ -441,7 +439,7 @@ public class OrderControllerTest extends BaseUnitTests {
 
     // test case: Tests if the getUserAllocation method returns the ComputeAllocation properly.
     @Test
-    public void testGetUserAllocation() throws UnexpectedException, InvalidParameterException {
+    public void testGetUserAllocation() throws UnexpectedException {
         // set up
         SystemUser systemUser = createSystemUser();
         ComputeOrder computeOrder = createFulfilledComputeOrder(systemUser);
@@ -465,8 +463,7 @@ public class OrderControllerTest extends BaseUnitTests {
     // test case: Tests if the getUserAllocation method throws UnexpectedException when there is no order
     // with the ResourceType specified.
     @Test(expected = UnexpectedException.class)
-    public void testGetUserAllocationWithInvalidInstanceType()
-            throws UnexpectedException, InvalidParameterException {
+    public void testGetUserAllocationWithInvalidInstanceType() throws UnexpectedException {
         // set up
         SystemUser systemUser = createSystemUser();
         NetworkOrder networkOrder = createFulfilledNetworkOrder(systemUser);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/genericrequest/v2/OpenStackFogbowGenericRequestPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/genericrequest/v2/OpenStackFogbowGenericRequestPluginTest.java
@@ -8,12 +8,14 @@ import cloud.fogbow.common.util.GsonHolder;
 import cloud.fogbow.common.util.connectivity.HttpRequest;
 import cloud.fogbow.common.util.connectivity.cloud.openstack.OpenStackHttpClient;
 import cloud.fogbow.common.models.OpenStackV3User;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class OpenStackFogbowGenericRequestPluginTest {
 
@@ -37,7 +39,7 @@ public class OpenStackFogbowGenericRequestPluginTest {
     @Test
     public void testGenericRequestWithWrongHeader() throws FogbowException {
         // set up
-        HashMap<String, String> header = genericRequest.getHeaders();
+        Map<String, String> header = genericRequest.getHeaders();
         header.put(OpenStackConstants.X_AUTH_TOKEN_KEY, FAKE_VALUE);
         genericRequest.setHeaders(header);
         String serializedGenericRequest = GsonHolder.getInstance().toJson(genericRequest);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/mapper/all2one/CloudStackAllToOneMapperTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/mapper/all2one/CloudStackAllToOneMapperTest.java
@@ -20,6 +20,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.Map;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({CloudStackSystemIdentityProviderPlugin.class})
@@ -30,7 +31,8 @@ public class CloudStackAllToOneMapperTest {
     private static final String FAKE_USER_NAME = "fake-user-name";
     private static final String FAKE_DOMAIN = "fake-domain";
     private static final String FAKE_TOKEN_VALUE = "fake-api-key:fake-secret-key";
-    private static final HashMap<String, String> FAKE_COOKIE_HEADER = new HashMap<>();
+    private static final String FAKE_CLOUDSTACK_URL = "http://localhost:8080";
+    private static final Map<String, String> FAKE_COOKIE_HEADER = new HashMap<>();
 
     private String providerId;
     private CloudStackAllToOneMapper mapper;
@@ -43,7 +45,7 @@ public class CloudStackAllToOneMapperTest {
                 + "cloudstack" + File.separator + SystemConstants.MAPPER_CONF_FILE_NAME;
 
         this.providerId = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.LOCAL_PROVIDER_ID_KEY);
-        this.cloudStackIdentityProviderPlugin = Mockito.spy(CloudStackIdentityProviderPlugin.class);
+        this.cloudStackIdentityProviderPlugin = Mockito.spy(new CloudStackIdentityProviderPlugin(FAKE_CLOUDSTACK_URL));
         this.mapper = new CloudStackAllToOneMapper(mapperConfPath);
         this.mapper.setIdentityProviderPlugin(this.cloudStackIdentityProviderPlugin);
     }

--- a/src/test/java/cloud/fogbow/ras/core/processors/ClosedProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/ClosedProcessorTest.java
@@ -76,7 +76,7 @@ public class ClosedProcessorTest extends BaseUnitTests {
     // test case: Check the throw of UnexpectedException when running the thread in
     // the closed processor, while running a local order.
     @Test
-    public void testRunProcessLocalOrderThrowsUnexpectedException() throws InterruptedException, FogbowException {
+    public void testRunProcessLocalOrderThrowsUnexpectedException() throws InterruptedException, UnexpectedException {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         this.closedOrderList.addItem(order);
@@ -95,7 +95,7 @@ public class ClosedProcessorTest extends BaseUnitTests {
     // test case: During a thread running in closed processor, if any
     // errors occur, the processClosedOrder method will catch an exception.
     @Test
-    public void testRunProcessLocalOrderToCatchException() throws InterruptedException, FogbowException {
+    public void testRunProcessLocalOrderToCatchException() throws InterruptedException, UnexpectedException {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());

--- a/src/test/java/cloud/fogbow/ras/core/processors/ClosedProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/ClosedProcessorTest.java
@@ -1,14 +1,8 @@
 package cloud.fogbow.ras.core.processors;
 
-import cloud.fogbow.common.exceptions.UnexpectedException;
-import cloud.fogbow.common.models.linkedlists.ChainedList;
-import cloud.fogbow.ras.constants.ConfigurationPropertyDefaults;
-import cloud.fogbow.ras.core.*;
-import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
-import cloud.fogbow.ras.core.cloudconnector.LocalCloudConnector;
-import cloud.fogbow.ras.core.cloudconnector.RemoteCloudConnector;
-import cloud.fogbow.ras.core.models.orders.Order;
-import cloud.fogbow.ras.core.models.orders.OrderState;
+import java.util.Map;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,39 +10,45 @@ import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Map;
-import java.util.Properties;
-
-import static org.junit.Assert.assertNull;
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.linkedlists.ChainedList;
+import cloud.fogbow.ras.constants.ConfigurationPropertyDefaults;
+import cloud.fogbow.ras.core.BaseUnitTests;
+import cloud.fogbow.ras.core.OrderController;
+import cloud.fogbow.ras.core.OrderStateTransitioner;
+import cloud.fogbow.ras.core.SharedOrderHolders;
+import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
+import cloud.fogbow.ras.core.models.orders.Order;
+import cloud.fogbow.ras.core.models.orders.OrderState;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(CloudConnectorFactory.class)
 public class ClosedProcessorTest extends BaseUnitTests {
 
-    private ClosedProcessor closedProcessor;
-
-    @SuppressWarnings("unused")
-    private RemoteCloudConnector remoteCloudConnector;
-    private LocalCloudConnector localCloudConnector;
-
-    @SuppressWarnings("unused")
-    private Properties properties;
-    private Thread thread;
+    private static final long DEFAULT_SLEEP_TIME = 500;
+    
+    private static final String FAKE_INSTANCE_ID = "fake-instance-id";
+    
+    private Map<String, Order> activeOrdersMap;
+    private ChainedList<Order> closedOrderList;
+    private ClosedProcessor processor;
     private OrderController orderController;
+    private Thread thread;
 
     @Before
     public void setUp() throws UnexpectedException {
-        mockReadOrdersFromDataBase();
-        this.properties = new Properties();
+        super.mockReadOrdersFromDataBase();
 
-        PropertiesHolder propertiesHolder = PropertiesHolder.getInstance();
-        this.properties = propertiesHolder.getProperties();
-        this.orderController = new OrderController();
-
-        this.localCloudConnector = Mockito.mock(LocalCloudConnector.class);
-        this.remoteCloudConnector = Mockito.mock(RemoteCloudConnector.class);
-        this.closedProcessor = Mockito.spy(new ClosedProcessor(orderController,
+        this.orderController = Mockito.spy(new OrderController());
+        this.processor = Mockito.spy(new ClosedProcessor(this.orderController,
                 ConfigurationPropertyDefaults.CLOSED_ORDERS_SLEEP_TIME));
+        
+        SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
+        this.activeOrdersMap = sharedOrderHolders.getActiveOrdersMap();
+        this.closedOrderList = sharedOrderHolders.getClosedOrdersList();
+        
+        this.thread = null;
     }
 
     @Override
@@ -63,31 +63,61 @@ public class ClosedProcessorTest extends BaseUnitTests {
     //test case: the closed processor remove closed orders from the closed orders list
     @Test
     public void testProcessClosedLocalOrder() throws Exception {
-
         //set up
-        String instanceId = "fake-id";
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
 
-        Order localOrder = createLocalOrder(getLocalMemberId());
-        localOrder.setInstanceId(instanceId);
-
-        this.orderController.activateOrder(localOrder);
-        OrderStateTransitioner.transition(localOrder, OrderState.CLOSED);
-
+        this.orderController.activateOrder(order);
+        OrderStateTransitioner.transition(order, OrderState.CLOSED);
+        
         //exercise
-        this.thread = new Thread(this.closedProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(500);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         //verify
-        SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
-        ChainedList<Order> closedOrders = sharedOrderHolders.getClosedOrdersList();
-        Map<String, Order> activeOrdersMap = sharedOrderHolders.getActiveOrdersMap();
-        assertNull(activeOrdersMap.get(localOrder.getId()));
-
-        closedOrders.resetPointer();
-        assertNull(closedOrders.getNext());
-
-        //TODO: it would be good to verity that the OrderStateTransitioner.deactivateOrder was called. However,
-        //it is static thus, hard to mock
+        Mockito.verify(this.orderController, Mockito.times(1)).deactivateOrder(Mockito.eq(order));
+        Assert.assertNull(activeOrdersMap.get(order.getId()));
+        Assert.assertNull(closedOrderList.getNext());
     }
+    
+    // test case: Check the throw of UnexpectedException when running the thread in
+    // the closed processor, while running a local order.
+    @Test
+    public void testRunProcessLocalOrderThrowsUnexpectedException() throws InterruptedException, FogbowException {
+        // set up
+        Order order = createLocalOrder(getLocalMemberId());
+        this.closedOrderList.addItem(order);
+
+        Mockito.doThrow(new UnexpectedException()).when(this.processor).processClosedOrder(Mockito.eq(order));
+
+        // exercise
+        this.thread = new Thread(this.processor);
+        this.thread.start();
+        Thread.sleep(DEFAULT_SLEEP_TIME);
+
+        // verify
+        Mockito.verify(this.processor, Mockito.times(1)).processClosedOrder(Mockito.eq(order));
+    }
+    
+    // test case: During a thread running in closed processor, if any
+    // errors occur, the processClosedOrder method will catch an exception.
+    @Test
+    public void testRunProcessLocalOrderToCatchException() throws InterruptedException, FogbowException {
+
+        // set up
+        Order order = createLocalOrder(getLocalMemberId());
+        this.closedOrderList.addItem(order);
+
+        Mockito.doThrow(new RuntimeException()).when(this.processor).processClosedOrder(Mockito.eq(order));
+
+        // exercise
+        this.thread = new Thread(this.processor);
+        this.thread.start();
+        Thread.sleep(DEFAULT_SLEEP_TIME);
+
+        // verify
+        Mockito.verify(this.processor, Mockito.times(1)).processClosedOrder(Mockito.eq(order));
+    }
+    
 }

--- a/src/test/java/cloud/fogbow/ras/core/processors/ClosedProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/ClosedProcessorTest.java
@@ -5,10 +5,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
@@ -18,12 +15,9 @@ import cloud.fogbow.ras.core.BaseUnitTests;
 import cloud.fogbow.ras.core.OrderController;
 import cloud.fogbow.ras.core.OrderStateTransitioner;
 import cloud.fogbow.ras.core.SharedOrderHolders;
-import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
 import cloud.fogbow.ras.core.models.orders.Order;
 import cloud.fogbow.ras.core.models.orders.OrderState;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(CloudConnectorFactory.class)
 public class ClosedProcessorTest extends BaseUnitTests {
 
     private Map<String, Order> activeOrdersMap;

--- a/src/test/java/cloud/fogbow/ras/core/processors/ClosedProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/ClosedProcessorTest.java
@@ -26,10 +26,6 @@ import cloud.fogbow.ras.core.models.orders.OrderState;
 @PrepareForTest(CloudConnectorFactory.class)
 public class ClosedProcessorTest extends BaseUnitTests {
 
-    private static final long DEFAULT_SLEEP_TIME = 500;
-    
-    private static final String FAKE_INSTANCE_ID = "fake-instance-id";
-    
     private Map<String, Order> activeOrdersMap;
     private ChainedList<Order> closedOrderList;
     private ClosedProcessor processor;

--- a/src/test/java/cloud/fogbow/ras/core/processors/ClosedProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/ClosedProcessorTest.java
@@ -50,25 +50,27 @@ public class ClosedProcessorTest extends BaseUnitTests {
         super.tearDown();
     }
 
-    //test case: the closed processor remove closed orders from the closed orders list
+    // test case: When running the thread in ClosedProcessor, orders will be removed
+    // from the closed list and active order map, and marked as DEACTIVATED.
     @Test
     public void testProcessClosedLocalOrder() throws Exception {
-        //set up
+        // set up
         Order order = createLocalOrder(getLocalMemberId());
-        order.setInstanceId(FAKE_INSTANCE_ID);
+        order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
 
         this.orderController.activateOrder(order);
         OrderStateTransitioner.transition(order, OrderState.CLOSED);
-        
-        //exercise
+
+        // exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
-        //verify
+        // verify
         Mockito.verify(this.orderController, Mockito.times(1)).deactivateOrder(Mockito.eq(order));
-        Assert.assertNull(activeOrdersMap.get(order.getId()));
         Assert.assertNull(closedOrderList.getNext());
+        Assert.assertNull(activeOrdersMap.get(order.getId()));
+        Assert.assertEquals(OrderState.DEACTIVATED, order.getOrderState());
     }
     
     // test case: Check the throw of UnexpectedException when running the thread in
@@ -84,7 +86,7 @@ public class ClosedProcessorTest extends BaseUnitTests {
         // exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         // verify
         Mockito.verify(this.processor, Mockito.times(1)).processClosedOrder(Mockito.eq(order));
@@ -104,7 +106,7 @@ public class ClosedProcessorTest extends BaseUnitTests {
         // exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         // verify
         Mockito.verify(this.processor, Mockito.times(1)).processClosedOrder(Mockito.eq(order));

--- a/src/test/java/cloud/fogbow/ras/core/processors/FulfilledProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/FulfilledProcessorTest.java
@@ -6,12 +6,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.InstanceNotFoundException;
@@ -27,12 +22,9 @@ import cloud.fogbow.ras.core.PropertiesHolder;
 import cloud.fogbow.ras.core.SharedOrderHolders;
 import cloud.fogbow.ras.core.cloudconnector.CloudConnector;
 import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
-import cloud.fogbow.ras.core.cloudconnector.LocalCloudConnector;
 import cloud.fogbow.ras.core.models.orders.Order;
 import cloud.fogbow.ras.core.models.orders.OrderState;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(CloudConnectorFactory.class)
 public class FulfilledProcessorTest extends BaseUnitTests {
 
     /**
@@ -50,22 +42,15 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     @Before
     public void setUp() throws UnexpectedException {
         super.mockReadOrdersFromDataBase();
+        super.mockLocalCloudConnectorFromFactory();
 
         PropertiesHolder propertiesHolder = PropertiesHolder.getInstance();
         this.properties = propertiesHolder.getProperties();
         this.properties.put(ConfigurationPropertyKeys.XMPP_JID_KEY, BaseUnitTests.LOCAL_MEMBER_ID);
         
-        CloudConnectorFactory cloudConnectorFactory = Mockito.mock(CloudConnectorFactory.class);
-
-        PowerMockito.mockStatic(CloudConnectorFactory.class);
-        BDDMockito.given(CloudConnectorFactory.getInstance()).willReturn(cloudConnectorFactory);
-
-        LocalCloudConnector localCloudConnector = Mockito.mock(LocalCloudConnector.class);
-        Mockito.when(cloudConnectorFactory.getCloudConnector(Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(localCloudConnector);
 
         this.cloudConnector = CloudConnectorFactory.getInstance()
-                .getCloudConnector(BaseUnitTests.LOCAL_MEMBER_ID, DEFAULT_CLOUD_NAME);
+                .getCloudConnector(BaseUnitTests.LOCAL_MEMBER_ID, BaseUnitTests.DEFAULT_CLOUD_NAME);
         
         this.processor = Mockito.spy(new FulfilledProcessor(BaseUnitTests.LOCAL_MEMBER_ID,
                 ConfigurationPropertyDefaults.FULFILLED_ORDERS_SLEEP_TIME));
@@ -94,18 +79,18 @@ public class FulfilledProcessorTest extends BaseUnitTests {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        order.setInstanceId(FAKE_INSTANCE_ID);
+        order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
-        ComputeInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
+        ComputeInstance orderInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
         orderInstance.setState(InstanceState.READY);
 
         // exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         // verify
         Assert.assertNotNull(this.fulfilledOrderList.getNext());
@@ -121,10 +106,10 @@ public class FulfilledProcessorTest extends BaseUnitTests {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        order.setInstanceId(FAKE_INSTANCE_ID);
+        order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.FULFILLED);
 
-        ComputeInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
+        ComputeInstance orderInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
         orderInstance.setHasFailed();
 
         Mockito.doReturn(orderInstance).when(this.cloudConnector).getInstance(Mockito.any(Order.class));
@@ -135,7 +120,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
         // exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         // verify
         Order test = this.failedOrderList.getNext();
@@ -153,7 +138,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        order.setInstanceId(FAKE_INSTANCE_ID);
+        order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
         this.failedOrderList.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
@@ -175,18 +160,18 @@ public class FulfilledProcessorTest extends BaseUnitTests {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        order.setInstanceId(FAKE_INSTANCE_ID);
+        order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
-        this.processor = new FulfilledProcessor(FAKE_REMOTE_MEMBER_ID,
+        this.processor = new FulfilledProcessor(BaseUnitTests.FAKE_REMOTE_MEMBER_ID,
                 ConfigurationPropertyDefaults.FULFILLED_ORDERS_SLEEP_TIME);
 
         // exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         // verify
         Assert.assertEquals(order, this.fulfilledOrderList.getNext());
@@ -201,18 +186,18 @@ public class FulfilledProcessorTest extends BaseUnitTests {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        order.setInstanceId(FAKE_INSTANCE_ID);
+        order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
-        ComputeInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
+        ComputeInstance orderInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
         orderInstance.setState(InstanceState.READY);
 
         // exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         // verify
         Assert.assertNotNull(this.fulfilledOrderList.getNext());
@@ -227,12 +212,12 @@ public class FulfilledProcessorTest extends BaseUnitTests {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        order.setInstanceId(FAKE_INSTANCE_ID);
+        order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
-        ComputeInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
+        ComputeInstance orderInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
         orderInstance.setHasFailed();
 
         Mockito.doReturn(orderInstance).when(this.cloudConnector).getInstance(Mockito.any(Order.class));
@@ -262,12 +247,12 @@ public class FulfilledProcessorTest extends BaseUnitTests {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        order.setInstanceId(FAKE_INSTANCE_ID);
+        order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
-        ComputeInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
+        ComputeInstance orderInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
         orderInstance.setHasFailed();
 
         Mockito.doReturn(orderInstance).when(this.cloudConnector).getInstance(Mockito.any(Order.class));
@@ -275,7 +260,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
         // exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         // verify
         Order test = this.failedOrderList.getNext();
@@ -302,7 +287,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
         // exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         // verify
         Mockito.verify(this.processor, Mockito.times(1)).processFulfilledOrder(Mockito.eq(order));
@@ -326,7 +311,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
         // exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         // verify
         Mockito.verify(this.processor, Mockito.times(1)).processFulfilledOrder(Mockito.eq(order));

--- a/src/test/java/cloud/fogbow/ras/core/processors/FulfilledProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/FulfilledProcessorTest.java
@@ -74,8 +74,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     // the method processFulfilledOrder() must not change OrderState to Failed and the order
     // must remain in the Fulfilled list.
     @Test
-    public void testRunProcessLocalComputeOrderWithInstanceReady()
-            throws FogbowException, InterruptedException {
+    public void testRunProcessLocalComputeOrderWithInstanceReady() throws InterruptedException {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());
@@ -133,8 +132,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     // test case: In calling the processFulfilledOrder() method for any order other than Fulfilled,
     // you must not make state transition by keeping the order in your source list.
     @Test
-    public void testProcessLocalComputeOrderNotFulfilled()
-            throws FogbowException, InterruptedException {
+    public void testProcessLocalComputeOrderNotFulfilled() throws FogbowException {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());
@@ -155,8 +153,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     // processFulfilledOrder() must not change OrderState to Failed and must remain in Fulfilled
     // list.
     @Test
-    public void testRunProcessLocalComputeOrderWithoutLocalMember()
-            throws FogbowException, InterruptedException {
+    public void testRunProcessLocalComputeOrderWithoutLocalMember() throws InterruptedException {
 
         // set up
         Order order = createLocalOrder(getLocalMemberId());

--- a/src/test/java/cloud/fogbow/ras/core/processors/FulfilledProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/FulfilledProcessorTest.java
@@ -35,15 +35,10 @@ import cloud.fogbow.ras.core.models.orders.OrderState;
 @PrepareForTest(CloudConnectorFactory.class)
 public class FulfilledProcessorTest extends BaseUnitTests {
 
-    private static final String DEFAULT_CLOUD_NAME = "default";
-    private static final String FAKE_INSTANCE_ID = "fake-instance-id";
-    private static final String REMOTE_MEMBER_ID = "fake-intercomponent-member";
-
     /**
      * Maximum value that the thread should wait in sleep time
      */
     private static final int MAX_SLEEP_TIME = 10000;
-    private static final int DEFAULT_SLEEP_TIME = 500;
 
     private ChainedList<Order> failedOrderList;
     private ChainedList<Order> fulfilledOrderList;
@@ -185,7 +180,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
-        this.processor = new FulfilledProcessor(REMOTE_MEMBER_ID,
+        this.processor = new FulfilledProcessor(FAKE_REMOTE_MEMBER_ID,
                 ConfigurationPropertyDefaults.FULFILLED_ORDERS_SLEEP_TIME);
 
         // exercise

--- a/src/test/java/cloud/fogbow/ras/core/processors/FulfilledProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/FulfilledProcessorTest.java
@@ -74,12 +74,11 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     // the method processFulfilledOrder() must not change OrderState to Failed and the order
     // must remain in the Fulfilled list.
     @Test
-    public void testRunProcessLocalComputeOrderWithInstanceReady() throws InterruptedException {
-
+    public void testRunProcessLocalComputeOrderWithInstanceReady() throws Exception {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FULFILLED);
+        order.setOrderState(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
@@ -100,13 +99,11 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     // the processFulfilledOrder() method must change the OrderState to Failed by adding in that
     // list, and removed from the Fulfilled list.
     @Test
-    public void testRunProcessLocalComputeOrderWhenInstanceStateIsFailed()
-            throws FogbowException, InterruptedException {
-
+    public void testRunProcessLocalComputeOrderWhenInstanceStateIsFailed() throws Exception {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FULFILLED);
+        order.setOrderState(OrderState.FULFILLED);
 
         ComputeInstance orderInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
         orderInstance.setHasFailed();
@@ -133,11 +130,10 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     // you must not make state transition by keeping the order in your source list.
     @Test
     public void testProcessLocalComputeOrderNotFulfilled() throws FogbowException {
-
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        order.setOrderState(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
         this.failedOrderList.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
@@ -153,12 +149,11 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     // processFulfilledOrder() must not change OrderState to Failed and must remain in Fulfilled
     // list.
     @Test
-    public void testRunProcessLocalComputeOrderWithoutLocalMember() throws InterruptedException {
-
+    public void testRunProcessLocalComputeOrderWithoutLocalMember() throws Exception {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FULFILLED);
+        order.setOrderState(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
@@ -184,7 +179,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FULFILLED);
+        order.setOrderState(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
@@ -210,7 +205,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FULFILLED);
+        order.setOrderState(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
@@ -245,7 +240,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FULFILLED);
+        order.setOrderState(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
@@ -270,14 +265,11 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     // test case: When running thread in the FulfilledProcessor with OrderState Null must throw a
     // ThrowableException.
     @Test
-    public void testRunThrowableExceptionWhileTryingToProcessOrderStateNull()
-            throws InterruptedException, FogbowException {
-
+    public void testRunThrowableExceptionWhileTryingToProcessOrderStateNull() throws Exception {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        OrderState state = null;
-        order.setOrderStateInTestMode(state);
         this.fulfilledOrderList.addItem(order);
+        Assert.assertNull(order.getOrderState());
 
         Mockito.doThrow(new RuntimeException()).when(this.processor).processFulfilledOrder(Mockito.eq(order));
         
@@ -293,14 +285,11 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     // test case: When running thread in the FulfilledProcessor with OrderState Null must throw a
     // UnexpectedException.
     @Test
-    public void testThrowUnexpectedExceptionWhileTryingToProcessOrder()
-            throws InterruptedException, FogbowException {
-
+    public void testThrowUnexpectedExceptionWhileTryingToProcessOrder() throws Exception {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        OrderState state = null;
-        order.setOrderStateInTestMode(state);
         this.fulfilledOrderList.addItem(order);
+        Assert.assertNull(order.getOrderState());
 
         Mockito.doThrow(new UnexpectedException()).when(this.processor)
                 .processFulfilledOrder(Mockito.eq(order));
@@ -321,7 +310,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     public void testProcessFulfilledOrderThrowsUnavailableProviderException() throws FogbowException {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        order.setOrderStateInTestMode(OrderState.FULFILLED);
+        order.setOrderState(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
 
         Mockito.doThrow(new UnavailableProviderException()).when(this.cloudConnector)
@@ -338,7 +327,7 @@ public class FulfilledProcessorTest extends BaseUnitTests {
     public void testProcessFulfilledOrderWithInstanceNotFound() throws FogbowException {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
-        order.setOrderStateInTestMode(OrderState.FULFILLED);
+        order.setOrderState(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
 
         Mockito.doThrow(new InstanceNotFoundException()).when(this.cloudConnector)

--- a/src/test/java/cloud/fogbow/ras/core/processors/OpenProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/OpenProcessorTest.java
@@ -4,14 +4,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
@@ -22,12 +17,9 @@ import cloud.fogbow.ras.core.OrderController;
 import cloud.fogbow.ras.core.SharedOrderHolders;
 import cloud.fogbow.ras.core.cloudconnector.CloudConnector;
 import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
-import cloud.fogbow.ras.core.cloudconnector.LocalCloudConnector;
 import cloud.fogbow.ras.core.models.orders.Order;
 import cloud.fogbow.ras.core.models.orders.OrderState;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(CloudConnectorFactory.class)
 public class OpenProcessorTest extends BaseUnitTests {
 
     private static final int OPEN_SLEEP_TIME = 1000;
@@ -40,21 +32,15 @@ public class OpenProcessorTest extends BaseUnitTests {
     @Before
     public void setUp() throws UnexpectedException {
         super.mockReadOrdersFromDataBase();
+        super.mockLocalCloudConnectorFromFactory();
 
-        LocalCloudConnector localCloudConnector = Mockito.mock(LocalCloudConnector.class);
+        this.cloudConnector = CloudConnectorFactory.getInstance().getCloudConnector(BaseUnitTests.LOCAL_MEMBER_ID,
+                BaseUnitTests.DEFAULT_CLOUD_NAME);
 
-        CloudConnectorFactory cloudConnectorFactory = Mockito.mock(CloudConnectorFactory.class);
-        Mockito.when(cloudConnectorFactory.getCloudConnector(Mockito.anyString(), Mockito.anyString())).thenReturn(localCloudConnector);
-
-        PowerMockito.mockStatic(CloudConnectorFactory.class);
-        BDDMockito.given(CloudConnectorFactory.getInstance()).willReturn(cloudConnectorFactory);
-
-        this.cloudConnector = CloudConnectorFactory.getInstance().getCloudConnector(LOCAL_MEMBER_ID, DEFAULT_CLOUD_NAME);
-        this.orderController = new OrderController();
-
-        this.processor = Mockito.spy(new OpenProcessor(LOCAL_MEMBER_ID,
+        this.processor = Mockito.spy(new OpenProcessor(BaseUnitTests.LOCAL_MEMBER_ID, 
                 ConfigurationPropertyDefaults.OPEN_ORDERS_SLEEP_TIME));
-        
+
+        this.orderController = new OrderController();
         this.thread = null;
     }
 
@@ -75,7 +61,7 @@ public class OpenProcessorTest extends BaseUnitTests {
 
         this.orderController.activateOrder(localOrder);
 
-        Mockito.doReturn(FAKE_INSTANCE_ID)
+        Mockito.doReturn(BaseUnitTests.FAKE_INSTANCE_ID)
                 .when(this.cloudConnector)
                 .requestInstance(Mockito.any(Order.class));
 
@@ -113,7 +99,7 @@ public class OpenProcessorTest extends BaseUnitTests {
         //exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         //verify
         Assert.assertEquals(OrderState.FAILED_ON_REQUEST, localOrder.getOrderState());
@@ -143,7 +129,7 @@ public class OpenProcessorTest extends BaseUnitTests {
         //exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
 
         //verify
@@ -173,7 +159,7 @@ public class OpenProcessorTest extends BaseUnitTests {
         //exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         //verify
         Assert.assertEquals(OrderState.PENDING, remoteOrder.getOrderState());
@@ -203,7 +189,7 @@ public class OpenProcessorTest extends BaseUnitTests {
         //exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         //verify
         Assert.assertEquals(OrderState.FAILED_ON_REQUEST, remoteOrder.getOrderState());
@@ -230,7 +216,7 @@ public class OpenProcessorTest extends BaseUnitTests {
         //exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         //verify
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
@@ -245,7 +231,7 @@ public class OpenProcessorTest extends BaseUnitTests {
         //verify
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
     }
 
     //test case: test if the open processor still run and do not change the order state if the method
@@ -264,7 +250,7 @@ public class OpenProcessorTest extends BaseUnitTests {
         //exercise
         this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         //verify
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
@@ -282,7 +268,7 @@ public class OpenProcessorTest extends BaseUnitTests {
 
         this.orderController.activateOrder(localOrder);
 
-        Mockito.doReturn(FAKE_INSTANCE_ID)
+        Mockito.doReturn(BaseUnitTests.FAKE_INSTANCE_ID)
                 .when(this.cloudConnector)
                 .requestInstance(Mockito.any(Order.class));
 
@@ -290,12 +276,12 @@ public class OpenProcessorTest extends BaseUnitTests {
         synchronized (localOrder) {
             this.thread = new Thread(this.processor);
             this.thread.start();
-            Thread.sleep(DEFAULT_SLEEP_TIME);
+            Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
             Assert.assertEquals(OrderState.OPEN, localOrder.getOrderState());
         }
 
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         //verify
         Assert.assertEquals(OrderState.SPAWNING, localOrder.getOrderState());
@@ -315,12 +301,12 @@ public class OpenProcessorTest extends BaseUnitTests {
         synchronized (localOrder) {
             this.thread = new Thread(this.processor);
             this.thread.start();
-            Thread.sleep(DEFAULT_SLEEP_TIME);
+            Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
             localOrder.setOrderStateInTestMode(OrderState.CLOSED);
         }
 
-        Thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
         //verify
         Assert.assertEquals(OrderState.CLOSED, localOrder.getOrderState());
@@ -334,16 +320,14 @@ public class OpenProcessorTest extends BaseUnitTests {
 
         this.orderController.activateOrder(localOrder);
 
-        String id = FAKE_INSTANCE_ID;
-
         Mockito.when(this.cloudConnector.requestInstance(Mockito.any(Order.class)))
                 .thenAnswer(
                         new Answer<String>() {
                             @Override
                             public String answer(InvocationOnMock invocation)
                                     throws InterruptedException {
-                                Thread.sleep(DEFAULT_SLEEP_TIME);
-                                return id;
+                                Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
+                                return BaseUnitTests.FAKE_INSTANCE_ID;
                             }
                         });
         //exercise

--- a/src/test/java/cloud/fogbow/ras/core/processors/OpenProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/OpenProcessorTest.java
@@ -1,22 +1,11 @@
 package cloud.fogbow.ras.core.processors;
 
-import cloud.fogbow.common.exceptions.FogbowException;
-import cloud.fogbow.common.exceptions.UnexpectedException;
-import cloud.fogbow.common.models.linkedlists.ChainedList;
-import cloud.fogbow.ras.constants.ConfigurationPropertyDefaults;
-import cloud.fogbow.ras.core.BaseUnitTests;
-import cloud.fogbow.ras.core.OrderController;
-import cloud.fogbow.ras.core.OrderStateTransitioner;
-import cloud.fogbow.ras.core.SharedOrderHolders;
-import cloud.fogbow.ras.core.cloudconnector.CloudConnector;
-import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
-import cloud.fogbow.ras.core.cloudconnector.LocalCloudConnector;
-import cloud.fogbow.ras.core.models.orders.Order;
-import cloud.fogbow.ras.core.models.orders.OrderState;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -24,38 +13,49 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.when;
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.linkedlists.ChainedList;
+import cloud.fogbow.ras.constants.ConfigurationPropertyDefaults;
+import cloud.fogbow.ras.core.BaseUnitTests;
+import cloud.fogbow.ras.core.OrderController;
+import cloud.fogbow.ras.core.SharedOrderHolders;
+import cloud.fogbow.ras.core.cloudconnector.CloudConnector;
+import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
+import cloud.fogbow.ras.core.cloudconnector.LocalCloudConnector;
+import cloud.fogbow.ras.core.models.orders.Order;
+import cloud.fogbow.ras.core.models.orders.OrderState;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(CloudConnectorFactory.class)
 public class OpenProcessorTest extends BaseUnitTests {
 
-    private OpenProcessor openProcessor;
-    private Thread thread;
+    private static final int OPEN_SLEEP_TIME = 1000;
+    
     private CloudConnector cloudConnector;
     private OrderController orderController;
+    private OpenProcessor processor;
+    private Thread thread;
 
     @Before
     public void setUp() throws UnexpectedException {
-        mockReadOrdersFromDataBase();
+        super.mockReadOrdersFromDataBase();
 
         LocalCloudConnector localCloudConnector = Mockito.mock(LocalCloudConnector.class);
 
         CloudConnectorFactory cloudConnectorFactory = Mockito.mock(CloudConnectorFactory.class);
-        when(cloudConnectorFactory.getCloudConnector(anyString(), anyString())).thenReturn(localCloudConnector);
+        Mockito.when(cloudConnectorFactory.getCloudConnector(Mockito.anyString(), Mockito.anyString())).thenReturn(localCloudConnector);
 
         PowerMockito.mockStatic(CloudConnectorFactory.class);
-        given(CloudConnectorFactory.getInstance()).willReturn(cloudConnectorFactory);
+        BDDMockito.given(CloudConnectorFactory.getInstance()).willReturn(cloudConnectorFactory);
 
-        this.cloudConnector = CloudConnectorFactory.getInstance().getCloudConnector(BaseUnitTests.LOCAL_MEMBER_ID, "default");
-
-        this.thread = null;
-        this.openProcessor = Mockito.spy(new OpenProcessor(BaseUnitTests.LOCAL_MEMBER_ID,
-                ConfigurationPropertyDefaults.OPEN_ORDERS_SLEEP_TIME));
+        this.cloudConnector = CloudConnectorFactory.getInstance().getCloudConnector(LOCAL_MEMBER_ID, DEFAULT_CLOUD_NAME);
         this.orderController = new OrderController();
+
+        this.processor = Mockito.spy(new OpenProcessor(LOCAL_MEMBER_ID,
+                ConfigurationPropertyDefaults.OPEN_ORDERS_SLEEP_TIME));
+        
+        this.thread = null;
     }
 
     @After
@@ -75,27 +75,26 @@ public class OpenProcessorTest extends BaseUnitTests {
 
         this.orderController.activateOrder(localOrder);
 
-        String id = "fake-id";
-        Mockito.doReturn(id)
+        Mockito.doReturn(FAKE_INSTANCE_ID)
                 .when(this.cloudConnector)
                 .requestInstance(Mockito.any(Order.class));
 
         //exercise
-        this.thread = new Thread(this.openProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
 
-        Thread.sleep(1000);
+        Thread.sleep(OPEN_SLEEP_TIME);
 
         //verify
-        assertEquals(OrderState.SPAWNING, localOrder.getOrderState());
+        Assert.assertEquals(OrderState.SPAWNING, localOrder.getOrderState());
 
         // test if the open order list is empty and 
         // the spawningList is with the localOrder
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
         ChainedList<Order> openOrdersList = sharedOrderHolders.getOpenOrdersList();
         ChainedList<Order> spawningOrdersList = sharedOrderHolders.getSpawningOrdersList();
-        assertTrue(this.listIsEmpty(openOrdersList));
-        assertSame(localOrder, spawningOrdersList.getNext());
+        Assert.assertTrue(this.listIsEmpty(openOrdersList));
+        Assert.assertSame(localOrder, spawningOrdersList.getNext());
     }
 
     //test case: test if the open processor is setting to failed an open order when the request instance
@@ -112,21 +111,20 @@ public class OpenProcessorTest extends BaseUnitTests {
                 .requestInstance(Mockito.any(Order.class));
 
         //exercise
-        this.thread = new Thread(this.openProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-
-        Thread.sleep(500);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         //verify
-        assertEquals(OrderState.FAILED_ON_REQUEST, localOrder.getOrderState());
+        Assert.assertEquals(OrderState.FAILED_ON_REQUEST, localOrder.getOrderState());
 
         // test if the open order list is empty and the failedList is with the
         // localOrder
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
         ChainedList<Order> openOrdersList = sharedOrderHolders.getOpenOrdersList();
         ChainedList<Order> failedOrdersList = sharedOrderHolders.getFailedOnRequestOrdersList();
-        assertTrue(this.listIsEmpty(openOrdersList));
-        assertEquals(localOrder, failedOrdersList.getNext());
+        Assert.assertTrue(this.listIsEmpty(openOrdersList));
+        Assert.assertEquals(localOrder, failedOrdersList.getNext());
     }
 
     //test case: test if the open processor is setting to failed an open order when the request instance
@@ -138,26 +136,26 @@ public class OpenProcessorTest extends BaseUnitTests {
 
         this.orderController.activateOrder(localOrder);
 
-        Mockito.doThrow(new RuntimeException("Any Exception"))
+        Mockito.doThrow(new RuntimeException())
                 .when(this.cloudConnector)
                 .requestInstance(Mockito.any(Order.class));
 
         //exercise
-        this.thread = new Thread(this.openProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-        Thread.sleep(500);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
 
         //verify
-        assertEquals(OrderState.FAILED_ON_REQUEST, localOrder.getOrderState());
+        Assert.assertEquals(OrderState.FAILED_ON_REQUEST, localOrder.getOrderState());
 
         // test if the open order list is empty and 
         // the failedList is with the localOrder
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
         ChainedList<Order> openOrdersList = sharedOrderHolders.getOpenOrdersList();
         ChainedList<Order> failedOrdersList = sharedOrderHolders.getFailedOnRequestOrdersList();
-        assertTrue(this.listIsEmpty(openOrdersList));
-        assertSame(localOrder, failedOrdersList.getNext());
+        Assert.assertTrue(this.listIsEmpty(openOrdersList));
+        Assert.assertSame(localOrder, failedOrdersList.getNext());
     }
 
     //test case: test if the open processor is setting to pending an open intercomponent order.
@@ -173,21 +171,20 @@ public class OpenProcessorTest extends BaseUnitTests {
                 .requestInstance(Mockito.any(Order.class));
 
         //exercise
-        this.thread = new Thread(this.openProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-
-        Thread.sleep(500);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         //verify
-        assertEquals(OrderState.PENDING, remoteOrder.getOrderState());
+        Assert.assertEquals(OrderState.PENDING, remoteOrder.getOrderState());
 
         // test if the open order list is empty and
         // the pendingList is with the localOrder
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
         ChainedList<Order> openOrdersList = sharedOrderHolders.getOpenOrdersList();
         ChainedList<Order> pendingOrdersList = sharedOrderHolders.getPendingOrdersList();
-        assertTrue(this.listIsEmpty(openOrdersList));
-        assertSame(remoteOrder, pendingOrdersList.getNext());
+        Assert.assertTrue(this.listIsEmpty(openOrdersList));
+        Assert.assertSame(remoteOrder, pendingOrdersList.getNext());
     }
 
     //test case: test if the open processor is setting to fail an open intercomponent order when the request instance
@@ -204,21 +201,20 @@ public class OpenProcessorTest extends BaseUnitTests {
                 .requestInstance(Mockito.any(Order.class));
 
         //exercise
-        this.thread = new Thread(this.openProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-
-        Thread.sleep(500);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         //verify
-        assertEquals(OrderState.FAILED_ON_REQUEST, remoteOrder.getOrderState());
+        Assert.assertEquals(OrderState.FAILED_ON_REQUEST, remoteOrder.getOrderState());
 
         // test if the open order list is empty and
         // the failedList is with the localOrder
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
         ChainedList<Order> openOrdersList = sharedOrderHolders.getOpenOrdersList();
         ChainedList<Order> failedOrdersList = sharedOrderHolders.getFailedOnRequestOrdersList();
-        assertTrue(this.listIsEmpty(openOrdersList));
-        assertEquals(remoteOrder, failedOrdersList.getNext());
+        Assert.assertTrue(this.listIsEmpty(openOrdersList));
+        Assert.assertEquals(remoteOrder, failedOrdersList.getNext());
     }
 
     //test case: test if the open processor does not process an Order that is not in the open state.
@@ -232,26 +228,24 @@ public class OpenProcessorTest extends BaseUnitTests {
         order.setOrderStateInTestMode(OrderState.PENDING);
 
         //exercise
-        this.thread = new Thread(this.openProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-
-        Thread.sleep(500);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         //verify
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
         ChainedList<Order> openOrdersList = sharedOrderHolders.getOpenOrdersList();
-        assertEquals(OrderState.PENDING, order.getOrderState());
-        assertFalse(this.listIsEmpty(openOrdersList));
+        Assert.assertEquals(OrderState.PENDING, order.getOrderState());
+        Assert.assertFalse(this.listIsEmpty(openOrdersList));
     }
 
     //test case: test if the open processor still running if it try to process a null order.
     @Test
     public void testRunProcessWithNullOpenOrder() throws InterruptedException {
         //verify
-        this.thread = new Thread(this.openProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-
-        Thread.sleep(500);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
     }
 
     //test case: test if the open processor still run and do not change the order state if the method
@@ -264,21 +258,20 @@ public class OpenProcessorTest extends BaseUnitTests {
         this.orderController.activateOrder(order);
 
         Mockito.doThrow(Exception.class)
-                .when(this.openProcessor)
+                .when(this.processor)
                 .processOpenOrder(Mockito.any(Order.class));
 
         //exercise
-        this.thread = new Thread(this.openProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-
-        Thread.sleep(500);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         //verify
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
         ChainedList<Order> openOrdersList = sharedOrderHolders.getOpenOrdersList();
         openOrdersList.addItem(order);
-        assertEquals(OrderState.OPEN, order.getOrderState());
-        assertFalse(this.listIsEmpty(openOrdersList));
+        Assert.assertEquals(OrderState.OPEN, order.getOrderState());
+        Assert.assertFalse(this.listIsEmpty(openOrdersList));
     }
 
     //test case: this method tests a race condition when this class thread has the order operation priority.
@@ -289,25 +282,23 @@ public class OpenProcessorTest extends BaseUnitTests {
 
         this.orderController.activateOrder(localOrder);
 
-        String id = "fake-id";
-        Mockito.doReturn(id)
+        Mockito.doReturn(FAKE_INSTANCE_ID)
                 .when(this.cloudConnector)
                 .requestInstance(Mockito.any(Order.class));
 
         //exercise
         synchronized (localOrder) {
-            this.thread = new Thread(this.openProcessor);
+            this.thread = new Thread(this.processor);
             this.thread.start();
+            Thread.sleep(DEFAULT_SLEEP_TIME);
 
-            Thread.sleep(500);
-
-            assertEquals(OrderState.OPEN, localOrder.getOrderState());
+            Assert.assertEquals(OrderState.OPEN, localOrder.getOrderState());
         }
 
-        Thread.sleep(500);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         //verify
-        assertEquals(OrderState.SPAWNING, localOrder.getOrderState());
+        Assert.assertEquals(OrderState.SPAWNING, localOrder.getOrderState());
     }
 
     //test case: this method tests a race condition when this class thread has the order operation priority
@@ -322,18 +313,17 @@ public class OpenProcessorTest extends BaseUnitTests {
 
         //exercise
         synchronized (localOrder) {
-            this.thread = new Thread(this.openProcessor);
+            this.thread = new Thread(this.processor);
             this.thread.start();
-
-            Thread.sleep(500);
+            Thread.sleep(DEFAULT_SLEEP_TIME);
 
             localOrder.setOrderStateInTestMode(OrderState.CLOSED);
         }
 
-        Thread.sleep(500);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         //verify
-        assertEquals(OrderState.CLOSED, localOrder.getOrderState());
+        Assert.assertEquals(OrderState.CLOSED, localOrder.getOrderState());
     }
 
     //test case: this method tests a race condition when the attend open order thread has the order operation priority.
@@ -344,7 +334,7 @@ public class OpenProcessorTest extends BaseUnitTests {
 
         this.orderController.activateOrder(localOrder);
 
-        String id = "fake-id";
+        String id = FAKE_INSTANCE_ID;
 
         Mockito.when(this.cloudConnector.requestInstance(Mockito.any(Order.class)))
                 .thenAnswer(
@@ -352,24 +342,23 @@ public class OpenProcessorTest extends BaseUnitTests {
                             @Override
                             public String answer(InvocationOnMock invocation)
                                     throws InterruptedException {
-                                Thread.sleep(500);
+                                Thread.sleep(DEFAULT_SLEEP_TIME);
                                 return id;
                             }
                         });
         //exercise
-        this.thread = new Thread(this.openProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-
-        Thread.sleep(1000);
+        Thread.sleep(OPEN_SLEEP_TIME);
 
         synchronized (localOrder) {
-            Thread.sleep(1000);
-            assertEquals(OrderState.SPAWNING, localOrder.getOrderState());
+            Thread.sleep(OPEN_SLEEP_TIME);
+            Assert.assertEquals(OrderState.SPAWNING, localOrder.getOrderState());
             localOrder.setOrderStateInTestMode(OrderState.OPEN);
         }
 
         //verify
-        assertEquals(OrderState.OPEN, localOrder.getOrderState());
+        Assert.assertEquals(OrderState.OPEN, localOrder.getOrderState());
     }
 
     private boolean listIsEmpty(ChainedList<Order> list) {

--- a/src/test/java/cloud/fogbow/ras/core/processors/OpenProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/OpenProcessorTest.java
@@ -211,7 +211,7 @@ public class OpenProcessorTest extends BaseUnitTests {
 
         this.orderController.activateOrder(order);
 
-        order.setOrderStateInTestMode(OrderState.PENDING);
+        order.setOrderState(OrderState.PENDING);
 
         //exercise
         this.thread = new Thread(this.processor);
@@ -303,7 +303,7 @@ public class OpenProcessorTest extends BaseUnitTests {
             this.thread.start();
             Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
 
-            localOrder.setOrderStateInTestMode(OrderState.CLOSED);
+            localOrder.setOrderState(OrderState.CLOSED);
         }
 
         Thread.sleep(BaseUnitTests.DEFAULT_SLEEP_TIME);
@@ -338,7 +338,7 @@ public class OpenProcessorTest extends BaseUnitTests {
         synchronized (localOrder) {
             Thread.sleep(OPEN_SLEEP_TIME);
             Assert.assertEquals(OrderState.SPAWNING, localOrder.getOrderState());
-            localOrder.setOrderStateInTestMode(OrderState.OPEN);
+            localOrder.setOrderState(OrderState.OPEN);
         }
 
         //verify

--- a/src/test/java/cloud/fogbow/ras/core/processors/OpenProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/OpenProcessorTest.java
@@ -110,7 +110,7 @@ public class OpenProcessorTest extends BaseUnitTests {
         ChainedList<Order> openOrdersList = sharedOrderHolders.getOpenOrdersList();
         ChainedList<Order> failedOrdersList = sharedOrderHolders.getFailedOnRequestOrdersList();
         Assert.assertTrue(this.listIsEmpty(openOrdersList));
-        Assert.assertEquals(localOrder, failedOrdersList.getNext());
+        Assert.assertSame(localOrder, failedOrdersList.getNext());
     }
 
     //test case: test if the open processor is setting to failed an open order when the request instance
@@ -200,7 +200,7 @@ public class OpenProcessorTest extends BaseUnitTests {
         ChainedList<Order> openOrdersList = sharedOrderHolders.getOpenOrdersList();
         ChainedList<Order> failedOrdersList = sharedOrderHolders.getFailedOnRequestOrdersList();
         Assert.assertTrue(this.listIsEmpty(openOrdersList));
-        Assert.assertEquals(remoteOrder, failedOrdersList.getNext());
+        Assert.assertSame(remoteOrder, failedOrdersList.getNext());
     }
 
     //test case: test if the open processor does not process an Order that is not in the open state.

--- a/src/test/java/cloud/fogbow/ras/core/processors/SpawningProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/SpawningProcessorTest.java
@@ -72,7 +72,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.OPEN);
+        order.setOrderState(OrderState.OPEN);
         this.openOrderList.addItem(order);
 
         // exercise
@@ -91,7 +91,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
+        order.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
@@ -121,7 +121,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
     public void testRunProcessWhenOrderTypeIsVolume() throws Exception {
         // set up
         Order order = createLocalVolumeOrder();
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
+        order.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
@@ -153,7 +153,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         ComputeOrder computeOrder = createLocalComputeOrder();
         VolumeOrder volumeOrder = createLocalVolumeOrder();
         AttachmentOrder attachmentOrder = createLocalAttachmentOrder(computeOrder, volumeOrder);
-        attachmentOrder.setOrderStateInTestMode(OrderState.SPAWNING);
+        attachmentOrder.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(attachmentOrder);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
@@ -184,7 +184,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
+        order.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
         OrderInstance orderInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
@@ -210,7 +210,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
+        order.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
@@ -241,7 +241,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
+        order.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
 
@@ -274,7 +274,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
+        order.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
         Mockito.doThrow(new RuntimeException()).when(this.cloudConnector).getInstance(Mockito.any(Order.class));
@@ -295,7 +295,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
+        order.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
         Mockito.doThrow(new UnexpectedException()).when(this.processor).processSpawningOrder(order);
@@ -317,7 +317,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
+        order.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
         Mockito.doThrow(new UnavailableProviderException()).when(this.cloudConnector)
@@ -335,7 +335,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
+        order.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
         Mockito.doThrow(new InstanceNotFoundException()).when(this.cloudConnector)
@@ -355,7 +355,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
+        order.setOrderState(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
         this.processor = new SpawningProcessor(BaseUnitTests.FAKE_REMOTE_MEMBER_ID,

--- a/src/test/java/cloud/fogbow/ras/core/processors/SpawningProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/SpawningProcessorTest.java
@@ -15,7 +15,6 @@ import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.InstanceNotFoundException;
 import cloud.fogbow.common.exceptions.UnavailableProviderException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
-import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.models.linkedlists.ChainedList;
 import cloud.fogbow.ras.api.http.response.ComputeInstance;
 import cloud.fogbow.ras.api.http.response.InstanceState;
@@ -27,8 +26,6 @@ import cloud.fogbow.ras.core.cloudconnector.CloudConnector;
 import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
 import cloud.fogbow.ras.core.cloudconnector.LocalCloudConnector;
 import cloud.fogbow.ras.core.models.orders.AttachmentOrder;
-import cloud.fogbow.ras.core.models.orders.ComputeOrder;
-import cloud.fogbow.ras.core.models.orders.NetworkOrder;
 import cloud.fogbow.ras.core.models.orders.Order;
 import cloud.fogbow.ras.core.models.orders.OrderState;
 import cloud.fogbow.ras.core.models.orders.VolumeOrder;
@@ -37,10 +34,8 @@ import cloud.fogbow.ras.core.models.orders.VolumeOrder;
 @PrepareForTest(CloudConnectorFactory.class)
 public class SpawningProcessorTest extends BaseUnitTests {
 
+    private static final String DEFAULT_CLOUD_NAME = "default";
     private static final String FAKE_INSTANCE_ID = "fake-instance-id";
-    private static final String FAKE_INSTANCE_NAME = "fake-instance-name";
-    private static final String FAKE_IMAGE_NAME = "fake-image-name";
-    private static final String FAKE_PUBLIC_KEY = "fake-public-key";
     private static final String FAKE_REMOTE_MEMBER_ID = "fake-intercomponent-member";
 
     private static final int DEFAULT_SLEEP_TIME = 500;
@@ -51,12 +46,11 @@ public class SpawningProcessorTest extends BaseUnitTests {
     private ChainedList<Order> openOrderList;
     private ChainedList<Order> spawningOrderList;
     private CloudConnector cloudConnector;
-    private SpawningProcessor spawningProcessor;
+    private SpawningProcessor processor;
     private Thread thread;
 
     @Before
     public void setUp() throws UnexpectedException {
-
         super.mockReadOrdersFromDataBase();
 
         CloudConnectorFactory cloudConnectorFactory = Mockito.mock(CloudConnectorFactory.class);
@@ -69,9 +63,9 @@ public class SpawningProcessorTest extends BaseUnitTests {
                 .thenReturn(localCloudConnector);
 
         this.cloudConnector = CloudConnectorFactory.getInstance()
-                .getCloudConnector(BaseUnitTests.LOCAL_MEMBER_ID, "default");
+                .getCloudConnector(BaseUnitTests.LOCAL_MEMBER_ID, DEFAULT_CLOUD_NAME);
 
-        this.spawningProcessor = Mockito.spy(new SpawningProcessor(BaseUnitTests.LOCAL_MEMBER_ID,
+        this.processor = Mockito.spy(new SpawningProcessor(BaseUnitTests.LOCAL_MEMBER_ID,
                 ConfigurationPropertyDefaults.SPAWNING_ORDERS_SLEEP_TIME));
 
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
@@ -95,14 +89,14 @@ public class SpawningProcessorTest extends BaseUnitTests {
     // you must not make state transition by keeping the order in your source list.
     @Test
     public void testProcessComputeOrderNotSpawning() throws Exception {
-
         // set up
-        Order order = createComputeOrder();
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.OPEN);
         this.openOrderList.addItem(order);
 
         // exercise
-        this.spawningProcessor.processSpawningOrder(order);
+        this.processor.processSpawningOrder(order);
 
         // verify
         Assert.assertEquals(order, this.openOrderList.getNext());
@@ -114,26 +108,23 @@ public class SpawningProcessorTest extends BaseUnitTests {
     // Fulfilled by adding in that list, and removed from the Spawning list.
     @Test
     public void testRunProcessWhenOrderTypeIsNetwork() throws Exception {
-
         // set up
-        Order order = new NetworkOrder();
-        order.setRequester(BaseUnitTests.LOCAL_MEMBER_ID);
-        order.setProvider(BaseUnitTests.LOCAL_MEMBER_ID);
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
-        OrderInstance orderInstance = Mockito.spy(new ComputeInstance(FAKE_INSTANCE_ID));
+        OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
         orderInstance.setReady();
-        order.setInstanceId(FAKE_INSTANCE_ID);
 
         Mockito.doReturn(orderInstance).when(this.cloudConnector)
                 .getInstance(Mockito.any(Order.class));
 
         // exercise
-        this.thread = new Thread(this.spawningProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-        this.thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         // verify
         Order test = this.fulfilledOrderList.getNext();
@@ -148,7 +139,6 @@ public class SpawningProcessorTest extends BaseUnitTests {
     // Fulfilled by adding in that list, and removed from the Spawning list.
     @Test
     public void testRunProcessWhenOrderTypeIsVolume() throws Exception {
-
         // set up
         Order order = new VolumeOrder();
         order.setRequester(BaseUnitTests.LOCAL_MEMBER_ID);
@@ -157,17 +147,16 @@ public class SpawningProcessorTest extends BaseUnitTests {
         this.spawningOrderList.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
-        OrderInstance orderInstance = Mockito.spy(new ComputeInstance(FAKE_INSTANCE_ID));
+        OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
         orderInstance.setReady();
-        order.setInstanceId(FAKE_INSTANCE_ID);
 
         Mockito.doReturn(orderInstance).when(this.cloudConnector)
                 .getInstance(Mockito.any(Order.class));
 
         // exercise
-        this.thread = new Thread(this.spawningProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-        this.thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         // verify
         Order test = this.fulfilledOrderList.getNext();
@@ -182,7 +171,6 @@ public class SpawningProcessorTest extends BaseUnitTests {
     // Fulfilled by adding in that list, and removed from the Spawning list.
     @Test
     public void testRunProcessWhenOrderTypeIsAttachment() throws Exception {
-
         // set up
         Order order = new AttachmentOrder();
         order.setRequester(BaseUnitTests.LOCAL_MEMBER_ID);
@@ -191,17 +179,16 @@ public class SpawningProcessorTest extends BaseUnitTests {
         this.spawningOrderList.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
-        OrderInstance orderInstance = Mockito.spy(new ComputeInstance(FAKE_INSTANCE_ID));
+        OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
         orderInstance.setReady();
-        order.setInstanceId(FAKE_INSTANCE_ID);
 
         Mockito.doReturn(orderInstance).when(this.cloudConnector)
                 .getInstance(Mockito.any(Order.class));
 
         // exercise
-        this.thread = new Thread(this.spawningProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-        this.thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         // verify
         Order test = this.fulfilledOrderList.getNext();
@@ -216,21 +203,20 @@ public class SpawningProcessorTest extends BaseUnitTests {
     // remain in Spawning list.
     @Test
     public void testRunProcessComputeOrderWhenInstanceStateIsNotReady() throws Exception {
-
         // set up
-        Order order = createComputeOrder();
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
-        OrderInstance orderInstance = Mockito.spy(new ComputeInstance(FAKE_INSTANCE_ID));
+        OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
         orderInstance.setState(InstanceState.DISPATCHED);
-        order.setInstanceId(FAKE_INSTANCE_ID);
 
         Mockito.doReturn(orderInstance).when(this.cloudConnector)
                 .getInstance(Mockito.any(Order.class));
 
         // exercise
-        this.thread = new Thread(this.spawningProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
 
         // verify
@@ -241,27 +227,25 @@ public class SpawningProcessorTest extends BaseUnitTests {
     // test case: When running thread in the SpawningProcessor and the InstanceState is Ready, the
     // processSpawningOrder() method must change the OrderState to Fulfilled by adding in that list,
     // and removed from the Spawning list.
-    @SuppressWarnings("static-access")
     @Test
     public void testRunProcessComputeOrderInstanceReachable() throws Exception {
-
         // set up
-        Order order = createComputeOrder();
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
-        OrderInstance orderInstance = Mockito.spy(new ComputeInstance(FAKE_INSTANCE_ID));
+        OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
         orderInstance.setReady();
-        order.setInstanceId(FAKE_INSTANCE_ID);
 
         Mockito.doReturn(orderInstance).when(this.cloudConnector)
                 .getInstance(Mockito.any(Order.class));
 
         // exercise
-        this.thread = new Thread(this.spawningProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-        this.thread.sleep(SPAWNING_SLEEP_TIME);
+        Thread.sleep(SPAWNING_SLEEP_TIME);
 
         // verify
         Order test = this.fulfilledOrderList.getNext();
@@ -276,25 +260,23 @@ public class SpawningProcessorTest extends BaseUnitTests {
     // list, and removed from the Spawning list.
     @Test
     public void testRunProcessComputeOrderWhenInstanceStateIsFailed() throws Exception {
-
         // set up
-        Order order = createComputeOrder();
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
         Assert.assertNull(this.failedOrderList.getNext());
-        String orderId = order.getId();
 
-        OrderInstance orderInstance = Mockito.spy(new ComputeInstance(FAKE_INSTANCE_ID));
+        OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
         orderInstance.setHasFailed();
-        order.setInstanceId(FAKE_INSTANCE_ID);
 
         Mockito.doReturn(orderInstance).when(this.cloudConnector)
                 .getInstance(Mockito.any(Order.class));
 
         // exercise
-        this.thread = new Thread(this.spawningProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
-        this.thread.sleep(DEFAULT_SLEEP_TIME);
+        Thread.sleep(DEFAULT_SLEEP_TIME);
 
         // verify
         Order test = this.failedOrderList.getNext();
@@ -312,19 +294,20 @@ public class SpawningProcessorTest extends BaseUnitTests {
             throws InterruptedException, FogbowException {
 
         // set up
-        Order order = createComputeOrder();
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
         Mockito.doThrow(new RuntimeException()).when(this.cloudConnector).getInstance(Mockito.any(Order.class));
 
         // exercise
-        this.thread = new Thread(this.spawningProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
         Thread.sleep(DEFAULT_SLEEP_TIME);
 
         // verify
-        Mockito.verify(this.spawningProcessor, Mockito.times(1)).processSpawningOrder(order);
+        Mockito.verify(this.processor, Mockito.times(1)).processSpawningOrder(order);
     }
     
     // test case: Check the throw of UnexpectedException when running the thread in
@@ -332,19 +315,20 @@ public class SpawningProcessorTest extends BaseUnitTests {
     @Test
     public void testRunProcessLocalOrderThrowsUnexpectedException() throws InterruptedException, FogbowException {
         // set up
-        Order order = createComputeOrder();
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
-        Mockito.doThrow(new UnexpectedException()).when(this.spawningProcessor).processSpawningOrder(order);
+        Mockito.doThrow(new UnexpectedException()).when(this.processor).processSpawningOrder(order);
 
         // exercise
-        this.thread = new Thread(this.spawningProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
         Thread.sleep(DEFAULT_SLEEP_TIME);
 
         // verify
-        Mockito.verify(this.spawningProcessor, Mockito.times(1)).processSpawningOrder(order);
+        Mockito.verify(this.processor, Mockito.times(1)).processSpawningOrder(order);
     }
     
     // test case: When invoking the processSpawningOrder method and an error occurs
@@ -353,7 +337,8 @@ public class SpawningProcessorTest extends BaseUnitTests {
     @Test(expected = UnavailableProviderException.class) // Verify
     public void testProcessSpawningOrderThrowsUnavailableProviderException() throws FogbowException {
         // set up
-        Order order = createComputeOrder();
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
@@ -361,7 +346,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
                 .getInstance(Mockito.any(Order.class));
 
         // exercise
-        this.spawningProcessor.processSpawningOrder(order);
+        this.processor.processSpawningOrder(order);
     }
     
     // test case: When calling the processSpawningOrder method and the
@@ -370,7 +355,8 @@ public class SpawningProcessorTest extends BaseUnitTests {
     @Test
     public void testProcessSpawningOrderWithInstanceNotFound() throws FogbowException {
         // set up
-        Order order = createComputeOrder();
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
@@ -378,7 +364,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
                 .getInstance(Mockito.any(Order.class));
 
         // exercise
-        this.spawningProcessor.processSpawningOrder(order);
+        this.processor.processSpawningOrder(order);
 
         // verify
         Assert.assertEquals(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST, order.getOrderState());
@@ -389,29 +375,19 @@ public class SpawningProcessorTest extends BaseUnitTests {
     @Test
     public void testProcessSpawningOrderWithARemoteMember() throws FogbowException {
         // set up
-        Order order = createComputeOrder();
+        Order order = createLocalOrder(getLocalMemberId());
+        order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
 
-        this.spawningProcessor = new SpawningProcessor(FAKE_REMOTE_MEMBER_ID,
+        this.processor = new SpawningProcessor(FAKE_REMOTE_MEMBER_ID,
                 ConfigurationPropertyDefaults.FAILED_ORDERS_SLEEP_TIME);
 
         // exercise
-        this.spawningProcessor.processSpawningOrder(order);
+        this.processor.processSpawningOrder(order);
 
         // verify
         Assert.assertEquals(OrderState.SPAWNING, order.getOrderState());
-    }
-
-    private Order createComputeOrder() {
-        SystemUser systemUser = Mockito.mock(SystemUser.class);
-        String requestingMember = BaseUnitTests.LOCAL_MEMBER_ID;
-        String providingMember = BaseUnitTests.LOCAL_MEMBER_ID;
-
-        Order order = new ComputeOrder(systemUser, requestingMember,
-                providingMember, "default", FAKE_INSTANCE_NAME, 8, 1024, 30, FAKE_IMAGE_NAME, mockUserData(), FAKE_PUBLIC_KEY, null);
-
-        return order;
     }
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/processors/SpawningProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/SpawningProcessorTest.java
@@ -26,6 +26,7 @@ import cloud.fogbow.ras.core.cloudconnector.CloudConnector;
 import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
 import cloud.fogbow.ras.core.cloudconnector.LocalCloudConnector;
 import cloud.fogbow.ras.core.models.orders.AttachmentOrder;
+import cloud.fogbow.ras.core.models.orders.ComputeOrder;
 import cloud.fogbow.ras.core.models.orders.Order;
 import cloud.fogbow.ras.core.models.orders.OrderState;
 import cloud.fogbow.ras.core.models.orders.VolumeOrder;
@@ -34,11 +35,6 @@ import cloud.fogbow.ras.core.models.orders.VolumeOrder;
 @PrepareForTest(CloudConnectorFactory.class)
 public class SpawningProcessorTest extends BaseUnitTests {
 
-    private static final String DEFAULT_CLOUD_NAME = "default";
-    private static final String FAKE_INSTANCE_ID = "fake-instance-id";
-    private static final String FAKE_REMOTE_MEMBER_ID = "fake-intercomponent-member";
-
-    private static final int DEFAULT_SLEEP_TIME = 500;
     private static final int SPAWNING_SLEEP_TIME = 2000;
 
     private ChainedList<Order> failedOrderList;
@@ -140,9 +136,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
     @Test
     public void testRunProcessWhenOrderTypeIsVolume() throws Exception {
         // set up
-        Order order = new VolumeOrder();
-        order.setRequester(BaseUnitTests.LOCAL_MEMBER_ID);
-        order.setProvider(BaseUnitTests.LOCAL_MEMBER_ID);
+        Order order = createLocalVolumeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
         order.setOrderStateInTestMode(OrderState.SPAWNING);
         this.spawningOrderList.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
@@ -172,11 +166,13 @@ public class SpawningProcessorTest extends BaseUnitTests {
     @Test
     public void testRunProcessWhenOrderTypeIsAttachment() throws Exception {
         // set up
-        Order order = new AttachmentOrder();
-        order.setRequester(BaseUnitTests.LOCAL_MEMBER_ID);
-        order.setProvider(BaseUnitTests.LOCAL_MEMBER_ID);
-        order.setOrderStateInTestMode(OrderState.SPAWNING);
-        this.spawningOrderList.addItem(order);
+        ComputeOrder computeOrder = createLocalComputeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        VolumeOrder volumeOrder = createLocalVolumeOrder(LOCAL_MEMBER_ID, LOCAL_MEMBER_ID);
+        AttachmentOrder attachmentOrder = createLocalAttachmentOrder(computeOrder, volumeOrder);
+        attachmentOrder.setRequester(LOCAL_MEMBER_ID);
+        attachmentOrder.setProvider(LOCAL_MEMBER_ID);
+        attachmentOrder.setOrderStateInTestMode(OrderState.SPAWNING);
+        this.spawningOrderList.addItem(attachmentOrder);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
         OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
@@ -193,7 +189,7 @@ public class SpawningProcessorTest extends BaseUnitTests {
         // verify
         Order test = this.fulfilledOrderList.getNext();
         Assert.assertNotNull(test);
-        Assert.assertEquals(order.getInstanceId(), test.getInstanceId());
+        Assert.assertEquals(attachmentOrder.getInstanceId(), test.getInstanceId());
         Assert.assertEquals(OrderState.FULFILLED, test.getOrderState());
         Assert.assertNull(this.spawningOrderList.getNext());
     }

--- a/src/test/java/cloud/fogbow/ras/core/processors/UnableToCheckStatusProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/UnableToCheckStatusProcessorTest.java
@@ -59,7 +59,7 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
     // remote member ID, the processUnableToCheckStatusOrder method must not change
     // its state, remaining in the failed list.
     @Test
-    public void testRunProcessLocalOrderWithRemoteMember() throws FogbowException, InterruptedException {
+    public void testRunProcessLocalOrderWithRemoteMember() throws InterruptedException {
         // set up
         Order order = createRemoteOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
@@ -84,7 +84,7 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
     // requesting state other than failed after a successful request, it must not
     // transition states by keeping the request in its source list.
     @Test
-    public void testRunProcessLocalOrderNotFailed() throws FogbowException, InterruptedException {
+    public void testRunProcessLocalOrderNotFailed() throws FogbowException {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);

--- a/src/test/java/cloud/fogbow/ras/core/processors/UnableToCheckStatusProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/UnableToCheckStatusProcessorTest.java
@@ -31,11 +31,6 @@ import cloud.fogbow.ras.core.models.orders.OrderState;
 @PrepareForTest(CloudConnectorFactory.class)
 public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
 
-    private static final long DEFAULT_SLEEP_TIME = 500;
-    private static final String DEFAULT_CLOUD_NAME = "default";
-    private static final String FAKE_INSTANCE_ID = "fake-instance-id";
-    private static final String FAKE_REMOTE_MEMBER_ID = "fake-intercomponent-member";
-
     private ChainedList<Order> unableToCheckStatus;
     private ChainedList<Order> fulfilledOrderList;
     private CloudConnector cloudConnector;
@@ -56,9 +51,9 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
                 .thenReturn(localCloudConnector);
 
         this.cloudConnector = CloudConnectorFactory.getInstance()
-                .getCloudConnector(BaseUnitTests.LOCAL_MEMBER_ID, DEFAULT_CLOUD_NAME);
+                .getCloudConnector(LOCAL_MEMBER_ID, DEFAULT_CLOUD_NAME);
 
-        this.processor = Mockito.spy(new UnableToCheckStatusProcessor(BaseUnitTests.LOCAL_MEMBER_ID,
+        this.processor = Mockito.spy(new UnableToCheckStatusProcessor(LOCAL_MEMBER_ID,
                 ConfigurationPropertyDefaults.FAILED_ORDERS_SLEEP_TIME));
 
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
@@ -311,7 +306,7 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
     @Test
     public void testProcessUnableToCheckStatusOrderWithRemoteMember() throws FogbowException {
         // set up
-        Order order = createRemoteOrder(getLocalMemberId());
+        Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(FAKE_INSTANCE_ID);
         order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
         this.unableToCheckStatus.addItem(order);

--- a/src/test/java/cloud/fogbow/ras/core/processors/UnableToCheckStatusProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/UnableToCheckStatusProcessorTest.java
@@ -80,9 +80,9 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
         Assert.assertNull(this.fulfilledOrderList.getNext());
     }
 
-    // test case: When calling the processFulfilledOrder method for any requesting
-    // state other than failed after a successful request, it must not transition
-    // states by keeping the request in its source list.
+    // test case: When calling the processUnableToCheckStatusOrder method for any
+    // requesting state other than failed after a successful request, it must not
+    // transition states by keeping the request in its source list.
     @Test
     public void testRunProcessLocalOrderNotFailed() throws FogbowException, InterruptedException {
         // set up
@@ -142,10 +142,10 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
         this.unableToCheckStatus.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
-        OrderInstance orderInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
-        orderInstance.setReady();
+        ComputeInstance computeInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
+        computeInstance.setReady();
 
-        Mockito.doReturn(orderInstance).when(this.cloudConnector).getInstance(Mockito.any(Order.class));
+        Mockito.doReturn(computeInstance).when(this.cloudConnector).getInstance(Mockito.any(Order.class));
 
         // exercise
         this.thread = new Thread(this.processor);
@@ -265,7 +265,7 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
     }
 
     // test case: When calling the processUnableToCheckStatusOrder method and the
-    // order instance is not found, it must change the order state to
+    // InstanceNotFoundException has been thrown, it must change the order state to
     // FAILED_AFTER_SUCCESSFUL_REQUEST.
     @Test
     public void testProcessUnableToCheckStatusOrderWithInstanceNotFound() throws FogbowException {

--- a/src/test/java/cloud/fogbow/ras/core/processors/UnableToCheckStatusProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/UnableToCheckStatusProcessorTest.java
@@ -1,24 +1,8 @@
 package cloud.fogbow.ras.core.processors;
 
-import cloud.fogbow.common.exceptions.FogbowException;
-import cloud.fogbow.common.exceptions.UnexpectedException;
-import cloud.fogbow.common.models.SystemUser;
-import cloud.fogbow.common.models.linkedlists.ChainedList;
-import cloud.fogbow.ras.api.http.response.OrderInstance;
-import cloud.fogbow.ras.constants.ConfigurationPropertyDefaults;
-import cloud.fogbow.ras.constants.ConfigurationPropertyKeys;
-import cloud.fogbow.ras.core.BaseUnitTests;
-import cloud.fogbow.ras.core.PropertiesHolder;
-import cloud.fogbow.ras.core.SharedOrderHolders;
-import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
-import cloud.fogbow.ras.core.cloudconnector.LocalCloudConnector;
-import cloud.fogbow.ras.core.models.UserData;
-import cloud.fogbow.ras.api.http.response.ComputeInstance;
-import cloud.fogbow.ras.api.http.response.Instance;
-import cloud.fogbow.ras.api.http.response.InstanceState;
-import cloud.fogbow.ras.core.models.orders.ComputeOrder;
-import cloud.fogbow.ras.core.models.orders.Order;
-import cloud.fogbow.ras.core.models.orders.OrderState;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,44 +14,64 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.*;
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.exceptions.InstanceNotFoundException;
+import cloud.fogbow.common.exceptions.UnavailableProviderException;
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.SystemUser;
+import cloud.fogbow.common.models.linkedlists.ChainedList;
+import cloud.fogbow.ras.api.http.response.ComputeInstance;
+import cloud.fogbow.ras.api.http.response.InstanceState;
+import cloud.fogbow.ras.api.http.response.OrderInstance;
+import cloud.fogbow.ras.constants.ConfigurationPropertyDefaults;
+import cloud.fogbow.ras.constants.ConfigurationPropertyKeys;
+import cloud.fogbow.ras.core.BaseUnitTests;
+import cloud.fogbow.ras.core.PropertiesHolder;
+import cloud.fogbow.ras.core.SharedOrderHolders;
+import cloud.fogbow.ras.core.cloudconnector.CloudConnectorFactory;
+import cloud.fogbow.ras.core.cloudconnector.LocalCloudConnector;
+import cloud.fogbow.ras.core.models.UserData;
+import cloud.fogbow.ras.core.models.orders.ComputeOrder;
+import cloud.fogbow.ras.core.models.orders.Order;
+import cloud.fogbow.ras.core.models.orders.OrderState;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(CloudConnectorFactory.class)
 public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
 
-	private static final int CPU_VALUE = 8;
-	private static final long DEFAULT_SLEEP_TIME = 500;
-	private static final int DISK_VALUE = 30;
-	private static final int MEMORY_VALUE = 1024;
-	
-	private static final String CLOUD_NAME = "default";
-	private static final String FAKE_IMAGE_NAME = "fake-image-name";
-	private static final String FAKE_INSTANCE_ID = "fake-instance-id";
-	private static final String FAKE_INSTANCE_NAME = "fake-instance-name";
-	private static final String FAKE_PUBLIC_KEY = "fake-public-key";
-	private static final String FAKE_REMOTE_MEMBER_ID = "fake-intercomponent-member";
-	private static final String FAKE_TOKEN_PROVIDER = "fake-token-provider";
-	private static final String FAKE_USER_ID = "fake-user-id";
-	private static final String FAKE_USER_NAME = "fake-user-name";
-	
-	private ChainedList<Order> unableToCheckStatus;
+    private static final int CPU_VALUE = 8;
+    private static final long DEFAULT_SLEEP_TIME = 500;
+    private static final int DISK_VALUE = 30;
+    private static final int MEMORY_VALUE = 1024;
+
+    private static final String CLOUD_NAME = "default";
+    private static final String FAKE_IMAGE_NAME = "fake-image-name";
+    private static final String FAKE_INSTANCE_ID = "fake-instance-id";
+    private static final String FAKE_INSTANCE_NAME = "fake-instance-name";
+    private static final String FAKE_PUBLIC_KEY = "fake-public-key";
+    private static final String FAKE_REMOTE_MEMBER_ID = "fake-intercomponent-member";
+    private static final String FAKE_TOKEN_PROVIDER = "fake-token-provider";
+    private static final String FAKE_USER_ID = "fake-user-id";
+    private static final String FAKE_USER_NAME = "fake-user-name";
+
+    private ChainedList<Order> unableToCheckStatus;
     private ChainedList<Order> fulfilledOrderList;
-    private UnableToCheckStatusProcessor unableToCheckStatusProcessor;
-    private LocalCloudConnector localCloudConnector;
+    private UnableToCheckStatusProcessor processor;
     private Thread thread;
-    
+
     @Before
     public void setUp() throws UnexpectedException {
-    	super.mockReadOrdersFromDataBase();
-    	this.localCloudConnector = Mockito.mock(LocalCloudConnector.class);
+        super.mockReadOrdersFromDataBase();
         this.thread = null;
+
+        this.processor = Mockito.spy(new UnableToCheckStatusProcessor(BaseUnitTests.LOCAL_MEMBER_ID,
+                ConfigurationPropertyDefaults.FAILED_ORDERS_SLEEP_TIME));
 
         SharedOrderHolders sharedOrderHolders = SharedOrderHolders.getInstance();
         this.fulfilledOrderList = sharedOrderHolders.getFulfilledOrdersList();
         this.unableToCheckStatus = sharedOrderHolders.getUnableToCheckStatusOrdersList();
     }
-    
+
     @After
     public void tearDown() {
         if (this.thread != null) {
@@ -75,239 +79,284 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
         }
         super.tearDown();
     }
-    
-	// test case: When running thread in the UnableToCheckStatusProcessor with a remote member
-	// ID, the processUnableToCheckStatusOrder method must not change its state, remaining in the
-	// failed list.
-	@Test
-	public void testRunProcessLocalOrderWithRemoteMember()
-			throws FogbowException, InterruptedException {
 
-		// set up
-		Order order = this.createOrder();
-		order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
-		this.unableToCheckStatus.addItem(order);
-		Assert.assertNull(this.fulfilledOrderList.getNext());
-
-		this.unableToCheckStatusProcessor = new UnableToCheckStatusProcessor(FAKE_REMOTE_MEMBER_ID,
-				ConfigurationPropertyDefaults.FAILED_ORDERS_SLEEP_TIME);
-
-		// exercise
-		this.thread = new Thread(this.unableToCheckStatusProcessor);
-		this.thread.start();
-		Thread.sleep(DEFAULT_SLEEP_TIME);
-
-		// verify
-		Assert.assertEquals(order, this.unableToCheckStatus.getNext());
-		Assert.assertNull(this.fulfilledOrderList.getNext());
-	}
-	
-	// test case: When calling the processFulfilledOrder method for any requesting
-	// state other than failed after a successful request, it must not transition
-	// states by keeping the request in its source list.
-	@Test
-	public void testRunProcessLocalOrderNotFailed() throws FogbowException, InterruptedException {
-
-		// set up
-		Order order = this.createOrder();
-		order.setOrderStateInTestMode(OrderState.FULFILLED);
-		this.fulfilledOrderList.addItem(order);
-		Assert.assertNull(this.unableToCheckStatus.getNext());
-
-		// exercise
-		spyFailedProcessor();
-		this.unableToCheckStatusProcessor.processUnableToCheckStatusOrder(order);
-
-		// verify
-		Assert.assertEquals(order, this.fulfilledOrderList.getNext());
-		Assert.assertNull(this.unableToCheckStatus.getNext());
-	}
-    
-	// test case: When executing the thread in UnableToCheckStatusProcessor, if the instance
-	// state is still Failed after a successful request, the processUnableToCheckStatusOrder
-	// method should not change its state and it must remain in the list of
-	// failures.
-	@Test
-	public void testRunProcessLocalOrderWithInstanceFailed()
-			throws FogbowException, InterruptedException {
-		
-		// set up
-		Order order = createOrder();
-		order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
-		this.unableToCheckStatus.addItem(order);
-		Assert.assertNull(this.fulfilledOrderList.getNext());
-
-		OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
-		orderInstance.setState(InstanceState.FAILED);
-		order.setInstanceId(FAKE_INSTANCE_ID);
-
-		mockCloudConnectorFactory(orderInstance);
-
-		// exercise
-		this.thread = new Thread(this.unableToCheckStatusProcessor);
-		this.thread.start();
-		Thread.sleep(DEFAULT_SLEEP_TIME);
-
-		// verify
-		Assert.assertNotNull(this.unableToCheckStatus.getNext());
-		Assert.assertNull(this.fulfilledOrderList.getNext());
-	}
-	
-	// test case: When executing the thread in the UnableToCheckStatusProcessor, if the instance
-	// is back to the Ready state, the processUnableToCheckStatusOrder method must change
-	// OrderState from UnableToCheckStatus to Fulfilled and the order must be removed from the
-	// unableToCheckStatus list and put in the fulfilled list.
-	@Test
-	public void testRunProcessLocalOrderWithInstanceReady()
-			throws InterruptedException, FogbowException {
-
-		// set up
-		Order order = createOrder();
-		order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
-		this.unableToCheckStatus.addItem(order);
-		Assert.assertNull(this.fulfilledOrderList.getNext());
-
-		OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
-		orderInstance.setReady();
-		order.setInstanceId(FAKE_INSTANCE_ID);
-
-		mockCloudConnectorFactory(orderInstance);
-
-		// exercise
-		this.thread = new Thread(this.unableToCheckStatusProcessor);
-		this.thread.start();
-		Thread.sleep(DEFAULT_SLEEP_TIME);
-
-		// verify
-		Assert.assertNotNull(this.fulfilledOrderList.getNext());
-		Assert.assertNull(this.unableToCheckStatus.getNext());
-	}
-	
-	// test case: During a thread running in UnableToCheckStatusProcessor, if any errors occur
-	// when attempting to get a cloud provider instance, the processUnableToCheckStatusOrder
-	// method will catch an exception.
-	@Test
-	public void testRunProcessLocalOrderToCatchExceptionWhileTryingToGetInstance()
-			throws InterruptedException, FogbowException {
-
-		// set up
-		Order order = createOrder();
-		order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
-		this.unableToCheckStatus.addItem(order);
-
-		CloudConnectorFactory cloudConnectorFactory = Mockito.mock(CloudConnectorFactory.class);
-
-		PowerMockito.mockStatic(CloudConnectorFactory.class);
-		BDDMockito.given(CloudConnectorFactory.getInstance()).willReturn(cloudConnectorFactory);
-
-		Mockito.when(cloudConnectorFactory.getCloudConnector(Mockito.anyString(), Mockito.anyString()))
-				.thenReturn(this.localCloudConnector);
-
-		Mockito.doThrow(new RuntimeException()).when(this.localCloudConnector).getInstance(Mockito.any(Order.class));
-
-		spyFailedProcessor();
-
-		// exercise
-		this.thread = new Thread(this.unableToCheckStatusProcessor);
-		this.thread.start();
-		Thread.sleep(DEFAULT_SLEEP_TIME);
-
-		// verify
-		Mockito.verify(this.unableToCheckStatusProcessor, Mockito.times(1)).processUnableToCheckStatusOrder(order);
-	}
-	
-	// test case: Check the throw of UnexpectedException when running the thread in
-	// the UnableToCheckStatusProcessor, while running a local order.
-	@Test
-	public void testRunProcessLocalOrderThrowsUnexpectedException()
-			throws InterruptedException, FogbowException {
-
-		// set up
-		Order order = createOrder();
-		order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
-		this.unableToCheckStatus.addItem(order);
-
-		spyFailedProcessor();
-
-		Mockito.doThrow(new UnexpectedException()).when(this.unableToCheckStatusProcessor).processUnableToCheckStatusOrder(order);
-
-		// exercise
-		this.thread = new Thread(this.unableToCheckStatusProcessor);
-		this.thread.start();
-		Thread.sleep(DEFAULT_SLEEP_TIME);
-
-		// verify
-		Mockito.verify(this.unableToCheckStatusProcessor, Mockito.times(1)).processUnableToCheckStatusOrder(order);
-	}
-	
-	// test case: Check the throw of RuntimeException when running the thread in
-	// the UnableToCheckStatusProcessor, while running a local order.
+    // test case: When running thread in the UnableToCheckStatusProcessor with a
+    // remote member ID, the processUnableToCheckStatusOrder method must not change
+    // its state, remaining in the failed list.
     @Test
-    public void testRunProcessLocalOrderThrowsRuntimeException()
-			throws InterruptedException, FogbowException {
-
+    public void testRunProcessLocalOrderWithRemoteMember() throws FogbowException, InterruptedException {
         // set up
-		Order order = createOrder();
-		order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
-		this.unableToCheckStatus.addItem(order);
+        Order order = this.createOrder();
+        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        this.unableToCheckStatus.addItem(order);
+        Assert.assertNull(this.fulfilledOrderList.getNext());
 
-        spyFailedProcessor();
+        this.processor = Mockito.spy(new UnableToCheckStatusProcessor(FAKE_REMOTE_MEMBER_ID,
+                ConfigurationPropertyDefaults.FAILED_ORDERS_SLEEP_TIME));
 
         // exercise
-        Mockito.doThrow(new RuntimeException()).when(this.unableToCheckStatusProcessor)
-                .processUnableToCheckStatusOrder(order);
-
-        this.thread = new Thread(this.unableToCheckStatusProcessor);
+        this.thread = new Thread(this.processor);
         this.thread.start();
         Thread.sleep(DEFAULT_SLEEP_TIME);
 
         // verify
-        Mockito.verify(this.unableToCheckStatusProcessor, Mockito.times(1)).processUnableToCheckStatusOrder(order);
+        Assert.assertEquals(order, this.unableToCheckStatus.getNext());
+        Assert.assertNull(this.fulfilledOrderList.getNext());
     }
-    
-	private void mockCloudConnectorFactory(Instance orderInstance) throws FogbowException {
-		CloudConnectorFactory cloudConnectorFactory = Mockito.mock(CloudConnectorFactory.class);
-		
-		PowerMockito.mockStatic(CloudConnectorFactory.class);
-		BDDMockito.given(CloudConnectorFactory.getInstance()).willReturn(cloudConnectorFactory);
-		
-		Mockito.when(cloudConnectorFactory.getCloudConnector(Mockito.anyString(), Mockito.anyString()))
-				.thenReturn(this.localCloudConnector);
 
-		Mockito.doReturn(orderInstance).when(this.localCloudConnector).getInstance(Mockito.any(Order.class));
+    // test case: When calling the processFulfilledOrder method for any requesting
+    // state other than failed after a successful request, it must not transition
+    // states by keeping the request in its source list.
+    @Test
+    public void testRunProcessLocalOrderNotFailed() throws FogbowException, InterruptedException {
+        // set up
+        Order order = this.createOrder();
+        order.setOrderStateInTestMode(OrderState.FULFILLED);
+        this.fulfilledOrderList.addItem(order);
+        Assert.assertNull(this.unableToCheckStatus.getNext());
 
-		spyFailedProcessor();
-	}
+        // exercise
+        this.processor.processUnableToCheckStatusOrder(order);
 
-	private void spyFailedProcessor() {
-		this.unableToCheckStatusProcessor = Mockito.spy(new UnableToCheckStatusProcessor(BaseUnitTests.LOCAL_MEMBER_ID,
-				ConfigurationPropertyDefaults.FAILED_ORDERS_SLEEP_TIME));
-	}
+        // verify
+        Assert.assertEquals(order, this.fulfilledOrderList.getNext());
+        Assert.assertNull(this.unableToCheckStatus.getNext());
+    }
 
-	private Order createOrder() {
-		SystemUser systemUser = new SystemUser(FAKE_USER_ID, FAKE_USER_NAME, FAKE_TOKEN_PROVIDER);
-		String localMemberId = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.LOCAL_PROVIDER_ID_KEY);
+    // test case: When executing the thread in UnableToCheckStatusProcessor, if the
+    // instance state is still Failed after a successful request, the
+    // processUnableToCheckStatusOrder method should not change its state and it
+    // must remain in the list of failures.
+    @Test
+    public void testRunProcessLocalOrderWithInstanceFailed() throws FogbowException, InterruptedException {
+        // set up
+        Order order = createOrder();
+        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        this.unableToCheckStatus.addItem(order);
+        Assert.assertNull(this.fulfilledOrderList.getNext());
 
+        OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
+        orderInstance.setState(InstanceState.FAILED);
+        order.setInstanceId(FAKE_INSTANCE_ID);
 
-		String requestingMember = localMemberId;
-		String providingMember = localMemberId;
-		ArrayList<UserData> userData = super.mockUserData();
-		List<String> networkIds = null;
+        LocalCloudConnector localCloudConnector = Mockito.mock(LocalCloudConnector.class);
+        mockCloudConnectorFactory(localCloudConnector);
+        Mockito.doReturn(orderInstance).when(localCloudConnector).getInstance(Mockito.any(Order.class));
 
-		Order order = new ComputeOrder(
-				systemUser,
-				requestingMember, 
-				providingMember, 
-				CLOUD_NAME,
-				FAKE_INSTANCE_NAME, 
-				CPU_VALUE, 
-				MEMORY_VALUE, 
-				DISK_VALUE, 
-				FAKE_IMAGE_NAME, 
-				userData, 
-				FAKE_PUBLIC_KEY, 
-				networkIds);
-		
-		return order;
-	}
+        // exercise
+        this.thread = new Thread(this.processor);
+        this.thread.start();
+        Thread.sleep(DEFAULT_SLEEP_TIME);
+
+        // verify
+        Assert.assertNotNull(this.unableToCheckStatus.getNext());
+        Assert.assertNull(this.fulfilledOrderList.getNext());
+    }
+
+    // test case: When executing the thread in the UnableToCheckStatusProcessor, if
+    // the instance is back to the Ready state, the processUnableToCheckStatusOrder
+    // method must change OrderState from UnableToCheckStatus to Fulfilled and the
+    // order must be removed from the unableToCheckStatus list and put in the
+    // fulfilled list.
+    @Test
+    public void testRunProcessLocalOrderWithInstanceReady() throws InterruptedException, FogbowException {
+        // set up
+        Order order = createOrder();
+        order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
+        this.unableToCheckStatus.addItem(order);
+        Assert.assertNull(this.fulfilledOrderList.getNext());
+
+        OrderInstance orderInstance = new ComputeInstance(FAKE_INSTANCE_ID);
+        orderInstance.setReady();
+        order.setInstanceId(FAKE_INSTANCE_ID);
+
+        LocalCloudConnector localCloudConnector = Mockito.mock(LocalCloudConnector.class);
+        mockCloudConnectorFactory(localCloudConnector);
+        Mockito.doReturn(orderInstance).when(localCloudConnector).getInstance(Mockito.any(Order.class));
+
+        // exercise
+        this.thread = new Thread(this.processor);
+        this.thread.start();
+        Thread.sleep(DEFAULT_SLEEP_TIME);
+
+        // verify
+        Assert.assertNotNull(this.fulfilledOrderList.getNext());
+        Assert.assertNull(this.unableToCheckStatus.getNext());
+    }
+
+    // test case: During a thread running in UnableToCheckStatusProcessor, if any
+    // errors occur when attempting to get a cloud provider instance, the
+    // processUnableToCheckStatusOrder method will catch an exception.
+    @Test
+    public void testRunProcessLocalOrderToCatchExceptionWhileTryingToGetInstance()
+            throws InterruptedException, FogbowException {
+
+        // set up
+        Order order = createOrder();
+        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        this.unableToCheckStatus.addItem(order);
+
+        LocalCloudConnector localCloudConnector = Mockito.mock(LocalCloudConnector.class);
+        mockCloudConnectorFactory(localCloudConnector);
+        Mockito.doThrow(new RuntimeException()).when(localCloudConnector).getInstance(Mockito.any(Order.class));
+
+        // exercise
+        this.thread = new Thread(this.processor);
+        this.thread.start();
+        Thread.sleep(DEFAULT_SLEEP_TIME);
+
+        // verify
+        Mockito.verify(this.processor, Mockito.times(1)).processUnableToCheckStatusOrder(order);
+    }
+
+    // test case: Check the throw of UnexpectedException when running the thread in
+    // the UnableToCheckStatusProcessor, while running a local order.
+    @Test
+    public void testRunProcessLocalOrderThrowsUnexpectedException() throws InterruptedException, FogbowException {
+        // set up
+        Order order = createOrder();
+        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        this.unableToCheckStatus.addItem(order);
+
+        Mockito.doThrow(new UnexpectedException()).when(this.processor).processUnableToCheckStatusOrder(order);
+
+        // exercise
+        this.thread = new Thread(this.processor);
+        this.thread.start();
+        Thread.sleep(DEFAULT_SLEEP_TIME);
+
+        // verify
+        Mockito.verify(this.processor, Mockito.times(1)).processUnableToCheckStatusOrder(order);
+    }
+
+    // test case: Check the throw of RuntimeException when running the thread in
+    // the UnableToCheckStatusProcessor, while running a local order.
+    @Test
+    public void testRunProcessLocalOrderThrowsRuntimeException() throws InterruptedException, FogbowException {
+        // set up
+        Order order = createOrder();
+        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        this.unableToCheckStatus.addItem(order);
+
+        Mockito.doThrow(new RuntimeException()).when(this.processor).processUnableToCheckStatusOrder(order);
+
+        // exercise
+        this.thread = new Thread(this.processor);
+        this.thread.start();
+        Thread.sleep(DEFAULT_SLEEP_TIME);
+
+        // verify
+        Mockito.verify(this.processor, Mockito.times(1)).processUnableToCheckStatusOrder(order);
+    }
+
+    // test case: When invoking the processUnableToCheckStatusOrder method with an
+    // instance that failed after a successful request, it must change the order
+    // state to FAILED_AFTER_SUCCESSFUL_REQUEST.
+    @Test
+    public void testProcessUnableToCheckStatusOrderChangeStateToFailed() throws FogbowException {
+        // set up
+        Order order = createOrder();
+        order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
+        this.unableToCheckStatus.addItem(order);
+
+        ComputeInstance computeInstance = Mockito.mock(ComputeInstance.class);
+        Mockito.when(computeInstance.hasFailed()).thenReturn(true);
+
+        LocalCloudConnector localCloudConnector = Mockito.mock(LocalCloudConnector.class);
+        mockCloudConnectorFactory(localCloudConnector);
+        Mockito.doReturn(computeInstance).when(localCloudConnector).getInstance(Mockito.any(Order.class));
+
+        // exercise
+        this.processor.processUnableToCheckStatusOrder(order);
+
+        // verify
+        Assert.assertEquals(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST, order.getOrderState());
+    }
+
+    // test case: When invoking the processUnableToCheckStatusOrder method and an
+    // error occurs while trying to get an instance from the cloud provider, an
+    // UnavailableProviderException will be throw.
+    @Test(expected = UnavailableProviderException.class) // Verify
+    public void testProcessUnableToCheckStatusOrderThrowsUnavailableProviderException() throws FogbowException {
+        // set up
+        Order order = createOrder();
+        order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
+        this.unableToCheckStatus.addItem(order);
+
+        LocalCloudConnector localCloudConnector = Mockito.mock(LocalCloudConnector.class);
+        mockCloudConnectorFactory(localCloudConnector);
+        Mockito.doThrow(new UnavailableProviderException()).when(localCloudConnector)
+                .getInstance(Mockito.any(Order.class));
+
+        // exercise
+        this.processor.processUnableToCheckStatusOrder(order);
+    }
+
+    // test case: When calling the processUnableToCheckStatusOrder method and the
+    // order instance is not found, it must change the order state to
+    // FAILED_AFTER_SUCCESSFUL_REQUEST.
+    @Test
+    public void testProcessUnableToCheckStatusOrderWithInstanceNotFound() throws FogbowException {
+        // set up
+        Order order = createOrder();
+        order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
+        this.unableToCheckStatus.addItem(order);
+
+        LocalCloudConnector localCloudConnector = Mockito.mock(LocalCloudConnector.class);
+        mockCloudConnectorFactory(localCloudConnector);
+        Mockito.doThrow(new InstanceNotFoundException()).when(localCloudConnector)
+                .getInstance(Mockito.any(Order.class));
+
+        // exercise
+        this.processor.processUnableToCheckStatusOrder(order);
+
+        // verify
+        Assert.assertEquals(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST, order.getOrderState());
+    }
+
+    // test case: When calling the processUnableToCheckStatusOrder method with a
+    // remote member ID, the order state should not be changed.
+    @Test
+    public void testProcessUnableToCheckStatusOrderWithARemoteMember() throws FogbowException {
+        // set up
+        Order order = createOrder();
+        order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
+        this.unableToCheckStatus.addItem(order);
+
+        this.processor = Mockito.spy(new UnableToCheckStatusProcessor(FAKE_REMOTE_MEMBER_ID,
+                ConfigurationPropertyDefaults.FAILED_ORDERS_SLEEP_TIME));
+
+        // exercise
+        this.processor.processUnableToCheckStatusOrder(order);
+
+        // verify
+        Assert.assertEquals(OrderState.UNABLE_TO_CHECK_STATUS, order.getOrderState());
+    }
+
+    private void mockCloudConnectorFactory(LocalCloudConnector localCloudConnector) {
+        CloudConnectorFactory cloudConnectorFactory = Mockito.mock(CloudConnectorFactory.class);
+
+        PowerMockito.mockStatic(CloudConnectorFactory.class);
+        BDDMockito.given(CloudConnectorFactory.getInstance()).willReturn(cloudConnectorFactory);
+
+        Mockito.when(cloudConnectorFactory.getCloudConnector(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(localCloudConnector);
+    }
+
+    private Order createOrder() {
+        SystemUser systemUser = new SystemUser(FAKE_USER_ID, FAKE_USER_NAME, FAKE_TOKEN_PROVIDER);
+        String localMemberId = PropertiesHolder.getInstance()
+                .getProperty(ConfigurationPropertyKeys.LOCAL_PROVIDER_ID_KEY);
+
+        String requestingMember = localMemberId;
+        String providingMember = localMemberId;
+        ArrayList<UserData> userData = super.mockUserData();
+        List<String> networkIds = null;
+
+        Order order = new ComputeOrder(systemUser, requestingMember, providingMember, 
+                CLOUD_NAME, FAKE_INSTANCE_NAME, CPU_VALUE, MEMORY_VALUE, DISK_VALUE, 
+                FAKE_IMAGE_NAME, userData, FAKE_PUBLIC_KEY, networkIds);
+
+        return order;
+    }
 }

--- a/src/test/java/cloud/fogbow/ras/core/processors/UnableToCheckStatusProcessorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/processors/UnableToCheckStatusProcessorTest.java
@@ -59,11 +59,11 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
     // remote member ID, the processUnableToCheckStatusOrder method must not change
     // its state, remaining in the failed list.
     @Test
-    public void testRunProcessLocalOrderWithRemoteMember() throws InterruptedException {
+    public void testRunProcessLocalOrderWithRemoteMember() throws Exception {
         // set up
         Order order = createRemoteOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        order.setOrderState(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
         this.unableToCheckStatus.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
@@ -88,7 +88,7 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FULFILLED);
+        order.setOrderState(OrderState.FULFILLED);
         this.fulfilledOrderList.addItem(order);
         Assert.assertNull(this.unableToCheckStatus.getNext());
 
@@ -105,11 +105,11 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
     // processUnableToCheckStatusOrder method should not change its state and it
     // must remain in the list of failures.
     @Test
-    public void testRunProcessLocalOrderWithInstanceFailed() throws FogbowException, InterruptedException {
+    public void testRunProcessLocalOrderWithInstanceFailed() throws Exception {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        order.setOrderState(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
         this.unableToCheckStatus.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
@@ -134,11 +134,11 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
     // order must be removed from the unableToCheckStatus list and put in the
     // fulfilled list.
     @Test
-    public void testRunProcessLocalOrderWithInstanceReady() throws InterruptedException, FogbowException {
+    public void testRunProcessLocalOrderWithInstanceReady() throws Exception {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
+        order.setOrderState(OrderState.UNABLE_TO_CHECK_STATUS);
         this.unableToCheckStatus.addItem(order);
         Assert.assertNull(this.fulfilledOrderList.getNext());
 
@@ -167,7 +167,7 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        order.setOrderState(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
         this.unableToCheckStatus.addItem(order);
 
         Mockito.doThrow(new RuntimeException()).when(this.cloudConnector).getInstance(Mockito.any(Order.class));
@@ -184,11 +184,11 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
     // test case: Check the throw of UnexpectedException when running the thread in
     // the UnableToCheckStatusProcessor, while running a local order.
     @Test
-    public void testRunProcessLocalOrderThrowsUnexpectedException() throws InterruptedException, FogbowException {
+    public void testRunProcessLocalOrderThrowsUnexpectedException() throws Exception {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        order.setOrderState(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
         this.unableToCheckStatus.addItem(order);
 
         Mockito.doThrow(new UnexpectedException()).when(this.processor).processUnableToCheckStatusOrder(order);
@@ -205,11 +205,11 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
     // test case: Check the throw of RuntimeException when running the thread in
     // the UnableToCheckStatusProcessor, while running a local order.
     @Test
-    public void testRunProcessLocalOrderThrowsRuntimeException() throws InterruptedException, FogbowException {
+    public void testRunProcessLocalOrderThrowsRuntimeException() throws Exception {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
+        order.setOrderState(OrderState.FAILED_AFTER_SUCCESSFUL_REQUEST);
         this.unableToCheckStatus.addItem(order);
 
         Mockito.doThrow(new RuntimeException()).when(this.processor).processUnableToCheckStatusOrder(order);
@@ -231,7 +231,7 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
+        order.setOrderState(OrderState.UNABLE_TO_CHECK_STATUS);
         this.unableToCheckStatus.addItem(order);
         
         OrderInstance orderInstance = new ComputeInstance(BaseUnitTests.FAKE_INSTANCE_ID);
@@ -254,7 +254,7 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
+        order.setOrderState(OrderState.UNABLE_TO_CHECK_STATUS);
         this.unableToCheckStatus.addItem(order);
 
         Mockito.doThrow(new UnavailableProviderException()).when(this.cloudConnector)
@@ -272,7 +272,7 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
+        order.setOrderState(OrderState.UNABLE_TO_CHECK_STATUS);
         this.unableToCheckStatus.addItem(order);
 
         Mockito.doThrow(new InstanceNotFoundException()).when(this.cloudConnector)
@@ -292,7 +292,7 @@ public class UnableToCheckStatusProcessorTest extends BaseUnitTests {
         // set up
         Order order = createLocalOrder(getLocalMemberId());
         order.setInstanceId(BaseUnitTests.FAKE_INSTANCE_ID);
-        order.setOrderStateInTestMode(OrderState.UNABLE_TO_CHECK_STATUS);
+        order.setOrderState(OrderState.UNABLE_TO_CHECK_STATUS);
         this.unableToCheckStatus.addItem(order);
 
         this.processor = Mockito.spy(new UnableToCheckStatusProcessor(BaseUnitTests.FAKE_REMOTE_MEMBER_ID,


### PR DESCRIPTION
- Added more tests increased coverage of processor classes;
- Merge the 'order-controller-cover-test' branch into it;
- Changes made to the BaseUnitTests class and fixes made in the OrderControllerTest class and test classes of processors package.