### PR TITLE
Cloudstack securityrule test refactor pr one

### DIFF
--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -42,7 +42,7 @@ import java.util.*;
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore({"javax.net.ssl.*", "javax.crypto.*" })
 @PrepareForTest({SharedOrderHolders.class, DatabaseManager.class, CloudStackUrlUtil.class, CloudStackHttpClient.class, CloudStackQueryJobResult.class, CloudStackSecurityRulePlugin.class})
-public class CloudStackSecurityRuleInstancePluginTest extends BaseUnitTests {
+public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
 
     private static String FAKE_JOB_ID = "fake-job-id";
     private static String FAKE_SECURITY_RULE_ID = "fake-rule-id";
@@ -396,7 +396,7 @@ public class CloudStackSecurityRuleInstancePluginTest extends BaseUnitTests {
             public void run() {
                 String processingJobResponse = getProcessingJobResponse(status);
                 try {
-                    BDDMockito.given(CloudStackSecurityRuleInstancePluginTest.this.queryJobResult.getQueryJobResult(
+                    BDDMockito.given(CloudStackSecurityRulePluginTest.this.queryJobResult.getQueryJobResult(
                             Mockito.any(CloudStackHttpClient.class), Mockito.anyString(), Mockito.anyString(), Mockito.any(CloudStackUser.class))).
                             willReturn(processingJobResponse);
                 } catch (FogbowException e) {


### PR DESCRIPTION
# Description
Refactoring the Cloudstack Security Rules Plugin context. 

# Proposed changes
- Refactoring in the Cloudstack Security Rules Plugin

# Additional information
- This branch depends on a branch in the Fogbow Common (cloudstack-securityrules-test-refator)
Note: Maybe happen compiling error at PRs before PR5 in regards to Common Project because there were some changes in the PR5.

# PR Slices
[x] One: Refactoring in the Cloudstack Security Rules Plugin
[] Two: Migrating Cloudstack asynchronous operation to the Cloudstack  Utils
[] Three: Refactoring "request Instance" tests context.
[] Four: Refactoring "get Instance" tests context.
[] Five: Refactoring "delete instance" tests context.

# Reminding
- PRs order: 
develop < PR1 < PR2 < PR3 < PR4 < PR5