### PR TITLE
Cloudstack securityrule test refactor pr two

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -79,7 +79,7 @@ public class CloudStackCloudUtils {
         try {
             Thread.sleep(getTimeSleepThread());
         } catch (InterruptedException e) {
-            LOGGER.warn("", e);
+            LOGGER.warn("Waiting interrupeted", e);
         }
     }
 
@@ -88,8 +88,9 @@ public class CloudStackCloudUtils {
         return ONE_SECOND_IN_MILIS;
     }
 
-    public static String processJobResult(@NotNull CloudStackQueryAsyncJobResponse response,
-                                          String jobId)
+    @VisibleForTesting
+    static String processJobResult(@NotNull CloudStackQueryAsyncJobResponse response,
+                                   String jobId)
             throws FogbowException {
 
         switch (response.getJobStatus()){

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -25,7 +25,6 @@ public class CloudStackCloudUtils {
     public static final int JOB_STATUS_COMPLETE = 1;
     public static final int JOB_STATUS_PENDING = 0;
     public static final int JOB_STATUS_FAILURE = 2;
-    public static final int JOB_STATUS_INCONSISTENT = 3;
     public static final String PENDING_STATE = "pending";
     public static final String FAILURE_STATE = "failure";
 
@@ -51,7 +50,8 @@ public class CloudStackCloudUtils {
     }
 
     /**
-     * Wait and process the Cloudstack async response in its life cycle.
+     * Wait and process the Cloudstack asynchronous response in its asynchronous life cycle.
+     * @throws FogbowException
      */
     public static String waitForResult(@NotNull CloudStackHttpClient client,
                                        String cloudStackUrl,
@@ -66,26 +66,12 @@ public class CloudStackCloudUtils {
             if (countTries >= MAX_TRIES) {
                 throw new TimeoutCloudstackAsync(String.format(Messages.Exception.JOB_TIMEOUT, jobId));
             }
+            sleepThread();
             response = getAsyncJobResponse(client, cloudStackUrl, jobId, cloudStackUser);
             countTries++;
-            sleepThread();
         }
 
         return processJobResult(response, jobId);
-    }
-
-    @VisibleForTesting
-    static void sleepThread() {
-        try {
-            Thread.sleep(getTimeSleepThread());
-        } catch (InterruptedException e) {
-            LOGGER.warn("Waiting interrupeted", e);
-        }
-    }
-
-    @VisibleForTesting
-    static long getTimeSleepThread() {
-        return ONE_SECOND_IN_MILIS;
     }
 
     @VisibleForTesting
@@ -115,10 +101,25 @@ public class CloudStackCloudUtils {
         return CloudStackQueryAsyncJobResponse.fromJson(jsonResponse);
     }
 
+    @VisibleForTesting
+    protected static long getTimeSleepThread() {
+        return ONE_SECOND_IN_MILIS;
+    }
+
+    private static void sleepThread() {
+        try {
+            Thread.sleep(getTimeSleepThread());
+        } catch (InterruptedException e) {
+            LOGGER.warn("Thread waiting was interrupeted", e);
+        }
+    }
+
     public static class TimeoutCloudstackAsync extends FogbowException {
-        public TimeoutCloudstackAsync(String message) {
+
+        private TimeoutCloudstackAsync(String message) {
             super(message);
         }
+
     }
 
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -142,8 +142,8 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
                 return CloudStackCloudUtils.waitForResult(
                         this.client, this.cloudStackUrl, response.getJobId(), cloudStackUser);
             } catch (CloudStackCloudUtils.TimeoutCloudstackAsync e) {
-                CloudStackQueryAsyncJobResponse asyncJobResponse = CloudStackCloudUtils.getAsyncJobResponse(client,
-                        cloudStackUrl, response.getJobId(), cloudStackUser);
+                CloudStackQueryAsyncJobResponse asyncJobResponse = CloudStackCloudUtils.getAsyncJobResponse(
+                        this.client, this.cloudStackUrl, response.getJobId(), cloudStackUser);
                 deleteSecurityRule(asyncJobResponse.getJobInstanceId(), cloudStackUser);
                 throw e;
             }


### PR DESCRIPTION
# Description
Refactoring the Cloudstack Security Rules Plugin context. 

# Proposed changes
- Migrating Cloudstack asynchronous operation to the Cloudstack Utils

# Additional information
- This branch depends on a branch in the Fogbow Common (cloudstack-securityrules-test-refator)
Note: Maybe happen compiling error at PRs before PR5 in regards to Common Project because there were some changes in the PR5.

# PR Slices
[x] One: Refactoring in the Cloudstack Security Rules Plugin
[x] Two: Migrating Cloudstack asynchronous operation to the Cloudstack  Utils
[] Three: Refactoring "request Instance" tests context.
[] Four: Refactoring "get Instance" tests context.
[] Five: Refactoring "delete instance" tests context.

# Reminding
- PRs order: 
develop < **PR1 < PR2** < PR3 < PR4 < PR5