### PR TITLE
Cloudstack securityrule test refactor pr three

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -110,6 +110,7 @@ public class CloudStackCloudUtils {
         try {
             Thread.sleep(getTimeSleepThread());
         } catch (InterruptedException e) {
+            // TODO(chico) - use constants
             LOGGER.warn("Thread waiting was interrupeted", e);
         }
     }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -116,7 +116,7 @@ public class CloudStackCloudUtils {
 
     public static class TimeoutCloudstackAsync extends FogbowException {
 
-        private TimeoutCloudstackAsync(String message) {
+        public TimeoutCloudstackAsync(String message) {
             super(message);
         }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
@@ -6,6 +6,15 @@ import com.google.gson.annotations.SerializedName;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_RESPONSE;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_KEY_JSON;
 
+/**
+ * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
+ * <p>
+ * {
+ *  "createfirewallruleresponse": {
+ *      "jobstatus": 1,
+ *   }
+ * }
+ */
 public class CreateFirewallRuleAsyncResponse {
 
     @SerializedName(CREATE_FIREWALL_RULE_RESPONSE)

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -3,13 +3,13 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
-import static cloud.fogbow.common.constants.CloudStackConstants.Network.CREATE_FIREWALL_RULE_COMMAND;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
- * <p>
- * Request Example:
+ *
+ * Request Example: http://cloudstack?command=createFirewallRule&response=json&protocol=protocol /
+ * &startport=startPort&endport=endPort&ipaddressid=ipAddressId&cidrlist=cird
  */
 public class CreateFirewallRuleRequest extends CloudStackRequest {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -3,6 +3,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
+import static cloud.fogbow.common.constants.CloudStackConstants.Network.CREATE_FIREWALL_RULE_COMMAND;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 
 /**
@@ -11,8 +12,6 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
  * Request Example:
  */
 public class CreateFirewallRuleRequest extends CloudStackRequest {
-
-    public static final String CREATE_FIREWALL_RULE_COMMAND = "createFirewallRule";
 
     protected CreateFirewallRuleRequest(Builder builder) throws InvalidParameterException {
         super(builder.cloudStackUrl);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -135,7 +135,8 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         CloudStackUrlUtil.sign(uriRequest, cloudStackUser.getToken());
 
         try {
-            String jsonResponse = this.client.doGetRequest(uriRequest.toString(), cloudStackUser);
+            String jsonResponse = CloudStackCloudUtils.doRequest(
+                    this.client, uriRequest.toString(), cloudStackUser);
             CreateFirewallRuleAsyncResponse response = CreateFirewallRuleAsyncResponse.fromJson(jsonResponse);
             try {
                 return CloudStackCloudUtils.waitForResult(

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -120,8 +120,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
                                         @NotNull Order majorOrder) throws InvalidParameterException {
 
         if (securityRule.getDirection() == SecurityRule.Direction.OUT) {
-            // TODO(chico) - check this exception. Does it make sense ?
-            throw new UnsupportedOperationException();
+            throw new InvalidParameterException(Messages.Exception.INVALID_PARAMETER);
         }
         if (majorOrder.getType() != ResourceType.PUBLIC_IP) {
             throw new InvalidParameterException(Messages.Exception.INVALID_RESOURCE);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -127,6 +127,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         }
     }
 
+    @NotNull
     @VisibleForTesting
     String doRequestInstance(@NotNull CreateFirewallRuleRequest request,
                              @NotNull CloudStackUser cloudStackUser) throws FogbowException {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
@@ -53,6 +53,7 @@ public class CloudstackTestUtils {
     private static final String DETACH_VOLUME_ERROR_RESPONSE = "detachvolumeresponse_error.json";
     private static final String ASYNC_ATTACH_VOLUME_RESPONSE = "queryasyncattachvolumeresponse.json";
     private static final String ASYNC_ERROR_RESPONSE = "queryasyncresponse_error.json";
+    private static final String CREATE_FIREWALL_RULE_RESPONSE = "createfirewallruleresponse.json";
 
     public static final CloudStackUser CLOUD_STACK_USER =
             new CloudStackUser("id", "", "", "", new HashMap<>());
@@ -296,6 +297,13 @@ public class CloudstackTestUtils {
                 + ASYNC_ERROR_RESPONSE);
 
         return String.format(rawJson, jobStatus, errorCode, errorText);
+    }
+
+    public static String createFirewallRuleAsyncResponseJson(String jobId) throws IOException {
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + CREATE_FIREWALL_RULE_RESPONSE);
+
+        return String.format(rawJson, jobId);
     }
 
     private static String readFileAsString(final String fileName) throws IOException {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
@@ -10,6 +10,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.compute.v4_9.Ge
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.CreateNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.DeleteNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.GetNetworkRequest;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
 import org.mockito.ArgumentMatcher;
 
 public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher<T> {
@@ -83,6 +84,12 @@ public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher
 
     public static class AttachmentJobStatus extends RequestMatcher<AttachmentJobStatusRequest> {
         public AttachmentJobStatus(CloudStackRequest cloudStackRequest) {
+            super(cloudStackRequest);
+        }
+    }
+
+    public static class CreateFirewallRule extends RequestMatcher<CreateFirewallRuleRequest> {
+        public CreateFirewallRule(CloudStackRequest cloudStackRequest) {
             super(cloudStackRequest);
         }
     }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -87,7 +87,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
     // it must verify if the doRequestInstance is called with the right parameters;
     // this includes the checking of the Cloudstack request.
     @Test
-    public void testRequestSecurityRule() throws FogbowException {
+    public void testRequestSecurityRuleSuccessfully() throws FogbowException {
         // set up
         String cidr = "10.10.10.10/20";
         int portFromExpected = 22;

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleAsyncResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleAsyncResponseTest.java
@@ -1,4 +1,34 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
 
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleAsyncResponse;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
 public class CreateFirewallRuleAsyncResponseTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right CreateFirewallRuleAsyncResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String jobId = "1";
+        String createFirewallRuleResponseJson =
+                CloudstackTestUtils.createFirewallRuleAsyncResponseJson(jobId);
+
+        // execute
+        CreateFirewallRuleAsyncResponse response =
+                CreateFirewallRuleAsyncResponse.fromJson(createFirewallRuleResponseJson);
+
+        // verify
+        Assert.assertEquals(jobId, response.getJobId());
+    }
+
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleAsyncResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleAsyncResponseTest.java
@@ -1,0 +1,4 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
+
+public class CreateFirewallRuleAsyncResponseTest {
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
@@ -1,0 +1,74 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
+
+public class CreateFirewallRuleRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.Network.CREATE_FIREWALL_RULE_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String protocol = "protocol";
+        String startPort = "startPort";
+        String endPort = "endPort";
+        String ipAddressId = "ipAddressId";
+        String cird = "cird";
+
+        String protocolIdStructureUrl = String.format(
+                "%s=%s", PROTOCOL_KEY_JSON, protocol);
+        String startPortStructureUrl = String.format(
+                "%s=%s", STARTPORT_KEY_JSON, startPort);
+        String endPortStructureUrl = String.format(
+                "%s=%s", ENDPORT_KEY_JSON, endPort);
+        String ipAddressIdStructureUrl = String.format(
+                "%s=%s", IP_ADDRESS_ID_KEY_JSON, ipAddressId);
+        String cirdStructureUrl = String.format(
+                "%s=%s", CIDR_LIST_KEY_JSON, cird);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                protocolIdStructureUrl,
+                startPortStructureUrl,
+                endPortStructureUrl,
+                ipAddressIdStructureUrl,
+                cirdStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        CreateFirewallRuleRequest createFirewallRuleRequest = new CreateFirewallRuleRequest.Builder()
+                .startPort(startPort)
+                .endPort(endPort)
+                .protocol(protocol)
+                .ipAddressId(ipAddressId)
+                .cidrList(cird)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String createFireWallRequestUrl = createFirewallRuleRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, createFireWallRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new CreateFirewallRuleRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
@@ -19,7 +19,7 @@ public class CreateFirewallRuleRequestTest {
         // set up
         URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
                 CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
-                CloudStackConstants.Network.CREATE_FIREWALL_RULE_COMMAND);
+                CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_COMMAND);
         String urlBaseExpected = uriBuilder.toString();
         String protocol = "protocol";
         String startPort = "startPort";

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
@@ -1,0 +1,5 @@
+{
+  "createfirewallruleresponse": {
+    "jobid": 1
+  }
+}


### PR DESCRIPTION
# Description
Refactoring the Cloudstack Security Rules Plugin context. 

# Proposed changes
- Refactoring "request Instance" tests context.

# Additional information
- This branch depends on a branch in the Fogbow Common (cloudstack-securityrules-test-refator)
Note: Maybe happen compiling error at PRs before PR5 in regards to Common Project because there were some changes in the PR5.

# PR Slices
[x] One: Refactoring in the Cloudstack Security Rules Plugin.
[x] Two: Migrating Cloudstack asynchronous operation to the Cloudstack Utils.
[x] Three: Refactoring "request Instance" tests context.
[] Four: Refactoring "get Instance" tests context.
[] Five: Refactoring "delete instance" tests context.

# Reminding
- PRs order: 
develop < PR1 < **PR2 < PR3** < PR4 < PR5