### PR TITLE
Cloudstack securityrule test refactor pr four

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -8,8 +8,8 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
  *
- * Request Example: http://cloudstack?command=createFirewallRule&response=json&protocol=protocol /
- * &startport=startPort&endport=endPort&ipaddressid=ipAddressId&cidrlist=cird
+ * Request Example: {url_cloudstack}?command=createFirewallRule&response=json&protocol={protocol} /
+ * &startport={startPort}&endport={endPort}&ipaddressid={ipAddressId}&cidrlist={cird}
  */
 public class CreateFirewallRuleRequest extends CloudStackRequest {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -73,16 +73,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Info.GETTING_INSTANCE_S, majorOrder.getInstanceId()));
-        switch (majorOrder.getType()) {
-        	case PUBLIC_IP:
-                String publicIpId = CloudStackPublicIpPlugin.getPublicIpId(majorOrder.getId());
-                return getFirewallRules(publicIpId, cloudStackUser);
-        	case NETWORK:
-        		return new ArrayList<>();
-        	default:
-				String errorMsg = String.format(Messages.Error.INVALID_LIST_SECURITY_RULE_TYPE, majorOrder.getType());
-				throw new UnexpectedException(errorMsg);
-        }
+        return doGetSecurityRules(majorOrder, cloudStackUser);
     }
        
     @Override
@@ -95,6 +86,24 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
                 .build(this.cloudStackUrl);
 
         doDeleteInstance(request, cloudStackUser);
+    }
+
+    @NotNull
+    @VisibleForTesting
+    List<SecurityRuleInstance> doGetSecurityRules(@NotNull Order majorOrder,
+                                                  @NotNull CloudStackUser cloudStackUser)
+            throws FogbowException {
+
+        switch (majorOrder.getType()) {
+            case PUBLIC_IP:
+                String publicIpId = CloudStackPublicIpPlugin.getPublicIpId(majorOrder.getId());
+                return getFirewallRules(publicIpId, cloudStackUser);
+            case NETWORK:
+                return new ArrayList<>();
+            default:
+                String errorMsg = String.format(Messages.Error.INVALID_LIST_SECURITY_RULE_TYPE, majorOrder.getType());
+                throw new UnexpectedException(errorMsg);
+        }
     }
 
     @VisibleForTesting

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -189,8 +189,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 	@NotNull
     @VisibleForTesting
 	List<SecurityRuleInstance> convertToFogbowSecurityRules(
-	        @NotNull List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse)
-            throws UnexpectedException {
+	        @NotNull List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse) {
 
 		List<SecurityRuleInstance> securityRuleInstances = new ArrayList<SecurityRuleInstance>();
 		for (ListFirewallRulesResponse.SecurityRuleResponse securityRuleResponse : securityRulesResponse) {
@@ -211,7 +210,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 	}
 
 	@VisibleForTesting
-	SecurityRule.Protocol getFogbowProtocol(String protocol) throws UnexpectedException {
+	SecurityRule.Protocol getFogbowProtocol(String protocol) {
 		switch (protocol) {
 			case CloudStackConstants.SecurityGroupPlugin.TCP_VALUE_PROTOCOL:
 				return SecurityRule.Protocol.TCP;
@@ -222,7 +221,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 			case CloudStackConstants.SecurityGroupPlugin.ALL_VALUE_PROTOCOL:
 				return SecurityRule.Protocol.ANY;
 			default:
-				throw new UnexpectedException(Messages.Exception.INVALID_CLOUDSTACK_PROTOCOL);
+				return null;
 		}
 	}
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -164,7 +164,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 
     @NotNull
     @VisibleForTesting
-	List<SecurityRuleInstance> getFirewallRules(String ipAddressId, @NotNull CloudStackUser cloudUser)
+	List<SecurityRuleInstance> getFirewallRules(String ipAddressId, @NotNull CloudStackUser cloudStackUser)
             throws FogbowException {
 
 		ListFirewallRulesRequest request = new ListFirewallRulesRequest.Builder()
@@ -172,10 +172,11 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 				.build(this.cloudStackUrl);
 
         URIBuilder uriRequest = request.getUriBuilder();
-        CloudStackUrlUtil.sign(uriRequest, cloudUser.getToken());
+        CloudStackUrlUtil.sign(uriRequest, cloudStackUser.getToken());
 
 		try {
-			String jsonResponse = this.client.doGetRequest(uriRequest.toString(), cloudUser);
+			String jsonResponse = CloudStackCloudUtils.doRequest(
+			        this.client, uriRequest.toString(), cloudStackUser);
             ListFirewallRulesResponse response = ListFirewallRulesResponse.fromJson(jsonResponse);
             List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse =
                     response.getSecurityRulesResponse();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequest.java
@@ -21,7 +21,6 @@ public class ListFirewallRulesRequest extends CloudStackRequest {
 	public String getCommand() {
 		return CloudStackConstants.SecurityGroupPlugin.LIST_FIREWALL_RULES_COMMAND;
 	}
-	
 
     public static class Builder {
         private String cloudStackUrl;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesResponse.java
@@ -1,18 +1,20 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
 
-import cloud.fogbow.common.constants.CloudStackConstants;
 import cloud.fogbow.common.util.GsonHolder;
 import cloud.fogbow.ras.api.parameters.SecurityRule;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackErrorResponse;
 import com.google.gson.annotations.SerializedName;
+import org.apache.http.client.HttpResponseException;
 
 import java.util.List;
+
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroupPlugin.*;
 
 /**
  * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/listFirewallRules.html
  * 
  * Response example:
- * 
- * {  
+ * {
  *  "listfirewallrulesresponse":{  
  *    "firewallrule":[  
  *      {  
@@ -21,7 +23,7 @@ import java.util.List;
  *        "startport":23,
  *        "endport":24,
  *        "ipaddress" : "0.0.0.1",
- *        "cidrList":"0.0.0.0/0",
+ *        "cidrlist":"0.0.0.0/0",
  *      },
  *      {  
  *        "id":"0bd00d5f-5550-4e06-880a-893de7a13082",
@@ -29,7 +31,7 @@ import java.util.List;
  *        "startport":22,
  *        "endport":22,
  *        "ipaddress" : "0.0.0.2",
- *        "cidrList":"0.0.0.0/0",
+ *        "cidrlist":"0.0.0.0/0",
  *      }
  *    ]
  *   }
@@ -38,37 +40,40 @@ import java.util.List;
  */
 public class ListFirewallRulesResponse {
 
-	@SerializedName(CloudStackConstants.SecurityGroupPlugin.LIST_FIREWALL_RULES_KEY_JSON)
+	@SerializedName(LIST_FIREWALL_RULES_KEY_JSON)
 	private ListFirewallRules response;
 
-	public static ListFirewallRulesResponse fromJson(String jsonResponse) {
-		return GsonHolder.getInstance().fromJson(jsonResponse, ListFirewallRulesResponse.class);
+	public static ListFirewallRulesResponse fromJson(String jsonResponse) throws HttpResponseException {
+		ListFirewallRulesResponse listFirewallRulesResponse =
+				GsonHolder.getInstance().fromJson(jsonResponse, ListFirewallRulesResponse.class);
+		listFirewallRulesResponse.response.checkErrorExistence();
+		return listFirewallRulesResponse;
 	}
 
 	public List<SecurityRuleResponse> getSecurityRulesResponse() {
 		return this.response.securityRulesResponse;
 	}
 	
-	private class ListFirewallRules {
+	private class ListFirewallRules extends CloudStackErrorResponse {
 
-		@SerializedName(CloudStackConstants.SecurityGroupPlugin.FIREWALL_RULE_KEY_JSON)
+		@SerializedName(FIREWALL_RULE_KEY_JSON)
 		private List<SecurityRuleResponse> securityRulesResponse;
 
 	}
 
     public class SecurityRuleResponse {
 
-    	@SerializedName(CloudStackConstants.SecurityGroupPlugin.ID_KEY_JSON)
+    	@SerializedName(ID_KEY_JSON)
         private String instanceId;
-    	@SerializedName(CloudStackConstants.SecurityGroupPlugin.CIDR_LIST_KEY_JSON)
+    	@SerializedName(CIDR_LIST_KEY_JSON)
         private String cidr;
-    	@SerializedName(CloudStackConstants.SecurityGroupPlugin.START_PORT_KEY_JSON)
+    	@SerializedName(START_PORT_KEY_JSON)
         private int portFrom;
-    	@SerializedName(CloudStackConstants.SecurityGroupPlugin.END_PORT_KEY_JSON)
+    	@SerializedName(END_PORT_KEY_JSON)
         private int portTo;
-        @SerializedName(CloudStackConstants.SecurityGroupPlugin.PROPOCOL_KEY_JSON)
+        @SerializedName(PROPOCOL_KEY_JSON)
 		private String protocol;
-        @SerializedName(CloudStackConstants.SecurityGroupPlugin.IP_ADDRESS_KEY_JSON)
+        @SerializedName(IP_ADDRESS_KEY_JSON)
         private String ipAddress;
         
 		public String getInstanceId() {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
@@ -54,6 +54,11 @@ public class CloudstackTestUtils {
     private static final String ASYNC_ATTACH_VOLUME_RESPONSE = "queryasyncattachvolumeresponse.json";
     private static final String ASYNC_ERROR_RESPONSE = "queryasyncresponse_error.json";
     private static final String CREATE_FIREWALL_RULE_RESPONSE = "createfirewallruleresponse.json";
+    private static final String LIST_FIREWALL_RULES_RESPONSE = "listfirewallrulesresponse.json";
+    private static final String LIST_FIREWALL_RULES_ERROR_RESPONSE =
+            "listfirewallrulesresponse_error.json";
+    private static final String LIST_FIREWALL_RULES_EMPTY_RESPONSE =
+            "listfirewallrulesresponse_empty.json";
 
     public static final CloudStackUser CLOUD_STACK_USER =
             new CloudStackUser("id", "", "", "", new HashMap<>());
@@ -311,6 +316,32 @@ public class CloudstackTestUtils {
         byte[] bytes = Files.readAllBytes(path);
         String data = new String(bytes);
         return data;
+    }
+
+    public static String createListFirewallRulesResponseJson(String id, String protocol, int startPort,
+                                                      int endPort, String ipaddress, String cird)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + LIST_FIREWALL_RULES_RESPONSE);
+
+        return String.format(rawJson, id, protocol, startPort, endPort, ipaddress, cird);
+    }
+
+    public static String createListFirewallRulesEmptyResponseJson() throws IOException {
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + LIST_FIREWALL_RULES_EMPTY_RESPONSE);
+
+        return String.format(rawJson);
+    }
+
+    public static String createListFirewallRulesErrorResponseJson(int errorCode, String errorText)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + LIST_FIREWALL_RULES_ERROR_RESPONSE);
+
+        return String.format(rawJson, errorCode, errorText);
     }
 
     private static String getPathCloudstackFile() {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -554,6 +554,76 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
         Assert.assertTrue(securityRuleInstances.isEmpty());
     }
 
+    // test case: When calling the getFogbowProtocol method and the protocol is TCP,
+    // it must verify if It return a TPC FogbowProtocol.
+    @Test
+    public void testGetFogbowProtocolWheIsTcp() {
+        // set up
+        String protocol = CloudStackConstants.SecurityGroupPlugin.TCP_VALUE_PROTOCOL;
+
+        // exercise
+        SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
+
+        // verify
+        Assert.assertEquals(SecurityRule.Protocol.TCP, fogbowProtocol);
+    }
+
+    // test case: When calling the getFogbowProtocol method and the protocol is UDP,
+    // it must verify if It return a UDP FogbowProtocol.
+    @Test
+    public void testGetFogbowProtocolWhenIsUdp() {
+        // set up
+        String protocol = CloudStackConstants.SecurityGroupPlugin.UDP_VALUE_PROTOCOL;
+
+        // exercise
+        SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
+
+        // verify
+        Assert.assertEquals(SecurityRule.Protocol.UDP, fogbowProtocol);
+    }
+
+    // test case: When calling the getFogbowProtocol method and the protocol is IMCP,
+    // it must verify if It return a IMCP FogbowProtocol.
+    @Test
+    public void testGetFogbowProtocolWhenIsImcp() {
+        // set up
+        String protocol = CloudStackConstants.SecurityGroupPlugin.ICMP_VALUE_PROTOCOL;
+
+        // exercise
+        SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
+
+        // verify
+        Assert.assertEquals(SecurityRule.Protocol.ICMP, fogbowProtocol);
+    }
+
+    // test case: When calling the getFogbowProtocol method and the protocol is any,
+    // it must verify if It return a ANY FogbowProtocol.
+    @Test
+    public void testGetFogbowProtocolWhenIsAny() {
+        // set up
+        String protocol = CloudStackConstants.SecurityGroupPlugin.ALL_VALUE_PROTOCOL;
+
+        // exercise
+        SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
+
+        // verify
+        Assert.assertEquals(SecurityRule.Protocol.ANY, fogbowProtocol);
+    }
+
+    // test case: When calling the getFogbowProtocol method and the protocol is unknown,
+    // it must verify if It return null.
+    @Test
+    public void testGetFogbowProtocolFail() {
+        // set up
+        String protocol = "unknown";
+
+        // exercise
+        SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
+
+        // verify
+        Assert.assertNull(fogbowProtocol);
+    }
+
     // # ------- old code --------- @
 
     // test case: success case

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequestTest.java
@@ -1,0 +1,54 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
+
+public class ListFirewallRulesRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.SecurityGroupPlugin.LIST_FIREWALL_RULES_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String ipAddressId = "ipAddressId";
+
+        String ipAddressIdStructureUrl = String.format(
+                "%s=%s", IP_ADDRESS_ID_KEY_JSON, ipAddressId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                ipAddressIdStructureUrl,
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        ListFirewallRulesRequest listFirewallRulesRequest = new ListFirewallRulesRequest.Builder()
+                .ipAddressId(ipAddressId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String listFireWallRequestUrl = listFirewallRulesRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, listFireWallRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new ListFirewallRulesRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesResponseTest.java
@@ -1,0 +1,80 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpResponseException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+public class ListFirewallRulesResponseTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the fromJson method, it must verify if It returns the right ListFirewallRulesResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws Exception {
+        // set up
+        String instanceId = "1";
+        String protocol = "protocol";
+        int startPort = 1;
+        int endPort = 2;
+        String ipaddress = "ip";
+        String cird = "cird";
+        String listFirewallRulesResponseJson = CloudstackTestUtils.createListFirewallRulesResponseJson(
+                instanceId, protocol, startPort, endPort, ipaddress, cird);
+
+        // execute
+        ListFirewallRulesResponse listFirewallRulesResponse =
+                ListFirewallRulesResponse.fromJson(listFirewallRulesResponseJson);
+
+        // verify
+        ListFirewallRulesResponse.SecurityRuleResponse firstSecurityRule =
+                listFirewallRulesResponse.getSecurityRulesResponse().listIterator().next();
+        Assert.assertEquals(instanceId, firstSecurityRule.getInstanceId());
+        Assert.assertEquals(ipaddress, firstSecurityRule.getIpAddress());
+        Assert.assertEquals(protocol, firstSecurityRule.getProtocol());
+        Assert.assertEquals(startPort, firstSecurityRule.getPortFrom());
+        Assert.assertEquals(endPort, firstSecurityRule.getPortTo());
+        Assert.assertEquals(cird, firstSecurityRule.getCidr());
+    }
+
+    // test case: When calling the fromJson method with empty json response,
+    // it must verify if It returns the ListFirewallRulesResponse with null values.
+    @Test
+    public void testFromJsonWithEmptyValue() throws Exception {
+        // set up
+        String listFirewallRulesEmptyResponseJson = CloudstackTestUtils
+                .createListFirewallRulesEmptyResponseJson();
+
+        // execute
+        ListFirewallRulesResponse listFirewallRulesResponse =
+                ListFirewallRulesResponse.fromJson(listFirewallRulesEmptyResponseJson);
+
+        // verify
+        Assert.assertTrue(listFirewallRulesResponse.getSecurityRulesResponse().isEmpty());
+    }
+
+    // test case: When calling the fromJson method with error json response,
+    // it must verify if It throws a HttpResponseException.
+    @Test
+    public void testFromJsonFail() throws IOException {
+        // set up
+        String errorText = "anyString";
+        int errorCode = HttpStatus.SC_BAD_REQUEST;
+        String volumesErrorResponseJson = CloudstackTestUtils
+                .createListFirewallRulesErrorResponseJson(errorCode, errorText);
+
+        // verify
+        this.expectedException.expect(HttpResponseException.class);
+        this.expectedException.expectMessage(errorText);
+
+        // execute
+        ListFirewallRulesResponse.fromJson(volumesErrorResponseJson);
+    }
+
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse.json
@@ -1,0 +1,14 @@
+{
+  "listfirewallrulesresponse": {
+    "firewallrule": [
+      {
+        "id": "%s",
+        "protocol": "%s",
+        "startport": %s,
+        "endport": %s,
+        "ipaddress": "%s",
+        "cidrlist": "%s"
+      }
+    ]
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse_empty.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse_empty.json
@@ -1,0 +1,5 @@
+{
+  "listfirewallrulesresponse": {
+    "firewallrule": []
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse_error.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse_error.json
@@ -1,0 +1,6 @@
+{
+  "listfirewallrulesresponse": {
+    "errorcode":%s,
+    "errortext":"%s"
+  }
+}


### PR DESCRIPTION
# Description
Refactoring the Cloudstack Security Rules Plugin context. 

# Proposed changes
- Refactoring "get Instance" tests context.

# Additional information
- This branch depends on a branch in the Fogbow Common (cloudstack-securityrules-test-refator)
Note: Maybe happen compiling error at PRs before PR5 in regards to Common Project because there were some changes in the PR5.

# PR Slices
[x] One: Refactoring in the Cloudstack Security Rules Plugin.
[x] Two: Migrating Cloudstack asynchronous operation to the Cloudstack Utils.
[x] Three: Refactoring "request Instance" tests context.
[x] Four: Refactoring "get Instance" tests context.
[] Five: Refactoring "delete instance" tests context.

# Reminding
- PRs order: 
develop < PR1 < PR2 < **PR3 < PR4** < PR5