### PR TITLE
Cloudstack publicip test refactor pr two

### DIFF
--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -121,6 +121,8 @@ public class Messages {
         public static final String STARTING_THREADS = "Starting processor threads.";
         public static final String SUCCESS = "Successfully executed operation.";
         public static final String XMPP_HANDLERS_SET = "XMPP handlers set.";
+        public static final String ASYNCHRONOUS_PUBLIC_IP_STATE =
+                "The asynchronous public ip request %s is in the state %s.";
     }
 
     public static class Error {

--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -178,5 +178,7 @@ public class Messages {
         public static final String UNEXPECTED_ERROR_WITH_MESSAGE = "Unexpected exception error: %s.";
         public static final String UNEXPECTED_JOB_STATUS = "Job status must be one of {0, 1, 2}.";
         public static final String UNSPECIFIED_PROJECT_ID = "Unspecified projectId.";
+        public static final String INSTANCE_OPERATIONAL_LOST_MEMORY_FAILURE =
+                "The instanceid %s had an operational failure due to the memory lost. It might left trash in the cloud.";
     }
 }

--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -150,6 +150,8 @@ public class Messages {
         public static final String ERROR_WHILE_INSTANTIATING_FROM_TEMPLATE = "Error while instatiating an instance from template: %s.";
         public static final String ERROR_WHILE_PROCESSING_VOLUME_REQUIREMENTS = "Error while processing volume requirements";
         public static final String ERROR_WHILE_REMOVING_RESOURCE = "An error occurred while removing %s: %s.";
+        public static final String ERROR_WHILE_PROCESSING_ASYNCHRONOUS_REQUEST_INSTANCE_STEP =
+                "Error while It was trying to pass to the next step in the asynchronous request instance.";
         public static final String ERROR_WHILE_REMOVING_VOLUME_IMAGE = "Error while removing volume image: %s, with response: %s.";
         public static final String ERROR_WHILE_UPDATING_NETWORK = "Error while updating a network from template: %s.";
         public static final String ERROR_WHILE_UPDATING_SECURITY_GROUPS = "Error while updating a security groups from template: %s.";

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponse.java
@@ -1,13 +1,15 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 
 import cloud.fogbow.common.util.GsonHolder;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackErrorResponse;
 import com.google.gson.annotations.SerializedName;
+import org.apache.http.client.HttpResponseException;
 
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.ASSOCIATE_IP_ADDRESS_RESPONSE_KEY_JSON;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_KEY_JSON;
 
 /**
- * Documentation:
+ * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/associateIpAddress.html
  *
  * Response Example:
  * {
@@ -19,17 +21,17 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_
 public class AssociateIpAddressAsyncJobIdResponse {
 
     @SerializedName(ASSOCIATE_IP_ADDRESS_RESPONSE_KEY_JSON)
-    private AssociateIpAddressResponse associateIpAddressResponse;
+    private AssociateIpAddressResponse response;
 
     public String getJobId() {
-        return this.associateIpAddressResponse.getJobId();
+        return this.response.getJobId();
     }
 
-    public static AssociateIpAddressAsyncJobIdResponse fromJson(String json) {
+    public static AssociateIpAddressAsyncJobIdResponse fromJson(String json) throws HttpResponseException {
         return GsonHolder.getInstance().fromJson(json, AssociateIpAddressAsyncJobIdResponse.class);
     }
 
-    public class AssociateIpAddressResponse {
+    public class AssociateIpAddressResponse extends CloudStackErrorResponse {
 
         @SerializedName(JOB_ID_KEY_JSON)
         private String jobId;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequest.java
@@ -9,7 +9,7 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.NETWORK
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/associateIpAddress.html
  *
- * Request Example:
+ * Request Example: {url_cloudstack}?command=associateIpAddress&networkid={networkid}&apikey={apiKey}&secret_key={secretKey}
  */
 public class AssociateIpAddressRequest extends CloudStackRequest {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AsyncRequestInstanceState.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AsyncRequestInstanceState.java
@@ -3,6 +3,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 public class AsyncRequestInstanceState {
 
     private StateType state;
+    private String orderInstanceId;
     private String currentJobId;
     private String ip;
     private String ipInstanceId;
@@ -52,6 +53,14 @@ public class AsyncRequestInstanceState {
 
     public void setIpInstanceId(String ipInstanceId) {
         this.ipInstanceId = ipInstanceId;
+    }
+
+    public void setOrderInstanceId(String orderInstanceId) {
+        this.orderInstanceId = orderInstanceId;
+    }
+
+    public String getOrderInstanceId() {
+        return orderInstanceId;
     }
 
     public enum StateType {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -137,7 +137,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         if (asyncRequestInstanceState.isReady()) {
             return buildReadyPublicIpInstance(asyncRequestInstanceState);
         } else {
-            return buildNextPublicIpInstance(publicIpOrder, cloudStackUser);
+            return buildCurrentPublicIpInstance(publicIpOrder, cloudStackUser);
         }
     }
 
@@ -158,8 +158,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
      */
     @NotNull
     @VisibleForTesting
-    PublicIpInstance buildNextPublicIpInstance(@NotNull PublicIpOrder publicIpOrder,
-                                               @NotNull CloudStackUser cloudStackUser)
+    PublicIpInstance buildCurrentPublicIpInstance(@NotNull PublicIpOrder publicIpOrder,
+                                                  @NotNull CloudStackUser cloudStackUser)
             throws FogbowException {
 
         String temporaryInstanceId = getInstanceId(publicIpOrder);
@@ -391,12 +391,18 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         }
     }
 
-    // TODO(chico) - This method will be removed after the Cloudstack Security Rule PR is accepted.
-    public static String getPublicIpId(String orderId) {
-        return asyncRequestInstanceStateMap.get(orderId).getIpInstanceId();
+    @VisibleForTesting
+    void setClient(CloudStackHttpClient client) {
+        this.client = client;
     }
 
     // TODO(chico) - This method will be removed after the Cloudstack Security Rule PR is accepted.
+
+    public static String getPublicIpId(String orderId) {
+        return asyncRequestInstanceStateMap.get(orderId).getIpInstanceId();
+    }
+    // TODO(chico) - This method will be removed after the Cloudstack Security Rule PR is accepted.
+
     public static void setOrderidToInstanceIdMapping(String orderId, String instanceId) {
         AsyncRequestInstanceState currentAsyncRequest = new AsyncRequestInstanceState(AsyncRequestInstanceState.StateType.READY, null, instanceId);
         asyncRequestInstanceStateMap.put(orderId, currentAsyncRequest);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -382,7 +382,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
 
     @NotNull
     @VisibleForTesting
-    String requestCreateFirewallRule(CreateFirewallRuleRequest request, @NotNull CloudStackUser cloudUser)
+    String requestCreateFirewallRule(@NotNull CreateFirewallRuleRequest request,
+                                     @NotNull CloudStackUser cloudUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -26,8 +26,8 @@ import java.util.Properties;
 public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> {
     private static final Logger LOGGER = Logger.getLogger(CloudStackPublicIpPlugin.class);
 
-    public static final String DEFAULT_SSH_PORT = "22";
-    public static final String DEFAULT_PROTOCOL = "TCP";
+    static final String DEFAULT_SSH_PORT = "22";
+    static final String DEFAULT_PROTOCOL = "TCP";
 
     // Since the ip creation and association involves multiple asynchronous requests instance,
     // we need to keep track of where we are in the process in order to fulfill the operation.
@@ -131,6 +131,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
             // order was still spawning, the spawning processor will start monitoring this order after the RAS
             // is restarted. Unfortunately, even if the operation succeeded, we cannot retrieve this information
             // and will have to signal that the order has failed.
+            LOGGER.error(Messages.Error.INSTANCE_OPERATIONAL_LOST_MEMORY_FAILURE);
             return buildFailedPublicIpInstance();
         }
 
@@ -394,6 +395,13 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     @VisibleForTesting
     void setClient(CloudStackHttpClient client) {
         this.client = client;
+    }
+
+    @VisibleForTesting
+    static void setAsyncRequestInstanceStateMap(
+            Map<String, AsyncRequestInstanceState> asyncRequestInstanceStateMap) {
+
+        CloudStackPublicIpPlugin.asyncRequestInstanceStateMap = asyncRequestInstanceStateMap;
     }
 
     // TODO(chico) - This method will be removed after the Cloudstack Security Rule PR is accepted.

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -143,17 +143,6 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         }
     }
 
-
-    /**
-     * We don't have the id of the ip address yet, but since the instance id is only used
-     * by the plugin, we can return an orderId as an instanceId in the plugin
-     */
-    @NotNull
-    @VisibleForTesting
-    String getInstanceId(@NotNull PublicIpOrder publicIpOrder) {
-        return publicIpOrder.getId();
-    }
-
     /**
      * Retrieve the current Cloudstack asynchronous job and treat the next operation of the
      * asynchronous request instance flow.
@@ -340,6 +329,15 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
             ip = asyncRequestInstanceState.getIp();
         }
         return new PublicIpInstance(id, state, ip);
+    }
+
+    /**
+     * We don't have the id of the ip address yet, but since the instance id is only used
+     * by the plugin, we can return an orderId as an instanceId in the plugin
+     */
+    @NotNull
+    private String getInstanceId(@NotNull PublicIpOrder publicIpOrder) {
+        return publicIpOrder.getId();
     }
 
     @NotNull

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -278,7 +278,14 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
                                 @NotNull CloudStackUser cloudStackUser) throws FogbowException {
 
         String ipAddressId = response.getIpAddress().getId();
-        return requestCreateFirewallRule(ipAddressId, cloudStackUser);
+        CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder()
+                .protocol(DEFAULT_PROTOCOL)
+                .startPort(DEFAULT_SSH_PORT)
+                .endPort(DEFAULT_SSH_PORT)
+                .ipAddressId(ipAddressId)
+                .build(this.cloudStackUrl);
+
+        return requestCreateFirewallRule(request, cloudStackUser);
     }
 
     @VisibleForTesting
@@ -376,17 +383,10 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
 
     @NotNull
     @VisibleForTesting
-    String requestCreateFirewallRule(String ipAdressId, @NotNull CloudStackUser cloudUser)
+    String requestCreateFirewallRule(CreateFirewallRuleRequest request, @NotNull CloudStackUser cloudUser)
             throws FogbowException {
 
-        CreateFirewallRuleRequest createFirewallRuleRequest = new CreateFirewallRuleRequest.Builder()
-                .protocol(DEFAULT_PROTOCOL)
-                .startPort(DEFAULT_SSH_PORT)
-                .endPort(DEFAULT_SSH_PORT)
-                .ipAddressId(ipAdressId)
-                .build(this.cloudStackUrl);
-
-        URIBuilder uriRequest = createFirewallRuleRequest.getUriBuilder();
+        URIBuilder uriRequest = request.getUriBuilder();
         CloudStackUrlUtil.sign(uriRequest, cloudUser.getToken());
 
         try {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -289,7 +289,12 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         String ipAddressId = response.getIpAddress().getId();
         String computeInstanceId = asyncRequestInstanceState.getComputeInstanceId();
 
-        requestEnableStaticNat(computeInstanceId, ipAddressId, cloudStackUser);
+        EnableStaticNatRequest request = new EnableStaticNatRequest.Builder()
+                .ipAddressId(ipAddressId)
+                .virtualMachineId(computeInstanceId)
+                .build(this.cloudStackUrl);
+
+        requestEnableStaticNat(request, cloudStackUser);
     }
 
     @NotNull
@@ -355,17 +360,11 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
 
     @NotNull
     @VisibleForTesting
-    void requestEnableStaticNat(String computeInstanceId,
-                                String ipAdressId,
+    void requestEnableStaticNat(@NotNull EnableStaticNatRequest request,
                                 @NotNull CloudStackUser cloudStackUser)
             throws FogbowException {
 
-        EnableStaticNatRequest enableStaticNatRequest = new EnableStaticNatRequest.Builder()
-                .ipAddressId(ipAdressId)
-                .virtualMachineId(computeInstanceId)
-                .build(this.cloudStackUrl);
-
-        URIBuilder uriRequest = enableStaticNatRequest.getUriBuilder();
+        URIBuilder uriRequest = request.getUriBuilder();
         CloudStackUrlUtil.sign(uriRequest, cloudStackUser.getToken());
 
         try {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -258,11 +258,12 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
                                            @NotNull AsyncRequestInstanceState asyncRequestInstanceState,
                                            String createFirewallRuleJobId) {
 
-        String ipAddressId = response.getIpAddress().getId();
-        String ipAddress = response.getIpAddress().getIpAddress();
+        SuccessfulAssociateIpAddressResponse.IpAddress ipAddress = response.getIpAddress();
+        String ipAddressId = ipAddress.getId();
+        String ip = ipAddress.getIpAddress();
 
         asyncRequestInstanceState.setIpInstanceId(ipAddressId);
-        asyncRequestInstanceState.setIp(ipAddress);
+        asyncRequestInstanceState.setIp(ip);
         asyncRequestInstanceState.setCurrentJobId(createFirewallRuleJobId);
         asyncRequestInstanceState.setState(AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE);
     }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -330,8 +330,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     @NotNull
-    @VisibleForTesting
-    PublicIpInstance buildPublicIpInstance(@NotNull AsyncRequestInstanceState asyncRequestInstanceState,
+    private PublicIpInstance buildPublicIpInstance(@NotNull AsyncRequestInstanceState asyncRequestInstanceState,
                                            String state) {
         String id = null;
         String ip = null;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
@@ -6,6 +6,16 @@ import com.google.gson.annotations.SerializedName;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_RESPONSE;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_KEY_JSON;
 
+/**
+ * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
+ *
+ * Response Example:
+ * {
+ *   "createfirewallruleresponse":{
+ *     "jobid":"7568bb4f-d925-437e-80b0-b2d984d225d4"
+ *   }
+ * }
+ */
 public class CreateFirewallRuleAsyncResponse {
 
     @SerializedName(CREATE_FIREWALL_RULE_RESPONSE)

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -8,11 +8,10 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
  * <p>
- * Request Example:
+ * Request Example: {url_cloudstack}?command=createFirewallRule&protocol={protocol}&startport={startport} /
+ *  * &endport={endport}&ipaddressid={ipaddressid}&cidrlist={cidrlist}&apikey={apiKey}&secret_key={secretKey}
  */
 public class CreateFirewallRuleRequest extends CloudStackRequest {
-
-    public static final String CREATE_FIREWALL_RULE_COMMAND = "createFirewallRule";
 
     protected CreateFirewallRuleRequest(Builder builder) throws InvalidParameterException {
         super(builder.cloudStackUrl);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequest.java
@@ -3,17 +3,15 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
+import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.DISASSOCIATE_IP_ADDRESS_COMMAND;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.ID_KEY_JSON;
 
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/disassociateIpAddress.html
  * 
- * Request Example: 
- *
+ * Request Example: {url_cloudstack}?command=disassociateIpAddress&id={id}&apikey={apiKey}&secret_key={secretKey}
  */	
 public class DisassociateIpAddressRequest extends CloudStackRequest {
-
-	public static final String DISASSOCIATE_IP_ADDRESS_COMMAND = "disassociateIpAddress";
 
 	protected DisassociateIpAddressRequest(Builder builder) throws InvalidParameterException {
 		super(builder.cloudStackUrl);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequest.java
@@ -8,7 +8,8 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/enableStaticNat.html
  * <p>
- * Request Example:
+ * Request Example: {url_cloudstack}?command=enableStaticNat&virtualmachineid={virtualmachineid} /
+ * &ipaddressid={ipaddressid}&apikey={apiKey}&secret_key={secretKey}
  */
 public class EnableStaticNatRequest extends CloudStackRequest {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponse.java
@@ -1,7 +1,9 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 
 import cloud.fogbow.common.util.GsonHolder;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackErrorResponse;
 import com.google.gson.annotations.SerializedName;
+import org.apache.http.client.HttpResponseException;
 
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 
@@ -9,7 +11,6 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/associateIpAddress.html
  * 
  * Response Example: 
- *
  *{
  *  "queryasyncjobresultresponse":{
  *     "jobresult":{
@@ -20,7 +21,6 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
  *     }
  *   }
  * }
- *
  */
 public class SuccessfulAssociateIpAddressResponse {
 
@@ -31,8 +31,11 @@ public class SuccessfulAssociateIpAddressResponse {
 		return this.response.jobResult.ipAddress;
 	}
 	
-    public static SuccessfulAssociateIpAddressResponse fromJson(String json) {
-        return GsonHolder.getInstance().fromJson(json, SuccessfulAssociateIpAddressResponse.class);
+    public static SuccessfulAssociateIpAddressResponse fromJson(String json) throws HttpResponseException {
+        SuccessfulAssociateIpAddressResponse successfulAssociateIpAddressResponse =
+                GsonHolder.getInstance().fromJson(json, SuccessfulAssociateIpAddressResponse.class);
+        successfulAssociateIpAddressResponse.response.jobResult.checkErrorExistence();
+        return successfulAssociateIpAddressResponse;
     }
 
     private class QueryAsyncJobResultResponse {
@@ -45,7 +48,7 @@ public class SuccessfulAssociateIpAddressResponse {
 
     }
 
-    private class JobResult {
+    private class JobResult extends CloudStackErrorResponse {
 
         @SerializedName(IP_ADDRESS_KEY_JSON)
         private IpAddress ipAddress;

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
@@ -56,6 +56,11 @@ public class CloudstackTestUtils {
     private static final String LIST_TEMPLATES_RESPONSE = "listtemplatesresponse.json";
     private static final String LIST_TEMPLATES_ERROR_RESPONSE = "listtemplatesresponse_error.json";
     private static final String LIST_TEMPLATES_EMPTY_RESPONSE = "listtemplatesresponse_empty.json";
+    private static final String ASSOCIATE_IP_ADDRESS_RESPONSE = "associateipaddressresponse.json";
+    private static final String CREATE_FIREWALL_RULE_ADDRESS_RESPONSE = "createfirewallruleresponse.json";
+    private static final String ASYNC_ASSOCIATE_IP_ADDRESS_RESPONSE = "queryasyncassociateipaddressresponse.json";
+    private static final String ASYNC_ASSOCIATE_IP_ADDRESS_ERROR_RESPONSE =
+            "queryasyncassociateipaddressresponse_error.json";
 
     public static final CloudStackUser CLOUD_STACK_USER =
             new CloudStackUser("id", "", "", "", new HashMap<>());
@@ -324,6 +329,42 @@ public class CloudstackTestUtils {
                 + LIST_TEMPLATES_ERROR_RESPONSE);
 
         return String.format(rawJson, errorCode, errorText);
+    }
+
+    public static String createAssociateIpAddressAsyncResponseJson(String jobId)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + ASSOCIATE_IP_ADDRESS_RESPONSE);
+
+        return String.format(rawJson, jobId);
+    }
+
+    public static String createFirewallRuleAsyncResponseJson(String jobId)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + CREATE_FIREWALL_RULE_ADDRESS_RESPONSE);
+
+        return String.format(rawJson, jobId);
+    }
+
+    public static String createAsyncAssociateIpAddressErrorResponseJson(int errorCode, String errorText)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + ASYNC_ASSOCIATE_IP_ADDRESS_ERROR_RESPONSE);
+
+        return String.format(rawJson, errorCode, errorText);
+    }
+
+    public static String createAsyncAssociateIpAddressResponseJson(String id, String idAddress)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + ASYNC_ASSOCIATE_IP_ADDRESS_RESPONSE);
+
+        return String.format(rawJson, id, idAddress);
     }
 
     private static String readFileAsString(final String fileName) throws IOException {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
@@ -11,7 +11,9 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.image.v4_9.GetA
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.CreateNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.DeleteNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.GetNetworkRequest;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.AssociateIpAddressRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.DisassociateIpAddressRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.EnableStaticNatRequest;
 import org.mockito.ArgumentMatcher;
 
@@ -104,6 +106,18 @@ public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher
 
     public static class CreateFirewallRule extends RequestMatcher<CreateFirewallRuleRequest> {
         public CreateFirewallRule(CloudStackRequest cloudStackRequest) {
+            super(cloudStackRequest);
+        }
+    }
+
+    public static class DisassociateIpAddress extends RequestMatcher<DisassociateIpAddressRequest> {
+        public DisassociateIpAddress(CloudStackRequest cloudStackRequest) {
+            super(cloudStackRequest);
+        }
+    }
+
+    public static class AssociateIpAddress extends RequestMatcher<AssociateIpAddressRequest> {
+        public AssociateIpAddress(CloudStackRequest cloudStackRequest) {
             super(cloudStackRequest);
         }
     }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
@@ -11,6 +11,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.image.v4_9.GetA
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.CreateNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.DeleteNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.GetNetworkRequest;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.EnableStaticNatRequest;
 import org.mockito.ArgumentMatcher;
 
 public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher<T> {
@@ -90,6 +91,12 @@ public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher
 
     public static class GetAllImages extends RequestMatcher<GetAllImagesRequest> {
         public GetAllImages(CloudStackRequest cloudStackRequest) {
+            super(cloudStackRequest);
+        }
+    }
+
+    public static class EnableStaticNat extends RequestMatcher<EnableStaticNatRequest> {
+        public EnableStaticNat(CloudStackRequest cloudStackRequest) {
             super(cloudStackRequest);
         }
     }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
@@ -11,6 +11,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.image.v4_9.GetA
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.CreateNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.DeleteNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.GetNetworkRequest;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.EnableStaticNatRequest;
 import org.mockito.ArgumentMatcher;
 
@@ -100,4 +101,11 @@ public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher
             super(cloudStackRequest);
         }
     }
+
+    public static class CreateFirewallRule extends RequestMatcher<CreateFirewallRuleRequest> {
+        public CreateFirewallRule(CloudStackRequest cloudStackRequest) {
+            super(cloudStackRequest);
+        }
+    }
+
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponseTest.java
@@ -1,0 +1,28 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AssociateIpAddressAsyncJobIdResponseTest {
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right AssociateIpAddressAsyncJobIdResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String jobId = "1";
+        String associateIpAddressAsyncResponseJson =
+                CloudstackTestUtils.createAssociateIpAddressAsyncResponseJson(jobId);
+
+        // execute
+        AssociateIpAddressAsyncJobIdResponse associateIpAddressAsyncJobIdResponse =
+                AssociateIpAddressAsyncJobIdResponse.fromJson(associateIpAddressAsyncResponseJson);
+
+        // verify
+        Assert.assertEquals(jobId, associateIpAddressAsyncJobIdResponse.getJobId());
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequestTest.java
@@ -1,0 +1,51 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AssociateIpAddressRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.ASSOCIATE_IP_ADDRESS_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String networkId = "networkId";
+
+        String networkIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.NETWORK_ID_KEY_JSON, networkId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                networkIdStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        AssociateIpAddressRequest associateIpAddressRequest = new AssociateIpAddressRequest.Builder()
+                .networkId(networkId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String associateIpAddressRequestUrl = associateIpAddressRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, associateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new AssociateIpAddressRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -72,6 +72,41 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         CloudstackTestUtils.ignoringCloudStackUrl();
     }
 
+    // test case: When calling the setAsyncRequestInstanceSecondStep method, it must verify if It
+    // set the rigth values in the AsyncRequestInstanceState.
+    @Test
+    public void testSetAsyncRequestInstanceSecondStepSuccessfully() {
+        // set up
+        String ipAddressIdExpected = "ipId";
+        String ipExpected = "ip";
+
+        SuccessfulAssociateIpAddressResponse response = Mockito.mock(SuccessfulAssociateIpAddressResponse.class);
+        SuccessfulAssociateIpAddressResponse.IpAddress ipAddress =
+                Mockito.mock(SuccessfulAssociateIpAddressResponse.IpAddress.class);
+        Mockito.when(ipAddress.getId()).thenReturn(ipAddressIdExpected);
+        Mockito.when(ipAddress.getIpAddress()).thenReturn(ipExpected);
+
+        Mockito.when(response.getIpAddress()).thenReturn(ipAddress);
+        AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(null, null , null);
+        String createFirewallRuleJobId = "jobId";
+
+        // verify before
+        Assert.assertNull(asyncRequestInstanceState.getIpInstanceId());
+        Assert.assertNull(asyncRequestInstanceState.getIp());
+        Assert.assertNull(asyncRequestInstanceState.getState());
+        Assert.assertNull(asyncRequestInstanceState.getCurrentJobId());
+
+        // exercise
+        this.plugin.setAsyncRequestInstanceSecondStep(response, asyncRequestInstanceState, createFirewallRuleJobId);
+
+        // verify after
+        Assert.assertEquals(ipAddressIdExpected, asyncRequestInstanceState.getIpInstanceId());
+        Assert.assertEquals(ipExpected, asyncRequestInstanceState.getIp());
+        Assert.assertEquals(AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE,
+                asyncRequestInstanceState.getState());
+        Assert.assertEquals(createFirewallRuleJobId, asyncRequestInstanceState.getCurrentJobId());
+    }
+
     // test case: When calling the requestCreateFirewallRule method and occurs a HttpResponseException,
     // it must verify if It throws FogbowException.
     @Test

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -1,22 +1,31 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 
+import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.CloudStackUser;
 import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackHttpClient;
+import cloud.fogbow.ras.api.http.response.PublicIpInstance;
 import cloud.fogbow.ras.core.BaseUnitTests;
 import cloud.fogbow.ras.core.datastore.DatabaseManager;
+import cloud.fogbow.ras.core.models.orders.PublicIpOrder;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackCloudUtils;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackStateMapper;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 @PrepareForTest({DatabaseManager.class})
 public class CloudStackPublicIpPluginTest extends BaseUnitTests {
 
+    private Map<String, AsyncRequestInstanceState> asyncRequestInstanceStateMapMockEmpty = new HashMap<>();
     private CloudStackPublicIpPlugin plugin;
     private CloudStackHttpClient client;
     private CloudStackUser cloudStackUser;
@@ -30,11 +39,68 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         this.plugin = Mockito.spy(new CloudStackPublicIpPlugin(cloudStackConfFilePath));
         this.client = Mockito.mock(CloudStackHttpClient.class);
         this.plugin.setClient(this.client);
+        this.plugin.setAsyncRequestInstanceStateMap(this.asyncRequestInstanceStateMapMockEmpty);
 
         this.cloudStackUrl = properties.getProperty(CloudStackCloudUtils.CLOUDSTACK_URL_CONFIG);
         this.cloudStackUser = CloudstackTestUtils.CLOUD_STACK_USER;
 
         this.testUtils.mockReadOrdersFromDataBase();
+    }
+
+    // TODO(chico) - add "test case" description
+    @Test
+    public void testDoGetInstanceWhenIsReady() throws FogbowException {
+        // set up
+        PublicIpOrder publicIpOrder = Mockito.mock(PublicIpOrder.class);
+        String instanceId = "instanceId";
+        Mockito.when(publicIpOrder.getId()).thenReturn(instanceId);
+        AsyncRequestInstanceState asyncRequestInstanceStateReady = new AsyncRequestInstanceState(
+                AsyncRequestInstanceState.StateType.READY, null, null);
+        this.asyncRequestInstanceStateMapMockEmpty.put(instanceId, asyncRequestInstanceStateReady);
+
+        // exercise
+        PublicIpInstance publicIpInstance = this.plugin.doGetInstance(publicIpOrder, this.cloudStackUser);
+
+        // verify
+        Assert.assertEquals(CloudStackStateMapper.READY_STATUS, publicIpInstance.getCloudState());
+    }
+
+    // TODO(chico) - add "test case" description
+    @Test
+    public void testDoGetInstanceWhenIsNotReady() throws FogbowException {
+        // set up
+        PublicIpOrder publicIpOrder = Mockito.mock(PublicIpOrder.class);
+        String instanceId = "instanceId";
+        Mockito.when(publicIpOrder.getId()).thenReturn(instanceId);
+        AsyncRequestInstanceState asyncRequestInstanceStateReady = new AsyncRequestInstanceState(
+                AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE, null, null);
+        this.asyncRequestInstanceStateMapMockEmpty.put(instanceId, asyncRequestInstanceStateReady);
+
+        PublicIpInstance publicIpInstanceExcepted = Mockito.mock(PublicIpInstance.class);
+        Mockito.doReturn(publicIpInstanceExcepted).when(this.plugin).buildCurrentPublicIpInstance(
+                Mockito.eq(publicIpOrder), Mockito.eq(this.cloudStackUser));
+
+        // exercise
+        PublicIpInstance publicIpInstance = this.plugin.doGetInstance(publicIpOrder, this.cloudStackUser);
+
+        // verify
+        Assert.assertEquals(publicIpInstanceExcepted, publicIpInstance);
+    }
+
+    // TODO(chico) - add "test case" description
+    @Test
+    public void testDoGetInstanceFailWhenThereMemoryLost() throws FogbowException {
+        // set up
+        PublicIpOrder publicIpOrder = Mockito.mock(PublicIpOrder.class);
+        String instanceId = "instanceId";
+        Mockito.when(publicIpOrder.getId()).thenReturn(instanceId);
+        this.asyncRequestInstanceStateMapMockEmpty = new HashMap<>();
+
+        // exercise
+        PublicIpInstance publicIpInstance = this.plugin.doGetInstance(publicIpOrder, this.cloudStackUser);
+
+        // verify
+        Assert.assertEquals(CloudStackStateMapper.FAILURE_STATUS, publicIpInstance.getCloudState());
     }
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -47,7 +47,8 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         this.testUtils.mockReadOrdersFromDataBase();
     }
 
-    // TODO(chico) - add "test case" description
+    // test case: When calling the doGetInstance method with secondary methods mocked and the
+    // asynchronous request instance is ready, it must verify if It returns the publicIpInstance ready.
     @Test
     public void testDoGetInstanceWhenIsReady() throws FogbowException {
         // set up
@@ -65,20 +66,22 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         Assert.assertEquals(CloudStackStateMapper.READY_STATUS, publicIpInstance.getCloudState());
     }
 
-    // TODO(chico) - add "test case" description
+    // test case: When calling the doGetInstance method with secondary methods mocked and the
+    // asynchronous request instance is neither ready or failed, it must verify if It returns
+    // the current publicIpInstance returned by the buildCurrentPublicIpInstance.
     @Test
     public void testDoGetInstanceWhenIsNotReady() throws FogbowException {
         // set up
         PublicIpOrder publicIpOrder = Mockito.mock(PublicIpOrder.class);
         String instanceId = "instanceId";
         Mockito.when(publicIpOrder.getId()).thenReturn(instanceId);
-        AsyncRequestInstanceState asyncRequestInstanceStateReady = new AsyncRequestInstanceState(
+        AsyncRequestInstanceState asyncRequestInstanceStateNotReady = new AsyncRequestInstanceState(
                 AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE, null, null);
-        this.asyncRequestInstanceStateMapMockEmpty.put(instanceId, asyncRequestInstanceStateReady);
+        this.asyncRequestInstanceStateMapMockEmpty.put(instanceId, asyncRequestInstanceStateNotReady);
 
         PublicIpInstance publicIpInstanceExcepted = Mockito.mock(PublicIpInstance.class);
         Mockito.doReturn(publicIpInstanceExcepted).when(this.plugin).buildCurrentPublicIpInstance(
-                Mockito.eq(publicIpOrder), Mockito.eq(this.cloudStackUser));
+                Mockito.eq(asyncRequestInstanceStateNotReady), Mockito.eq(publicIpOrder), Mockito.eq(this.cloudStackUser));
 
         // exercise
         PublicIpInstance publicIpInstance = this.plugin.doGetInstance(publicIpOrder, this.cloudStackUser);
@@ -87,7 +90,9 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         Assert.assertEquals(publicIpInstanceExcepted, publicIpInstance);
     }
 
-    // TODO(chico) - add "test case" description
+    // test case: When calling the doGetInstance method with secondary methods mocked and the
+    // asynchronous request instance is null because a memory lost, it must verify if It returns
+    // the current publicIpInstance failure.
     @Test
     public void testDoGetInstanceFailWhenThereMemoryLost() throws FogbowException {
         // set up

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -64,6 +64,114 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         this.testUtils.mockReadOrdersFromDataBase();
     }
 
+    // test case: When calling the buildNextOperationPublicIpInstance method with secondary methods mocked
+    // and the current state is Ready, it must verify if It returns null.
+    @Test
+    public void testBuildNextOperationPublicIpInstanceFail() throws FogbowException {
+        // set up
+        AsyncRequestInstanceState asyncRequestInstanceState = Mockito.mock(AsyncRequestInstanceState.class);
+        AsyncRequestInstanceState.StateType state = AsyncRequestInstanceState.StateType.READY;
+        Mockito.when(asyncRequestInstanceState.getState()).thenReturn(state);
+        String jsonResponse = "jsonResponse";
+
+        Mockito.doNothing().when(this.plugin).finishAsyncRequestInstanceSteps(
+                Mockito.eq(asyncRequestInstanceState));
+
+        PublicIpInstance publicIpInstanceExpected = Mockito.mock(PublicIpInstance.class);
+        Mockito.doReturn(publicIpInstanceExpected).when(this.plugin).buildReadyPublicIpInstance(
+                Mockito.eq(asyncRequestInstanceState));
+
+        // exercise
+        PublicIpInstance publicIpInstance = this.plugin.buildNextOperationPublicIpInstance(
+                asyncRequestInstanceState, this.cloudStackUser, jsonResponse);
+
+        // verify
+        Assert.assertNull(publicIpInstance);
+    }
+
+    // test case: When calling the buildNextOperationPublicIpInstance method with secondary methods mocked
+    // and the current state is CreatingFirewall, it must verify if It returns the PublicIpInstance by the
+    // buildReadyPublicIpInstance method.
+    @Test
+    public void testBuildNextOperationPublicIpInstanceWhenCreatingFirewallState() throws FogbowException {
+        // set up
+        AsyncRequestInstanceState asyncRequestInstanceState = Mockito.mock(AsyncRequestInstanceState.class);
+        AsyncRequestInstanceState.StateType state = AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE;
+        Mockito.when(asyncRequestInstanceState.getState()).thenReturn(state);
+        String jsonResponse = "jsonResponse";
+
+        Mockito.doNothing().when(this.plugin).finishAsyncRequestInstanceSteps(
+                Mockito.eq(asyncRequestInstanceState));
+
+        PublicIpInstance publicIpInstanceExpected = Mockito.mock(PublicIpInstance.class);
+        Mockito.doReturn(publicIpInstanceExpected).when(this.plugin).buildReadyPublicIpInstance(
+                Mockito.eq(asyncRequestInstanceState));
+
+        // exercise
+        PublicIpInstance publicIpInstance = this.plugin.buildNextOperationPublicIpInstance(
+                asyncRequestInstanceState, this.cloudStackUser, jsonResponse);
+
+        // verify
+        Assert.assertEquals(publicIpInstanceExpected, publicIpInstance);
+    }
+
+    // test case: When calling the buildNextOperationPublicIpInstance method with secondary methods mocked
+    // and the current state is AssociateIp but occurs a FogbowException, it must verify if It throws
+    // a FogbowException.
+    @Test
+    public void testBuildNextOperationPublicIpInstanceFailWhenAssociateIpState() throws FogbowException {
+        // set up
+        AsyncRequestInstanceState asyncRequestInstanceState = Mockito.mock(AsyncRequestInstanceState.class);
+        AsyncRequestInstanceState.StateType state = AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS;
+        Mockito.when(asyncRequestInstanceState.getState()).thenReturn(state);
+        String jsonResponse = "jsonResponse";
+
+        Mockito.doNothing().when(this.plugin).doCreatingFirewallOperation(
+                Mockito.eq(asyncRequestInstanceState), Mockito.eq(this.cloudStackUser), Mockito.eq(jsonResponse));
+
+        Mockito.doThrow(new FogbowException()).when(this.plugin).buildCreatingFirewallPublicIpInstance(
+                Mockito.eq(asyncRequestInstanceState));
+
+        // verify
+        this.expectedException.expect(FogbowException.class);
+
+        // exercise
+        this.plugin.buildNextOperationPublicIpInstance(
+                asyncRequestInstanceState, this.cloudStackUser, jsonResponse);
+    }
+
+    // test case: When calling the buildNextOperationPublicIpInstance method with secondary methods mocked
+    // and the current state is AssociateIp, it must verify if It returns the PublicIpInstance by the
+    // buildCreatingFirewallPublicIpInstance method.
+    @Test
+    public void testBuildNextOperationPublicIpInstanceWhenAssociateIpState() throws FogbowException {
+        // set up
+        AsyncRequestInstanceState asyncRequestInstanceState = Mockito.mock(AsyncRequestInstanceState.class);
+        AsyncRequestInstanceState.StateType state = AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS;
+        Mockito.when(asyncRequestInstanceState.getState()).thenReturn(state);
+        String jsonResponse = "jsonResponse";
+
+        Mockito.doNothing().when(this.plugin).doCreatingFirewallOperation(
+                Mockito.eq(asyncRequestInstanceState), Mockito.eq(this.cloudStackUser), Mockito.eq(jsonResponse));
+
+        PublicIpInstance publicIpInstanceExpected = Mockito.mock(PublicIpInstance.class);
+        Mockito.doReturn(publicIpInstanceExpected).when(this.plugin).buildCreatingFirewallPublicIpInstance(
+                Mockito.eq(asyncRequestInstanceState));
+
+        // exercise
+        PublicIpInstance publicIpInstance = this.plugin.buildNextOperationPublicIpInstance(
+                asyncRequestInstanceState, this.cloudStackUser, jsonResponse);
+
+        // verify
+        Assert.assertEquals(publicIpInstanceExpected, publicIpInstance);
+    }
+
+    // TODO(chico) - Implement
+    @Test
+    public void testBuildCurrentPublicIpInstanceFailWhenUnexpected() throws FogbowException {
+        Assert.fail();
+    }
+
     // test case: When calling the buildCurrentPublicIpInstance method with secondary methods mocked
     // and occurs an exception, it must verify if It throws a FogbowException.
     @Test

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -1,0 +1,40 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.CloudStackUser;
+import cloud.fogbow.common.util.PropertiesUtil;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackHttpClient;
+import cloud.fogbow.ras.core.BaseUnitTests;
+import cloud.fogbow.ras.core.datastore.DatabaseManager;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackCloudUtils;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.junit.Before;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+
+import java.util.Properties;
+
+@PrepareForTest({DatabaseManager.class})
+public class CloudStackPublicIpPluginTest extends BaseUnitTests {
+
+    private CloudStackPublicIpPlugin plugin;
+    private CloudStackHttpClient client;
+    private CloudStackUser cloudStackUser;
+    private String cloudStackUrl;
+
+    @Before
+    public void setUp() throws UnexpectedException {
+        String cloudStackConfFilePath = CloudstackTestUtils.CLOUDSTACK_CONF_FILE_PATH;
+        Properties properties = PropertiesUtil.readProperties(cloudStackConfFilePath);
+
+        this.plugin = Mockito.spy(new CloudStackPublicIpPlugin(cloudStackConfFilePath));
+        this.client = Mockito.mock(CloudStackHttpClient.class);
+        this.plugin.setClient(this.client);
+
+        this.cloudStackUrl = properties.getProperty(CloudStackCloudUtils.CLOUDSTACK_URL_CONFIG);
+        this.cloudStackUser = CloudstackTestUtils.CLOUD_STACK_USER;
+
+        this.testUtils.mockReadOrdersFromDataBase();
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -69,6 +69,70 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         CloudstackTestUtils.ignoringCloudStackUrl();
     }
 
+    // test case: When calling the buildProcessingPublicIpInstance method, it must verify if It
+    // returns a right publicIpInstance.
+    @Test
+    public void testBuildProcessingPublicIpInstanceSuccessfully() {
+        // exercise
+        PublicIpInstance publicIpInstance = this.plugin.buildProcessingPublicIpInstance();
+
+        // verify
+        Assert.assertEquals(CloudStackStateMapper.PROCESSING_STATUS, publicIpInstance.getCloudState());
+    }
+
+    // test case: When calling the buildFailedPublicIpInstance method, it must verify if It
+    // returns a right publicIpInstance.
+    @Test
+    public void testBuildFailedPublicIpInstanceSuccessfully() {
+        // exercise
+        PublicIpInstance publicIpInstance = this.plugin.buildFailedPublicIpInstance();
+
+        // verify
+        Assert.assertEquals(CloudStackStateMapper.FAILURE_STATUS, publicIpInstance.getCloudState());
+    }
+
+    // test case: When calling the buildReadyPublicIpInstance method, it must verify if It
+    // returns a right publicIpInstance.
+    @Test
+    public void testBuildReadyPublicIpInstanceSuccessfully() {
+        // set up
+        String ipExpected = "ip";
+        String instanceIdExpected = "instanceId";
+        AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(null, null, null);
+        asyncRequestInstanceState.setIp(ipExpected);
+        asyncRequestInstanceState.setIpInstanceId(instanceIdExpected);
+
+        // exercise
+        PublicIpInstance publicIpInstance = this.plugin.
+                buildReadyPublicIpInstance(asyncRequestInstanceState);
+
+        // verify
+        Assert.assertEquals(CloudStackStateMapper.READY_STATUS, publicIpInstance.getCloudState());
+        Assert.assertEquals(ipExpected, publicIpInstance.getIp());
+        Assert.assertEquals(instanceIdExpected, publicIpInstance.getId());
+    }
+
+    // test case: When calling the buildCreatingFirewallPublicIpInstance method,
+    // it must verify if It returns a right publicIpInstance.
+    @Test
+    public void testBuildCreatingFirewallPublicIpInstanceSuccessfully() {
+        // set up
+        String ipExpected = "ip";
+        String instanceIdExpected = "instanceId";
+        AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(null, null, null);
+        asyncRequestInstanceState.setIp(ipExpected);
+        asyncRequestInstanceState.setIpInstanceId(instanceIdExpected);
+
+        // exercise
+        PublicIpInstance publicIpInstance = this.plugin.
+                buildCreatingFirewallPublicIpInstance(asyncRequestInstanceState);
+
+        // verify
+        Assert.assertEquals(CloudStackStateMapper.CREATING_FIREWALL_RULE_STATUS, publicIpInstance.getCloudState());
+        Assert.assertEquals(ipExpected, publicIpInstance.getIp());
+        Assert.assertEquals(instanceIdExpected, publicIpInstance.getId());
+    }
+
     // test case: When calling the doCreateFirewallRule method with secondary methods mocked,
     // it must verify if the requestCreateFirewallRule is called with the right parameters;
     // this includes the checking of the Cloudstack request.

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponseTest.java
@@ -1,0 +1,28 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class CreateFirewallRuleAsyncResponseTest {
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right CreateFirewallRuleAsyncResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String jobId = "1";
+        String firewallRuleAsyncResponseJson =
+                CloudstackTestUtils.createFirewallRuleAsyncResponseJson(jobId);
+
+        // execute
+        CreateFirewallRuleAsyncResponse createFirewallRuleAsyncResponse =
+                CreateFirewallRuleAsyncResponse.fromJson(firewallRuleAsyncResponseJson);
+
+        // verify
+        Assert.assertEquals(jobId, createFirewallRuleAsyncResponse.getJobId());
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequestTest.java
@@ -1,0 +1,71 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CreateFirewallRuleRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String cirdList = "cirdList";
+        String protocol = "protocol";
+        String startPort = "startPort";
+        String endPort = "endPort";
+        String ipAddressId = "ipAdressId";
+
+        String protocolStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.PROTOCOL_KEY_JSON, protocol);
+        String cirdListStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.CIDR_LIST_KEY_JSON, cirdList);
+        String startPortStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.STARTPORT_KEY_JSON, startPort);
+        String endPortStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.ENDPORT_KEY_JSON, endPort);
+        String ipAddressIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.IP_ADDRESS_ID_KEY_JSON, ipAddressId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                protocolStructureUrl,
+                startPortStructureUrl,
+                endPortStructureUrl,
+                ipAddressIdStructureUrl,
+                cirdListStructureUrl,
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        CreateFirewallRuleRequest createFirewallRuleRequest = new CreateFirewallRuleRequest.Builder()
+                .cidrList(cirdList)
+                .protocol(protocol)
+                .startPort(startPort)
+                .endPort(endPort)
+                .ipAddressId(ipAddressId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String associateIpAddressRequestUrl = createFirewallRuleRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, associateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new CreateFirewallRuleRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequestTest.java
@@ -1,0 +1,51 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DisassociateIpAddressRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.DISASSOCIATE_IP_ADDRESS_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String id = "id";
+
+        String idStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.ID_KEY_JSON, id);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                idStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        DisassociateIpAddressRequest disassociateIpAddressRequest = new DisassociateIpAddressRequest.Builder()
+                .id(id)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String disassociateIpAddressRequestUrl = disassociateIpAddressRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, disassociateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new DisassociateIpAddressRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequestTest.java
@@ -1,0 +1,56 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EnableStaticNatRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.ENABLE_STATIC_NAT_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String virtualMachineId = "virtualMachineId";
+        String ipAddressId = "ipAdressId";
+
+        String virtualMachineIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.VM_ID_KEY_JSON, virtualMachineId);
+        String ipAddressIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.IP_ADDRESS_ID_KEY_JSON, ipAddressId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                virtualMachineIdStructureUrl,
+                ipAddressIdStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        EnableStaticNatRequest enableStaticNatRequest = new EnableStaticNatRequest.Builder()
+                .virtualMachineId(virtualMachineId)
+                .ipAddressId(ipAddressId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String associateIpAddressRequestUrl = enableStaticNatRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, associateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new EnableStaticNatRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponseTest.java
@@ -1,0 +1,54 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpResponseException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+public class SuccessfulAssociateIpAddressResponseTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right SuccessfulAssociateIpAddressResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String id = "id";
+        String ipAddress = "ipAddress";
+        String asyncAssociateIpAddressResponseJson =
+                CloudstackTestUtils.createAsyncAssociateIpAddressResponseJson(id, ipAddress);
+
+        // execute
+        SuccessfulAssociateIpAddressResponse successfulAssociateIpAddressResponse =
+                SuccessfulAssociateIpAddressResponse.fromJson(asyncAssociateIpAddressResponseJson);
+
+        // verify
+        Assert.assertEquals(id, successfulAssociateIpAddressResponse.getIpAddress().getId());
+        Assert.assertEquals(ipAddress, successfulAssociateIpAddressResponse.getIpAddress().getIpAddress());
+    }
+
+    // test case: When calling the fromJson method with error json response,
+    // it must verify if It returns the rigth CloudStackErrorResponse.
+    @Test
+    public void testFromJsonFail() throws IOException {
+        // set up
+        String errorText = "anyString";
+        Integer errorCode = HttpStatus.SC_BAD_REQUEST;
+        String asyncAssociateIpAddressErrorResponseJson = CloudstackTestUtils
+                .createAsyncAssociateIpAddressErrorResponseJson(errorCode, errorText);
+
+        this.expectedException.expect(HttpResponseException.class);
+        this.expectedException.expectMessage(errorText);
+
+        // execute
+        SuccessfulAssociateIpAddressResponse.fromJson(asyncAssociateIpAddressErrorResponseJson);
+    }
+
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/associateipaddressresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/associateipaddressresponse.json
@@ -1,0 +1,5 @@
+{
+  "associateipaddressresponse": {
+    "jobid": "%s"
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
@@ -1,0 +1,5 @@
+{
+  "createfirewallruleresponse": {
+    "jobid": "%s"
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse.json
@@ -1,0 +1,10 @@
+{
+  "queryasyncjobresultresponse": {
+    "jobresult": {
+      "ipaddress": {
+        "id": "%s",
+        "ipaddress": "%s"
+      }
+    }
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse_error.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse_error.json
@@ -1,0 +1,8 @@
+{
+  "queryasyncjobresultresponse": {
+    "jobresult":{
+      "errorcode": %s,
+      "errortext": "%s"
+    }
+  }
+}


### PR DESCRIPTION
# Description
Refactoring the Cloudstack Public Ip Plugin context.
Note: I didn't touch in the architecture created previously related to the asynchronous request. I think It is not intuitive. Can you review and give your opinion?

# Proposed changes
- Refactoring "get Instance" tests context.

# Additional information
- This branch depends on a branch in the Fogbow Common (cloudstack-publicip-test-refator)

# PR Slices
[x] One: Refactoring in the Cloudstack Public IP Plugin
[x] Two: Refactoring "get Instance" tests context.
[] Three: Refactoring "request Instance" and "get Instance" tests context. 
[] Four: Implementing Cloudstack Requests and Responses tests.

# Reminding
PRs order:
develop < **PR1 < PR2** < PR3 < PR4