### PR TITLE
Refactoring ONe compute plugin

### DIFF
--- a/bin/one-startup-script.sh
+++ b/bin/one-startup-script.sh
@@ -1,0 +1,5 @@
+sudo adduser test --no-create-home --disabled-password --gecos ""
+sudo echo "oneuser:oneb" | chpasswd
+interface=$(ip l | grep -i down | awk '{print $2}' | sed 's/://')
+sudo dhclient ${interface}
+sudo ifconfig ${interface} up

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/OpenNebulaClientUtil.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/OpenNebulaClientUtil.java
@@ -6,6 +6,7 @@ import org.opennebula.client.ClientConfigurationException;
 import org.opennebula.client.OneResponse;
 import org.opennebula.client.Pool;
 import org.opennebula.client.PoolElement;
+import org.opennebula.client.datastore.DatastorePool;
 import org.opennebula.client.group.Group;
 import org.opennebula.client.group.GroupPool;
 import org.opennebula.client.image.Image;
@@ -35,12 +36,19 @@ public class OpenNebulaClientUtil {
 	protected static final String RESPONSE_DONE = "DONE";
 	protected static final String RESPONSE_NOT_ENOUGH_FREE_MEMORY = "Not enough free memory";
 	protected static final String RESPONSE_NO_SPACE_LEFT_ON_DEVICE = "No space left on device";
+
+	public static Client instance;
 	
 	private static final int CHMOD_PERMISSION_744 = 744;
 	
 	public static Client createClient(String endpoint, String tokenValue) throws UnexpectedException {
 		try {
-			return new Client(tokenValue, endpoint);
+			synchronized (Client.class) {
+				if (instance == null) {
+					instance = new Client(tokenValue, endpoint);
+				}
+				return instance;
+			}
 		} catch (ClientConfigurationException e) {
 			LOGGER.error(Messages.Error.ERROR_WHILE_CREATING_CLIENT, e);
 			throw new UnexpectedException();
@@ -87,10 +95,21 @@ public class OpenNebulaClientUtil {
 			LOGGER.error(String.format(Messages.Error.ERROR_WHILE_GETTING_TEMPLATES, response.getErrorMessage()));
 			throw new UnexpectedException(response.getErrorMessage());
 		}
-		LOGGER.info(String.format(Messages.Info.TEMPLATE_POOL_LENGTH, imagePool.getLength()));
 		return imagePool;
 	}
-	
+
+	public static DatastorePool getDatastorePool(Client client) throws UnexpectedException {
+		DatastorePool datastorePool = (DatastorePool) generateOnePool(client, DatastorePool.class);
+		OneResponse response = datastorePool.info();
+
+		if (response.isError()) {
+			LOGGER.error(String.format(Messages.Error.ERROR_WHILE_GETTING_TEMPLATES, response.getErrorMessage()));
+			throw new UnexpectedException(response.getErrorMessage());
+		}
+
+		return datastorePool;
+	}
+
 	public static VirtualMachine getVirtualMachine(Client client, String virtualMachineId)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
 
@@ -137,7 +156,6 @@ public class OpenNebulaClientUtil {
 			LOGGER.error(String.format(Messages.Error.ERROR_WHILE_GETTING_TEMPLATES, response.getErrorMessage()));
 			throw new UnexpectedException(response.getErrorMessage());
 		}
-		LOGGER.info(String.format(Messages.Info.TEMPLATE_POOL_LENGTH, templatePool.getLength()));
 		return templatePool;
 	}
 
@@ -148,7 +166,6 @@ public class OpenNebulaClientUtil {
  			LOGGER.error(String.format(Messages.Error.ERROR_WHILE_GETTING_USERS, response.getErrorMessage()));
 			throw new UnexpectedException(response.getErrorMessage());
  		}
- 		LOGGER.info(String.format(Messages.Info.USER_POOL_LENGTH, userpool.getLength()));
 		return userpool;
 	}
 
@@ -307,8 +324,10 @@ public class OpenNebulaClientUtil {
             return new ImagePool(client);
         } else if (classType.isAssignableFrom(UserPool.class)) {
 		    return new UserPool(client);
-        }
+        } else if (classType.isAssignableFrom(DatastorePool.class)) {
+			return new DatastorePool(client);
+		}
+
 		return null;
 	}
-	
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/OpenNebulaLaunchCommandGenerator.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/OpenNebulaLaunchCommandGenerator.java
@@ -19,6 +19,7 @@ public class OpenNebulaLaunchCommandGenerator implements LaunchCommandGenerator 
     private static final Logger LOGGER = Logger.getLogger(OpenNebulaLaunchCommandGenerator.class);
 
     private final String ONE_STARTUP_SCRIPT_FILE_PATH = "bin/one-startup-script.sh";
+    private final String SCRIPT_FILE_DELIMETER = "\\A";
 
     public OpenNebulaLaunchCommandGenerator() { }
 
@@ -30,7 +31,7 @@ public class OpenNebulaLaunchCommandGenerator implements LaunchCommandGenerator 
 
         try {
             scanner = new Scanner(new File(ONE_STARTUP_SCRIPT_FILE_PATH));
-            userDataBuilder.append(scanner.useDelimiter("\\A").next());
+            userDataBuilder.append(scanner.useDelimiter(SCRIPT_FILE_DELIMETER).next());
         } catch (IOException e) {
             throw new FatalErrorException(e.getMessage());
         } finally {
@@ -42,10 +43,10 @@ public class OpenNebulaLaunchCommandGenerator implements LaunchCommandGenerator 
                 if (userDataScript != null) {
                     String normalizedExtraUserData = null;
                     String extraUserDataFileContent = userDataScript.getExtraUserDataFileContent();
-                    // NOTE(pauloewerton): since only one script can be added to the request, we're appending only
-                    // the bash scripts to the default script in order to prevent errors
+                    // NOTE(pauloewerton): since ONe supports just one script for a single file type at VM creation,
+                    // we're appending only the bash scripts to the default script in order to prevent errors
                     if (extraUserDataFileContent != null &&
-                            userDataScript.getExtraUserDataFileType() == CloudInitUserDataBuilder.FileType.SHELL_SCRIPT) {
+                            userDataScript.getExtraUserDataFileType().equals(CloudInitUserDataBuilder.FileType.SHELL_SCRIPT)) {
                         normalizedExtraUserData = new String(Base64.decodeBase64(extraUserDataFileContent));
                         userDataBuilder.append("\n");
                         userDataBuilder.append(normalizedExtraUserData);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/OpenNebulaLaunchCommandGenerator.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/OpenNebulaLaunchCommandGenerator.java
@@ -1,0 +1,64 @@
+package cloud.fogbow.ras.core.plugins.interoperability.opennebula;
+
+import cloud.fogbow.common.exceptions.FatalErrorException;
+import cloud.fogbow.common.util.CloudInitUserDataBuilder;
+import cloud.fogbow.ras.constants.Messages;
+import cloud.fogbow.ras.core.models.UserData;
+import cloud.fogbow.ras.core.models.orders.ComputeOrder;
+import cloud.fogbow.ras.core.plugins.interoperability.util.LaunchCommandGenerator;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.log4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Scanner;
+
+public class OpenNebulaLaunchCommandGenerator implements LaunchCommandGenerator {
+    private static final Logger LOGGER = Logger.getLogger(OpenNebulaLaunchCommandGenerator.class);
+
+    private final String ONE_STARTUP_SCRIPT_FILE_PATH = "bin/one-startup-script.sh";
+
+    public OpenNebulaLaunchCommandGenerator() { }
+
+    @Override
+    public String createLaunchCommand(ComputeOrder order) {
+        List<UserData> userDataScripts = order.getUserData();
+        StringBuilder userDataBuilder = new StringBuilder();
+        Scanner scanner = null;
+
+        try {
+            scanner = new Scanner(new File(ONE_STARTUP_SCRIPT_FILE_PATH));
+            userDataBuilder.append(scanner.useDelimiter("\\A").next());
+        } catch (IOException e) {
+            throw new FatalErrorException(e.getMessage());
+        } finally {
+            scanner.close();
+        }
+
+        if (userDataScripts != null) {
+            for (UserData userDataScript : userDataScripts) {
+                if (userDataScript != null) {
+                    String normalizedExtraUserData = null;
+                    String extraUserDataFileContent = userDataScript.getExtraUserDataFileContent();
+                    // NOTE(pauloewerton): since only one script can be added to the request, we're appending only
+                    // the bash scripts to the default script in order to prevent errors
+                    if (extraUserDataFileContent != null &&
+                            userDataScript.getExtraUserDataFileType() == CloudInitUserDataBuilder.FileType.SHELL_SCRIPT) {
+                        normalizedExtraUserData = new String(Base64.decodeBase64(extraUserDataFileContent));
+                        userDataBuilder.append("\n");
+                        userDataBuilder.append(normalizedExtraUserData);
+                    } else {
+                        LOGGER.warn(Messages.Warn.UNABLE_TO_ADD_EXTRA_USER_DATA_FILE_CONTENT_NULL);
+                    }
+                }
+            }
+        }
+
+        String base64String = new String(Base64.encodeBase64(userDataBuilder.toString().getBytes(StandardCharsets.UTF_8),
+                false, false), StandardCharsets.UTF_8);
+
+        return base64String;
+    }
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/CreateComputeRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/CreateComputeRequest.java
@@ -16,6 +16,7 @@ public class CreateComputeRequest {
 	public CreateComputeRequest(Builder builder) {
 		String cpu = builder.cpu;
 		String memory = builder.memory;
+		String name = builder.name;
 		VirtualMachineTemplate.Context context = buildContext(builder);
 		VirtualMachineTemplate.Graphics graphics = buildGraphics(builder);
 		VirtualMachineTemplate.Disk disk = buildDisk(builder);
@@ -23,6 +24,7 @@ public class CreateComputeRequest {
 		VirtualMachineTemplate.OperationalSystem os = buildOs(builder);
 		
 		this.virtualMachine = new VirtualMachineTemplate();
+		this.virtualMachine.setName(name);
 		this.virtualMachine.setContext(context);
 		this.virtualMachine.setCpu(cpu);
 		this.virtualMachine.setGraphics(graphics);
@@ -34,10 +36,8 @@ public class CreateComputeRequest {
 
 	private Disk buildDisk(Builder builder) {
 		VirtualMachineTemplate.Disk disk = new VirtualMachineTemplate.Disk();
-		disk.setImageId(builder.diskImageId);
-		disk.setType(builder.diskType);
+		disk.setImageId(builder.imageId);
 		disk.setSize(builder.diskSize);
-		disk.setFormat(builder.diskFormat);
 		return disk;
 	}
 
@@ -66,34 +66,30 @@ public class CreateComputeRequest {
 
 	private VirtualMachineTemplate.Context buildContext(Builder builder) {
 		VirtualMachineTemplate.Context context = new VirtualMachineTemplate.Context();
-		context.setEncoding(builder.contextEncoding);
-		context.setUserdata(builder.contextUserdata);
+		context.setPublicKey(builder.publicKey);
+		context.setUserName(builder.userName);
+		context.setStartScriptBase64(builder.startScriptBase64);
 		context.setNetwork(builder.contextNetwork);
 		return context;
 	}
 
 	public static class Builder {
-		private String contextEncoding;
-		private String contextUserdata;
+		private String name;
 		private String contextNetwork;
 		private String cpu;
 		private String graphicsAddress;
 		private String graphicsType;
-		private String diskImageId;
-		private String diskType;
+		private String imageId;
 		private String diskSize;
-		private String diskFormat;
 		private String memory;
 		private List<String> networks;
+		private String publicKey;
+		private String userName;
+		private String startScriptBase64;
 		private String architecture;
-		
-		public Builder contextEncoding(String contextEncoding) {
-			this.contextEncoding = contextEncoding;
-			return this;
-		}
 
-		public Builder contextUserdata(String contextUserdata) {
-			this.contextUserdata = contextUserdata;
+		public Builder name(String name) {
+			this.name = name;
 			return this;
 		}
 
@@ -117,13 +113,8 @@ public class CreateComputeRequest {
 			return this;
 		}
 
-		public Builder diskImageId(String diskImageId) {
-			this.diskImageId = diskImageId;
-			return this;
-		}
-		
-		public Builder diskType(String diskType) {
-			this.diskType = diskType;
+		public Builder imageId(String imageId) {
+			this.imageId = imageId;
 			return this;
 		}
 		
@@ -132,11 +123,6 @@ public class CreateComputeRequest {
 			return this;
 		}
 		
-		public Builder diskFormat(String diskFormat) {
-			this.diskFormat = diskFormat;
-			return this;
-		}
-
 		public Builder memory(String memory) {
 			this.memory = memory;
 			return this;
@@ -146,7 +132,22 @@ public class CreateComputeRequest {
 			this.networks = networks;
 			return this;
 		}
-		
+
+		public Builder publicKey(String publicKey) {
+			this.publicKey = publicKey;
+			return this;
+		}
+
+		public Builder userName(String userName) {
+			this.userName = userName;
+			return this;
+		}
+
+		public Builder startScriptBase64(String startScriptBase64) {
+			this.startScriptBase64 = startScriptBase64;
+			return this;
+		}
+
 		public Builder architecture(String architecture) {
 			this.architecture = architecture;
 			return this;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/CreateComputeRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/CreateComputeRequest.java
@@ -5,6 +5,22 @@ import java.util.List;
 
 import cloud.fogbow.ras.core.plugins.interoperability.opennebula.compute.v5_4.VirtualMachineTemplate.Disk;
 
+/**
+ * http://docs.opennebula.org/5.4/operation/references/template.html#template
+ *
+ * <TEMPLATE>
+ *   <NAME>test_vm</NAME>
+ *   <CPU>2</CPU>
+ *   <MEMORY>1024</MEMORY>
+ *   <DISK>
+ *     <IMAGE_ID>2</IMAGE_ID>
+ *   </DISK>
+ *   <DISK>
+ *     <IMAGE>Data</IMAGE>
+ *     <IMAGE_UNAME>oneadmin</IMAGE_UNAME>
+ *   </DISK>
+ * </TEMPLATE>
+ */
 public class CreateComputeRequest {
 
 	private VirtualMachineTemplate virtualMachine;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/OpenNebulaComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/OpenNebulaComputePlugin.java
@@ -12,7 +12,6 @@ import cloud.fogbow.ras.core.PropertiesHolder;
 import cloud.fogbow.ras.core.plugins.interoperability.opennebula.*;
 import org.apache.log4j.Logger;
 import org.opennebula.client.Client;
-import org.opennebula.client.ClientConfigurationException;
 import org.opennebula.client.OneResponse;
 import org.opennebula.client.image.Image;
 import org.opennebula.client.image.ImagePool;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/VirtualMachineTemplate.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/VirtualMachineTemplate.java
@@ -13,12 +13,22 @@ import static cloud.fogbow.common.constants.OpenNebulaConstants.*;
 public class VirtualMachineTemplate extends OpenNebulaMarshallerTemplate {
 
 	private VirtualMachineTemplate.Context context;
+	private String name;
 	private String cpu;
 	private VirtualMachineTemplate.Graphics graphics;
 	private VirtualMachineTemplate.Disk disk;
 	private String memory;
 	private List<VirtualMachineTemplate.Nic> nic;
 	private VirtualMachineTemplate.OperationalSystem os;
+
+	@XmlElement(name = NAME)
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
 
 	@XmlElement(name = CONTEXT)
 	public VirtualMachineTemplate.Context getContext() {
@@ -85,29 +95,43 @@ public class VirtualMachineTemplate extends OpenNebulaMarshallerTemplate {
 
 	@XmlRootElement(name = CONTEXT)
 	public static class Context {
-
-		private String encoding;
-		private String userdata;
 		private String network;
-		
-		@XmlElement(name = USERDATA_ENCODING)
-		public String getEncoding() {
-			return encoding;
+		private String publicKey;
+		private String userName;
+		private String startScriptBase64;
+
+		// TODO(pauloewerton): move constants below to common?
+		private static final String SSH_PUBLIC_KEY = "SSH_PUBLIC_KEY";
+		private static final String USERNAME = "USERNAME";
+		private static final String START_SCRIPT_BASE64 = "START_SCRIPT_BASE64";
+
+		@XmlElement(name = SSH_PUBLIC_KEY)
+		public String getPublicKey() {
+			return publicKey;
 		}
-		
-		public void setEncoding(String encoding) {
-			this.encoding = encoding;
+
+		public void setPublicKey(String publicKey) {
+			this.publicKey = publicKey;
 		}
-		
-		@XmlElement(name = USERDATA)
-		public String getUserdata() {
-			return userdata;
+
+		@XmlElement(name = USERNAME)
+		public String getUserName() {
+			return userName;
 		}
-		
-		public void setUserdata(String userdata) {
-			this.userdata = userdata;
+
+		public void setUserName(String userName) {
+			this.userName = userName;
 		}
-		
+
+		@XmlElement(name = START_SCRIPT_BASE64)
+		public String getStartScriptBase64() {
+			return startScriptBase64;
+		}
+
+		public void setStartScriptBase64(String startScriptBase64) {
+			this.startScriptBase64 = startScriptBase64;
+		}
+
 		@XmlElement(name = NETWORK)
 		public String getNetwork() {
 			return network;
@@ -142,14 +166,11 @@ public class VirtualMachineTemplate extends OpenNebulaMarshallerTemplate {
 			this.type = type;
 		}
 	}
-	
+
 	@XmlRootElement(name = DISK)
 	public static class Disk {
-
 		private String imageId;
-		private String type;
 		private String size;
-		private String format;
 
 		@XmlElement(name = IMAGE_ID)
 		public String getImageId() {
@@ -159,15 +180,6 @@ public class VirtualMachineTemplate extends OpenNebulaMarshallerTemplate {
 		public void setImageId(String imageId) {
 			this.imageId = imageId;
 		}
-		
-		@XmlElement(name = TYPE)
-		public String getType() {
-			return type;
-		}
-
-		public void setType(String type) {
-			this.type = type;
-		}
 
 		@XmlElement(name = SIZE)
 		public String getSize() {
@@ -177,42 +189,8 @@ public class VirtualMachineTemplate extends OpenNebulaMarshallerTemplate {
 		public void setSize(String size) {
 			this.size = size;
 		}
-
-		@XmlElement(name = FORMAT)
-		public String getFormat() {
-			return format;
-		}
-
-		public void setFormat(String format) {
-			this.format = format;
-		}
 	}
-	
-	@XmlRootElement(name = DISK)
-	public static class VolumeDisk {
 
-		private String size;
-		private String type;
-		
-		@XmlElement(name = SIZE)
-		public String getSize() {
-			return size;
-		}
-		
-		public void setSize(String size) {
-			this.size = size;
-		}
-		
-		@XmlElement(name = TYPE)
-		public String getType() {
-			return type;
-		}
-		
-		public void setType(String type) {
-			this.type = type;
-		}
-	}
-	
 	@XmlRootElement(name = NETWORK_INTERFACE_CONNECTED)
 	public static class Nic {
 


### PR DESCRIPTION
This change adds:

- Datastore is chosen by listing available options in order to avoid having to put a datastore id in cloud.conf;
- Userdata is created using an ONe-compatible launch command generator and put on the right request parameter;
- Public key is put on the right request parameter;
- Disk size conversions, since ONe handles sizes in megabytes not gigabytes as expected by Fogbow.