### PR TITLE
ONe image plugin tests refactor

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePlugin.java
@@ -10,7 +10,6 @@ import org.opennebula.client.image.ImagePool;
 
 import cloud.fogbow.common.exceptions.FatalErrorException;
 import cloud.fogbow.common.exceptions.FogbowException;
-import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.models.CloudUser;
 import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.ras.api.http.response.InstanceState;
@@ -25,8 +24,6 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 
 	private static final Logger LOGGER = Logger.getLogger(OpenNebulaImagePlugin.class);
 
-	private static final String RESOURCE_NAME = "images";
-
 	protected static final String FORMAT_IMAGE_TYPE_PATH = "//IMAGE[%s]/TYPE";
 	protected static final String IMAGE_SIZE_PATH = "/IMAGE/SIZE";
 	protected static final String OPERATIONAL_SYSTEM_IMAGE_TYPE = "0";
@@ -40,7 +37,6 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 	
 	@Override
 	public List<ImageSummary> getAllImages(CloudUser cloudUser) throws FogbowException {
-		LOGGER.info(String.format(Messages.Info.RECEIVING_GET_ALL_REQUEST, RESOURCE_NAME));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 		ImagePool imagePool = OpenNebulaClientUtil.getImagePool(client);
 		return getImageSummaryList(imagePool);
@@ -48,7 +44,6 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 
 	@Override
 	public ImageInstance getImage(String imageId, CloudUser cloudUser) throws FogbowException {
-		LOGGER.info(String.format(Messages.Info.GETTING_INSTANCE, imageId, cloudUser.getToken()));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 		org.opennebula.client.image.Image image = OpenNebulaClientUtil.getImage(client, imageId);
 		return mount(image);
@@ -69,7 +64,7 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 		return images;
 	}
 	
-	protected ImageInstance mount(org.opennebula.client.image.Image image) throws InvalidParameterException {
+	protected ImageInstance mount(org.opennebula.client.image.Image image) {
 		String id = image.getId();
 		String name = image.getName();
 		String imageSize = image.xpath(IMAGE_SIZE_PATH);
@@ -82,13 +77,14 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 		return new ImageInstance(id, name, size, minDisk, minRam, status);
 	}
 	
-	protected int convertToInteger(String number) throws InvalidParameterException {
+	protected int convertToInteger(String number) {
+	    int size = 0;
 		try {
-			return Integer.parseInt(number);
+			size =  Integer.parseInt(number);
 		} catch (NumberFormatException e) {
 			LOGGER.error(String.format(Messages.Error.ERROR_WHILE_CONVERTING_TO_INTEGER), e);
-			throw new InvalidParameterException();
 		}
+		return size;
 	}
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/OpenNebulaBaseTests.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/OpenNebulaBaseTests.java
@@ -1,0 +1,52 @@
+package cloud.fogbow.ras.core.plugins.interoperability.opennebula;
+
+import cloud.fogbow.common.exceptions.*;
+import cloud.fogbow.common.models.CloudUser;
+import cloud.fogbow.common.util.HomeDir;
+import cloud.fogbow.ras.constants.SystemConstants;
+import cloud.fogbow.ras.core.BaseUnitTests;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.opennebula.client.Client;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+
+@Ignore
+@RunWith(PowerMockRunner.class)
+public class OpenNebulaBaseTests extends BaseUnitTests {
+
+    private static final String CLOUD_NAME = "opennebula";
+    private static final String FAKE_USER_NAME = "fake-user-name";
+    private static final String LOCAL_TOKEN_VALUE = "user:password";
+
+    protected String openNebulaConfFilePath;
+    protected CloudUser cloudUser;
+    protected Client client;
+
+    @Before
+    public void setUp() throws FogbowException {
+        this.testUtils.mockReadOrdersFromDataBase();
+        this.cloudUser = this.createCloudUser();
+        this.client = Mockito.mock(Client.class);
+
+        this.openNebulaConfFilePath = HomeDir.getPath() + SystemConstants.CLOUDS_CONFIGURATION_DIRECTORY_NAME
+                + File.separator + CLOUD_NAME + File.separator
+                + SystemConstants.CLOUD_SPECIFICITY_CONF_FILE_NAME;
+
+        PowerMockito.mockStatic(OpenNebulaClientUtil.class);
+        Mockito.when(OpenNebulaClientUtil.createClient(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(this.client);
+    }
+
+    private CloudUser createCloudUser() {
+        String userId = null;
+        String userName = FAKE_USER_NAME;
+        String tokenValue = LOCAL_TOKEN_VALUE;
+
+        return new CloudUser(userId, userName, tokenValue);
+    }
+}


### PR DESCRIPTION
This change refactors the ONe image plugin unit tests. A few modifications were added to the plugin code itself. To test this PR: check out code; set up a ONe cloud in your RAS; test image operations using a client; run image tests.