### PR TITLE
ONe Public IP plugin refactoring

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPuplicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPuplicIpPlugin.java
@@ -35,6 +35,8 @@ import cloud.fogbow.ras.core.plugins.interoperability.opennebula.network.v5_4.Cr
 import cloud.fogbow.ras.core.plugins.interoperability.opennebula.securityrule.v5_4.CreateSecurityGroupRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.opennebula.securityrule.v5_4.Rule;
 
+import javax.annotation.Nullable;
+
 public class OpenNebulaPuplicIpPlugin implements PublicIpPlugin<CloudUser> {
 
 	private static final Logger LOGGER = Logger.getLogger(OpenNebulaPuplicIpPlugin.class);
@@ -55,7 +57,7 @@ public class OpenNebulaPuplicIpPlugin implements PublicIpPlugin<CloudUser> {
 	protected static final String POWEROFF_STATE = "POWEROFF";
 	
 	protected static final long ONE_POINT_TWO_SECONDS = 1200;
-
+	protected static final boolean TERMINATE_HARD = true;
 
 	private String endpoint;
 	private String defaultPublicNetwork;
@@ -81,174 +83,82 @@ public class OpenNebulaPuplicIpPlugin implements PublicIpPlugin<CloudUser> {
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 
 		int defaultPublicNetworkId = convertToInteger(this.defaultPublicNetwork);
-		String name = SystemConstants.FOGBOW_INSTANCE_NAME_PREFIX + getRandomUUID();
 		int size = SIZE_ADDRESS_PUBLIC_IP;
+		String name = SystemConstants.FOGBOW_INSTANCE_NAME_PREFIX + getRandomUUID();
 
 		CreateNetworkReserveRequest reserveRequest = new CreateNetworkReserveRequest.Builder()
 				.name(name)
 				.size(size)
 				.build();
 
-		String publicNetworkReserveTemplate = reserveRequest.getVirtualNetworkReserved().marshalTemplate();
-		String publicIpInstanceId = OpenNebulaClientUtil.reserveVirtualNetwork(client, defaultPublicNetworkId,
-				publicNetworkReserveTemplate);
+		String publicIpInstanceId = this.doRequestInstance(client, defaultPublicNetworkId, reserveRequest);
+		String securityGroupInstanceId = this.createSecurityGroup(client, publicIpOrder);
 
-		String securityGroupInstanceId = createSecurityGroup(client, publicIpOrder);
-		CreateNetworkUpdateRequest updateSecurityGroupsRequest = new CreateNetworkUpdateRequest.Builder()
-				.securityGroups(securityGroupInstanceId)
-				.build();
+		this.addSecurityGroupToPublicIp(client, publicIpInstanceId, securityGroupInstanceId);
+		this.attachPublicIpToCompute(client, publicIpInstanceId, publicIpOrder.getComputeOrderId());
 
-		int virtualNetworkId = convertToInteger(publicIpInstanceId);
-		String publicNetworkUpdateTemplate = updateSecurityGroupsRequest.getVirtualNetworkUpdate().marshalTemplate();
-		OpenNebulaClientUtil.updateVirtualNetwork(client, virtualNetworkId, publicNetworkUpdateTemplate);
-		String computeInstanceId = publicIpOrder.getComputeId();
-
-		String template = createNicTemplate(publicIpInstanceId);
-		attachNetworkInterfaceConnected(client, computeInstanceId, template);
 		return publicIpInstanceId;
 	}
 
 	@Override
 	public void deleteInstance(PublicIpOrder publicIpOrder, CloudUser cloudUser) throws FogbowException {
-		String computeInstanceId = publicIpOrder.getComputeId();
-		String publicIpInstanceId = publicIpOrder.getInstanceId();
-		
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, computeInstanceId);
-		String nicId = virtualMachine.xpath(String.format(EXPRESSION_NIC_ID_FROM_NETWORK, publicIpInstanceId));
-
-		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, publicIpInstanceId);
-		String securityGroupId = null;
-		SecurityGroup securityGroup = this.getSecurityGroupForPublicIpNetwork(client, virtualNetwork, publicIpInstanceId);
-		if (securityGroup != null) securityGroupId = securityGroup.getId();
-		else throw new UnexpectedException();
+		String publicIpInstanceId = publicIpOrder.getInstanceId();
 
 		// NOTE(pauloewerton): ONe does not allow deleting a resource associated to a VM, so we're using a workaround
 		// by shutting down the VM, releasing network and secgroup resources, and then resuming it afterwards.
-		virtualMachine.poweroff(true);
+		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, publicIpOrder.getComputeId());
+		virtualMachine.poweroff(TERMINATE_HARD);
+
 		if (this.isPowerOff(virtualMachine)) {
-			detachNetworkInterfaceConnected(virtualMachine, nicId);
-			deleteSecurityGroup(client, securityGroupId);
-			deletePublicNetwork(client, publicIpInstanceId);
+			this.detachPublicIpFromCompute(virtualMachine, publicIpInstanceId);
+			this.deleteSecurityGroup(client, publicIpInstanceId);
+			this.doDeleteInstance(client, publicIpInstanceId);
 			virtualMachine.resume();
 		} else {
-			LOGGER.error(String.format(Messages.Error.ERROR_WHILE_REMOVING_RESOURCE, PUBLIC_IP_RESOURCE, publicIpInstanceId));
-			throw new UnexpectedException();
+			String message = String.format(Messages.Error.ERROR_WHILE_REMOVING_RESOURCE, PUBLIC_IP_RESOURCE, publicIpInstanceId);
+			throw new UnexpectedException(message);
 		}
 	}
 
 	@Override
 	public PublicIpInstance getInstance(PublicIpOrder publicIpOrder, CloudUser cloudUser) throws FogbowException {
-		String virtualMachineId = publicIpOrder.getComputeId();
+		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 		String publicIpInstanceId = publicIpOrder.getInstanceId();
 
-		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, virtualMachineId);
-		String publicIp = virtualMachine.xpath(String.format(EXPRESSION_IP_FROM_NETWORK, publicIpInstanceId));
+		String publicIp = this.doGetInstance(client, publicIpInstanceId, publicIpOrder.getComputeId());
 
-		LOGGER.info(String.format(Messages.Info.MOUNTING_INSTANCE, publicIpInstanceId));
-		PublicIpInstance publicIpInstance = new PublicIpInstance(publicIpInstanceId, OpenNebulaStateMapper.DEFAULT_READY_STATE, publicIp);
+		PublicIpInstance publicIpInstance = new PublicIpInstance(
+				publicIpInstanceId, OpenNebulaStateMapper.DEFAULT_READY_STATE, publicIp);
+
 		return publicIpInstance;
 	}
 
-	protected SecurityGroup getSecurityGroupForPublicIpNetwork(Client client, VirtualNetwork virtualNetwork, String orderId)
-			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
-		String securityGroupIdsStr = virtualNetwork.xpath(VNET_TEMPLATE_SECURITY_GROUPS_PATH);
-		if (securityGroupIdsStr == null || securityGroupIdsStr.isEmpty()) {
-			LOGGER.warn(Messages.Error.CONTENT_SECURITY_GROUP_NOT_DEFINED);
-			return null;
-		}
+	protected String doRequestInstance(Client client, int defaultPublicNetworkId, CreateNetworkReserveRequest reserveRequest)
+			throws InvalidParameterException {
 
-		String[] securityGroupIds =  securityGroupIdsStr.split(SECURITY_GROUP_SEPARATOR);
-		String securityGroupName = this.generateSecurityGroupName(orderId);
-		SecurityGroup securityGroup = null;
-		for (String securityGroupId : securityGroupIds) {
-			securityGroup = OpenNebulaClientUtil.getSecurityGroup(client, securityGroupId);
-			if (securityGroup.getName().equals(securityGroupName)) break;
-		}
-
-		return securityGroup;
+		String publicNetworkReserveTemplate = reserveRequest.getVirtualNetworkReserved().marshalTemplate();
+		return OpenNebulaClientUtil.reserveVirtualNetwork(client, defaultPublicNetworkId, publicNetworkReserveTemplate);
 	}
 
-	protected void deletePublicNetwork(Client client, String virtualNetworkId)
-			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
+	protected void doDeleteInstance(Client client, String virtualNetworkId)
+			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException, UnexpectedException {
 
 		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, virtualNetworkId);
 		OneResponse response = virtualNetwork.delete();
-		if (response.isError()) {
-			String message = response.getErrorMessage();
-			LOGGER.error(String.format(Messages.Error.ERROR_MESSAGE, message));
-		}
-	}
-	
-	protected void deleteSecurityGroup(Client client, String securityGroupId)
-			throws UnauthorizedRequestException, InvalidParameterException, InstanceNotFoundException {
 
-		SecurityGroup securityGroup = OpenNebulaClientUtil.getSecurityGroup(client, securityGroupId);
-		OneResponse response = securityGroup.delete();
 		if (response.isError()) {
-			String message = response.getErrorMessage();
-			LOGGER.error(String.format(Messages.Error.ERROR_MESSAGE, message));
+			throw new UnexpectedException(response.getErrorMessage());
 		}
 	}
 
-	protected void detachNetworkInterfaceConnected(VirtualMachine virtualMachine, String nicId)
-			throws InvalidParameterException {
-		
-		int id = convertToInteger(nicId);
-		OneResponse response = virtualMachine.nicDetach(id);
-		if (response.isError()) {
-			String message = response.getErrorMessage();
-			LOGGER.error(String.format(Messages.Error.ERROR_MESSAGE, message));
-		}
-	}
-	
-	protected boolean isPowerOff(VirtualMachine virtualMachine) {
-		String state;
-		int count = 0;
-		while (count < ATTEMPTS_LIMIT_NUMBER) {
-			count++;
-			waitMoment();
-			virtualMachine.info();
-			state = virtualMachine.stateStr();
-			if (state.equalsIgnoreCase(POWEROFF_STATE)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	protected void waitMoment() {
-		try {
-			Thread.sleep(ONE_POINT_TWO_SECONDS);
-		} catch (InterruptedException e) {
-			LOGGER.error(String.format(Messages.Error.ERROR_MESSAGE, e), e);
-		}
-	}
-	
-	protected void attachNetworkInterfaceConnected(Client client, String computeInstanceId, String template)
+	protected String doGetInstance(Client client, String publicIpInstanceId, String computeId)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
 
-		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, computeInstanceId);
-		OneResponse response = virtualMachine.nicAttach(template);
-		if (response.isError()) {
-			String message = response.getErrorMessage();
-			LOGGER.error(String.format(Messages.Error.ERROR_WHILE_CREATING_NIC, template));
-			LOGGER.error(String.format(Messages.Error.ERROR_MESSAGE, message));
-			throw new InvalidParameterException();
-		}
+		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, computeId);
+		return virtualMachine.xpath(String.format(EXPRESSION_IP_FROM_NETWORK, publicIpInstanceId));
 	}
-	
-	protected String createNicTemplate(String virtualNetworkId) {
-		String template;
-		CreateNicRequest request = new CreateNicRequest.Builder()
-				.networkId(virtualNetworkId)
-				.build();
 
-		template = request.getNic().marshalTemplate();
-		return template;
-	}
-	
 	protected String createSecurityGroup(Client client, PublicIpOrder publicIpOrder) throws InvalidParameterException {
 		String name = generateSecurityGroupName(publicIpOrder.getId());
 
@@ -283,6 +193,117 @@ public class OpenNebulaPuplicIpPlugin implements PublicIpPlugin<CloudUser> {
 
 		String template = request.getSecurityGroup().marshalTemplate();
 		return OpenNebulaClientUtil.allocateSecurityGroup(client, template);
+	}
+
+	protected void addSecurityGroupToPublicIp(Client client, String publicIpInstanceId, String securityGroupInstanceId)
+			throws InvalidParameterException {
+
+		CreateNetworkUpdateRequest updateSecurityGroupsRequest = new CreateNetworkUpdateRequest.Builder()
+				.securityGroups(securityGroupInstanceId)
+				.build();
+
+		int virtualNetworkId = this.convertToInteger(publicIpInstanceId);
+		String publicNetworkUpdateTemplate = updateSecurityGroupsRequest.getVirtualNetworkUpdate().marshalTemplate();
+
+		OpenNebulaClientUtil.updateVirtualNetwork(client, virtualNetworkId, publicNetworkUpdateTemplate);
+	}
+
+	protected void attachPublicIpToCompute(Client client, String publicIpId, String computeInstanceId)
+			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
+
+		String template = this.createNicTemplate(publicIpId);
+		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, computeInstanceId);
+		OneResponse response = virtualMachine.nicAttach(template);
+
+		if (response.isError()) {
+			String message = response.getErrorMessage();
+			LOGGER.error(String.format(Messages.Error.ERROR_WHILE_CREATING_NIC, template));
+			LOGGER.error(String.format(Messages.Error.ERROR_MESSAGE, message));
+			throw new InvalidParameterException();
+		}
+	}
+
+	protected String createNicTemplate(String virtualNetworkId) {
+		CreateNicRequest request = new CreateNicRequest.Builder()
+				.networkId(virtualNetworkId)
+				.build();
+
+		return request.getNic().marshalTemplate();
+	}
+
+	protected boolean isPowerOff(VirtualMachine virtualMachine) {
+		String state;
+		int count = 0;
+		while (count < ATTEMPTS_LIMIT_NUMBER) {
+			count++;
+			this.waitMoment();
+			virtualMachine.info();
+			state = virtualMachine.stateStr();
+			if (state.equalsIgnoreCase(POWEROFF_STATE)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	protected void waitMoment() {
+		try {
+			Thread.sleep(ONE_POINT_TWO_SECONDS);
+		} catch (InterruptedException e) {
+			LOGGER.error(String.format(Messages.Error.ERROR_MESSAGE, e), e);
+		}
+	}
+
+	protected void detachPublicIpFromCompute(VirtualMachine virtualMachine, String publicIpInstanceId)
+			throws InvalidParameterException {
+
+		String nicId = virtualMachine.xpath(String.format(EXPRESSION_NIC_ID_FROM_NETWORK, publicIpInstanceId));
+		int id = convertToInteger(nicId);
+
+		OneResponse response = virtualMachine.nicDetach(id);
+		if (response.isError()) {
+			String message = response.getErrorMessage();
+			LOGGER.error(String.format(Messages.Error.ERROR_MESSAGE, message));
+		}
+	}
+
+	protected void deleteSecurityGroup(Client client, String publicIpInstanceId)
+			throws UnauthorizedRequestException, InvalidParameterException, InstanceNotFoundException, UnexpectedException {
+		SecurityGroup securityGroup = this.getSecurityGroupForPublicIpNetwork(client, publicIpInstanceId);
+
+		if (securityGroup == null) {
+			throw new UnexpectedException();
+		}
+
+		OneResponse response = securityGroup.delete();
+		if (response.isError()) {
+			String message = response.getErrorMessage();
+			LOGGER.error(String.format(Messages.Error.ERROR_MESSAGE, message));
+		}
+	}
+
+	@Nullable
+	protected SecurityGroup getSecurityGroupForPublicIpNetwork(Client client, String publicIpInstanceId)
+			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
+
+		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, publicIpInstanceId);
+		String securityGroupIdsStr = virtualNetwork.xpath(VNET_TEMPLATE_SECURITY_GROUPS_PATH);
+
+		if (securityGroupIdsStr == null || securityGroupIdsStr.isEmpty()) {
+			LOGGER.warn(Messages.Error.CONTENT_SECURITY_GROUP_NOT_DEFINED);
+			return null;
+		}
+
+		String[] securityGroupIds =  securityGroupIdsStr.split(SECURITY_GROUP_SEPARATOR);
+		String securityGroupName = generateSecurityGroupName(publicIpInstanceId);
+		for (String securityGroupId : securityGroupIds) {
+			SecurityGroup securityGroup = OpenNebulaClientUtil.getSecurityGroup(client, securityGroupId);
+			if (securityGroup.getName().equals(securityGroupName)) {
+				return securityGroup;
+			}
+		}
+
+		return null;
 	}
 
 	private static String generateSecurityGroupName(String orderId) {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPuplicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPuplicIpPlugin.java
@@ -82,7 +82,6 @@ public class OpenNebulaPuplicIpPlugin implements PublicIpPlugin<CloudUser> {
 	public String requestInstance(PublicIpOrder publicIpOrder, CloudUser cloudUser) throws FogbowException {
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 
-		int defaultPublicNetworkId = convertToInteger(this.defaultPublicNetwork);
 		int size = SIZE_ADDRESS_PUBLIC_IP;
 		String name = SystemConstants.FOGBOW_INSTANCE_NAME_PREFIX + getRandomUUID();
 
@@ -91,34 +90,13 @@ public class OpenNebulaPuplicIpPlugin implements PublicIpPlugin<CloudUser> {
 				.size(size)
 				.build();
 
-		String publicIpInstanceId = this.doRequestInstance(client, defaultPublicNetworkId, reserveRequest);
-		String securityGroupInstanceId = this.createSecurityGroup(client, publicIpOrder);
-
-		this.addSecurityGroupToPublicIp(client, publicIpInstanceId, securityGroupInstanceId);
-		this.attachPublicIpToCompute(client, publicIpInstanceId, publicIpOrder.getComputeOrderId());
-
-		return publicIpInstanceId;
+		return this.doRequestInstance(client, publicIpOrder, reserveRequest);
 	}
 
 	@Override
 	public void deleteInstance(PublicIpOrder publicIpOrder, CloudUser cloudUser) throws FogbowException {
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-		String publicIpInstanceId = publicIpOrder.getInstanceId();
-
-		// NOTE(pauloewerton): ONe does not allow deleting a resource associated to a VM, so we're using a workaround
-		// by shutting down the VM, releasing network and secgroup resources, and then resuming it afterwards.
-		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, publicIpOrder.getComputeId());
-		virtualMachine.poweroff(TERMINATE_HARD);
-
-		if (this.isPowerOff(virtualMachine)) {
-			this.detachPublicIpFromCompute(virtualMachine, publicIpInstanceId);
-			this.deleteSecurityGroup(client, publicIpInstanceId);
-			this.doDeleteInstance(client, publicIpInstanceId);
-			virtualMachine.resume();
-		} else {
-			String message = String.format(Messages.Error.ERROR_WHILE_REMOVING_RESOURCE, PUBLIC_IP_RESOURCE, publicIpInstanceId);
-			throw new UnexpectedException(message);
-		}
+		this.doDeleteInstance(client, publicIpOrder);
 	}
 
 	@Override
@@ -126,22 +104,44 @@ public class OpenNebulaPuplicIpPlugin implements PublicIpPlugin<CloudUser> {
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 		String publicIpInstanceId = publicIpOrder.getInstanceId();
 
-		String publicIp = this.doGetInstance(client, publicIpInstanceId, publicIpOrder.getComputeId());
-
-		PublicIpInstance publicIpInstance = new PublicIpInstance(
-				publicIpInstanceId, OpenNebulaStateMapper.DEFAULT_READY_STATE, publicIp);
-
-		return publicIpInstance;
+		return this.doGetInstance(client, publicIpInstanceId, publicIpOrder.getComputeId());
 	}
 
-	protected String doRequestInstance(Client client, int defaultPublicNetworkId, CreateNetworkReserveRequest reserveRequest)
-			throws InvalidParameterException {
+	protected String doRequestInstance(Client client, PublicIpOrder publicIpOrder, CreateNetworkReserveRequest reserveRequest)
+			throws InvalidParameterException, InstanceNotFoundException, UnauthorizedRequestException {
 
+		int defaultPublicNetworkId = this.convertToInteger(this.defaultPublicNetwork);
 		String publicNetworkReserveTemplate = reserveRequest.getVirtualNetworkReserved().marshalTemplate();
-		return OpenNebulaClientUtil.reserveVirtualNetwork(client, defaultPublicNetworkId, publicNetworkReserveTemplate);
+		String instanceId = OpenNebulaClientUtil.reserveVirtualNetwork(client, defaultPublicNetworkId, publicNetworkReserveTemplate);
+
+		String securityGroupInstanceId = this.createSecurityGroup(client, publicIpOrder);
+
+		this.addSecurityGroupToPublicIp(client, instanceId, securityGroupInstanceId);
+		this.attachPublicIpToCompute(client, instanceId, publicIpOrder.getComputeOrderId());
+
+		return instanceId;
 	}
 
-	protected void doDeleteInstance(Client client, String virtualNetworkId)
+	protected void doDeleteInstance(Client client, PublicIpOrder order)
+			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException, UnexpectedException {
+		// NOTE(pauloewerton): ONe does not allow deleting a resource associated to a VM, so we're using a workaround
+		// by shutting down the VM, releasing network and secgroup resources, and then resuming it afterwards.
+		String publicIpInstanceId = order.getInstanceId();
+		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, order.getComputeId());
+		virtualMachine.poweroff(TERMINATE_HARD);
+
+		if (this.isPowerOff(virtualMachine)) {
+			this.detachPublicIpFromCompute(virtualMachine, publicIpInstanceId);
+			this.deleteSecurityGroup(client, publicIpInstanceId);
+			this.deletePublicIp(client, publicIpInstanceId);
+			virtualMachine.resume();
+		} else {
+			String message = String.format(Messages.Error.ERROR_WHILE_REMOVING_RESOURCE, PUBLIC_IP_RESOURCE, publicIpInstanceId);
+			throw new UnexpectedException(message);
+		}
+	}
+
+	protected void deletePublicIp(Client client, String virtualNetworkId)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException, UnexpectedException {
 
 		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, virtualNetworkId);
@@ -152,11 +152,13 @@ public class OpenNebulaPuplicIpPlugin implements PublicIpPlugin<CloudUser> {
 		}
 	}
 
-	protected String doGetInstance(Client client, String publicIpInstanceId, String computeId)
+	protected PublicIpInstance doGetInstance(Client client, String publicIpInstanceId, String computeId)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
 
 		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, computeId);
-		return virtualMachine.xpath(String.format(EXPRESSION_IP_FROM_NETWORK, publicIpInstanceId));
+		String publicIp =  virtualMachine.xpath(String.format(EXPRESSION_IP_FROM_NETWORK, publicIpInstanceId));
+
+		return new PublicIpInstance(publicIpInstanceId, OpenNebulaStateMapper.DEFAULT_READY_STATE, publicIp);
 	}
 
 	protected String createSecurityGroup(Client client, PublicIpOrder publicIpOrder) throws InvalidParameterException {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPublicIpPluginTest.java
@@ -376,7 +376,7 @@ public class OpenNebulaPublicIpPluginTest {
 		Mockito.when(response.isError()).thenReturn(true);
 
 		// exercise
-		this.plugin.doDeleteInstance(client, virtualNetworkId);
+		this.plugin.doDeleteInstance(client, this.publicIpOrder);
 
 		// verify
 		Mockito.verify(response, Mockito.times(1)).getErrorMessage();

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPublicIpPluginTest.java
@@ -376,7 +376,7 @@ public class OpenNebulaPublicIpPluginTest {
 		Mockito.when(response.isError()).thenReturn(true);
 
 		// exercise
-		this.plugin.deletePublicNetwork(client, virtualNetworkId);
+		this.plugin.doDeleteInstance(client, virtualNetworkId);
 
 		// verify
 		Mockito.verify(response, Mockito.times(1)).getErrorMessage();
@@ -423,7 +423,7 @@ public class OpenNebulaPublicIpPluginTest {
 		String nicId = STRING_ID_ONE;
 
 		// exercise
-		this.plugin.detachNetworkInterfaceConnected(virtualMachine, nicId);
+		this.plugin.detachPublicIpFromCompute(virtualMachine, nicId);
 
 		// verify
 		Mockito.verify(response, Mockito.times(1)).getErrorMessage();
@@ -485,7 +485,7 @@ public class OpenNebulaPublicIpPluginTest {
 		Mockito.when(response.isError()).thenReturn(true);
 
 		// exercise
-		this.plugin.attachNetworkInterfaceConnected(client, computeInstanceId, template);
+		this.plugin.attachPublicIpToCompute(client, computeInstanceId, template);
 	}
 	
 	// test case: When calling the createSecurityGroup method with a valid client


### PR DESCRIPTION
this change refactors the ONe public ip plugin in advance of its unit tests refactoring. to test: check out code; set up an ONe cloud in your RAS env; test public ip operations via a client.