### PR TITLE
Cloudstack publicip test refactor pr three

### DIFF
--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -121,6 +121,8 @@ public class Messages {
         public static final String STARTING_THREADS = "Starting processor threads.";
         public static final String SUCCESS = "Successfully executed operation.";
         public static final String XMPP_HANDLERS_SET = "XMPP handlers set.";
+        public static final String ASYNCHRONOUS_PUBLIC_IP_STAGE =
+                "The asynchronous public ip request %s is in the stage %s.";
     }
 
     public static class Error {

--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -121,8 +121,8 @@ public class Messages {
         public static final String STARTING_THREADS = "Starting processor threads.";
         public static final String SUCCESS = "Successfully executed operation.";
         public static final String XMPP_HANDLERS_SET = "XMPP handlers set.";
-        public static final String ASYNCHRONOUS_PUBLIC_IP_STAGE =
-                "The asynchronous public ip request %s is in the stage %s.";
+        public static final String ASYNCHRONOUS_PUBLIC_IP_STATE =
+                "The asynchronous public ip request %s is in the state %s.";
     }
 
     public static class Error {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponse.java
@@ -1,7 +1,9 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 
 import cloud.fogbow.common.util.GsonHolder;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackErrorResponse;
 import com.google.gson.annotations.SerializedName;
+import org.apache.http.client.HttpResponseException;
 
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.ASSOCIATE_IP_ADDRESS_RESPONSE_KEY_JSON;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_KEY_JSON;
@@ -19,17 +21,20 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_
 public class AssociateIpAddressAsyncJobIdResponse {
 
     @SerializedName(ASSOCIATE_IP_ADDRESS_RESPONSE_KEY_JSON)
-    private AssociateIpAddressResponse associateIpAddressResponse;
+    private AssociateIpAddressResponse response;
 
     public String getJobId() {
-        return this.associateIpAddressResponse.getJobId();
+        return this.response.getJobId();
     }
 
-    public static AssociateIpAddressAsyncJobIdResponse fromJson(String json) {
-        return GsonHolder.getInstance().fromJson(json, AssociateIpAddressAsyncJobIdResponse.class);
+    public static AssociateIpAddressAsyncJobIdResponse fromJson(String json) throws HttpResponseException {
+        AssociateIpAddressAsyncJobIdResponse associateIpAddressAsyncJobIdResponse =
+                GsonHolder.getInstance().fromJson(json, AssociateIpAddressAsyncJobIdResponse.class);
+        associateIpAddressAsyncJobIdResponse.response.checkErrorExistence();
+        return associateIpAddressAsyncJobIdResponse;
     }
 
-    public class AssociateIpAddressResponse {
+    public class AssociateIpAddressResponse extends CloudStackErrorResponse {
 
         @SerializedName(JOB_ID_KEY_JSON)
         private String jobId;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponse.java
@@ -9,7 +9,7 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.ASSOCIA
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_KEY_JSON;
 
 /**
- * Documentation:
+ * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/associateIpAddress.html
  *
  * Response Example:
  * {
@@ -28,10 +28,7 @@ public class AssociateIpAddressAsyncJobIdResponse {
     }
 
     public static AssociateIpAddressAsyncJobIdResponse fromJson(String json) throws HttpResponseException {
-        AssociateIpAddressAsyncJobIdResponse associateIpAddressAsyncJobIdResponse =
-                GsonHolder.getInstance().fromJson(json, AssociateIpAddressAsyncJobIdResponse.class);
-        associateIpAddressAsyncJobIdResponse.response.checkErrorExistence();
-        return associateIpAddressAsyncJobIdResponse;
+        return GsonHolder.getInstance().fromJson(json, AssociateIpAddressAsyncJobIdResponse.class);
     }
 
     public class AssociateIpAddressResponse extends CloudStackErrorResponse {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequest.java
@@ -9,7 +9,7 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.NETWORK
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/associateIpAddress.html
  *
- * Request Example:
+ * Request Example: {url_cloudstack}?command=associateIpAddress&networkid={networkid}&apikey={apiKey}&secret_key={secretKey}
  */
 public class AssociateIpAddressRequest extends CloudStackRequest {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AsyncRequestInstanceState.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AsyncRequestInstanceState.java
@@ -3,6 +3,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 public class AsyncRequestInstanceState {
 
     private StateType state;
+    private String orderInstanceId;
     private String currentJobId;
     private String ip;
     private String ipInstanceId;
@@ -52,6 +53,14 @@ public class AsyncRequestInstanceState {
 
     public void setIpInstanceId(String ipInstanceId) {
         this.ipInstanceId = ipInstanceId;
+    }
+
+    public void setOrderInstanceId(String orderInstanceId) {
+        this.orderInstanceId = orderInstanceId;
+    }
+
+    public String getOrderInstanceId() {
+        return orderInstanceId;
     }
 
     public enum StateType {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -103,11 +103,19 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         }
         String ipAddressId = asyncRequestInstanceState.getIpInstanceId();
 
-        DisassociateIpAddressRequest disassociateIpAddressRequest = new DisassociateIpAddressRequest.Builder()
+        DisassociateIpAddressRequest request = new DisassociateIpAddressRequest.Builder()
                 .id(ipAddressId)
                 .build(this.cloudStackUrl);
 
-        URIBuilder uriRequest = disassociateIpAddressRequest.getUriBuilder();
+        requestDisassociateIpAddress(request, cloudStackUser);
+    }
+
+    @VisibleForTesting
+    void requestDisassociateIpAddress(@NotNull DisassociateIpAddressRequest request,
+                                      @NotNull CloudStackUser cloudStackUser)
+            throws FogbowException {
+
+        URIBuilder uriRequest = request.getUriBuilder();
         CloudStackUrlUtil.sign(uriRequest, cloudStackUser.getToken());
 
         try {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -184,7 +184,6 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
                 }
             case CloudStackQueryJobResult.FAILURE:
                 try {
-                    // any failure should lead to a disassociation of the ip address
                     doDeleteInstance(publicIpOrder, cloudStackUser);
                 } catch (FogbowException e) {
                     LOGGER.error(String.format(Messages.Error.ERROR_WHILE_REMOVING_RESOURCE,
@@ -242,8 +241,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     /**
-     * Set the asynchronous request instance to the first stage; This stage consist of
-     * wait the asynchronous Associating Ip Address Operation finish in the Cloudstack.
+     * Set the asynchronous request instance to the first step; This step consist of
+     * wait the asynchronous Associating Ip Address Operation finishes in the Cloudstack.
      */
     @VisibleForTesting
     void setAsyncRequestInstanceFirstStep(String jobId, @NotNull PublicIpOrder publicIpOrder) {
@@ -253,13 +252,13 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
                 AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS, jobId, computeId);
         asyncRequestInstanceState.setOrderInstanceId(instanceId);
         this.asyncRequestInstanceStateMap.put(instanceId, asyncRequestInstanceState);
-        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 instanceId, AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS));
     }
 
     /**
-     * Set the asynchronous request instance to the second stage; This stage consist of
-     * wait the asynchronous Create Firewall Operation finish in the Cloudstack.
+     * Set the asynchronous request instance to the second step; This step consist of
+     * wait the asynchronous Create Firewall Operation finishes in the Cloudstack.
      */
     @VisibleForTesting
     void setAsyncRequestInstanceSecondStep(@NotNull SuccessfulAssociateIpAddressResponse response,
@@ -274,15 +273,18 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         asyncRequestInstanceState.setIp(ip);
         asyncRequestInstanceState.setCurrentJobId(createFirewallRuleJobId);
         asyncRequestInstanceState.setState(AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE);
-        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 asyncRequestInstanceState.getOrderInstanceId(),
                 AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE));
     }
 
+    /**
+     * Finish the cycle and set as Ready the asynchronous request instance.
+     */
     @VisibleForTesting
     void finishAsyncRequestInstanceSteps(@NotNull AsyncRequestInstanceState asyncRequestInstanceState) {
         asyncRequestInstanceState.setState(AsyncRequestInstanceState.StateType.READY);
-        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 asyncRequestInstanceState.getOrderInstanceId(), AsyncRequestInstanceState.StateType.READY));
     }
 
@@ -428,7 +430,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     void setAsyncRequestInstanceStateMap(
             Map<String, AsyncRequestInstanceState> asyncRequestInstanceStateMap) {
 
-        CloudStackPublicIpPlugin.asyncRequestInstanceStateMap = asyncRequestInstanceStateMap;
+        this.asyncRequestInstanceStateMap = asyncRequestInstanceStateMap;
     }
 
     // TODO(chico) - This method will be removed after the Cloudstack Security Rule PR is accepted.

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -227,14 +227,18 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
                                      String jsonResponse)
             throws FogbowException {
 
-        SuccessfulAssociateIpAddressResponse response =
-                SuccessfulAssociateIpAddressResponse.fromJson(jsonResponse);
+        try {
+            SuccessfulAssociateIpAddressResponse response =
+                    SuccessfulAssociateIpAddressResponse.fromJson(jsonResponse);
 
-        doEnableStaticNat(response, asyncRequestInstanceState, cloudStackUser);
+            doEnableStaticNat(response, asyncRequestInstanceState, cloudStackUser);
 
-        String createFirewallRuleJobId = doCreateFirewallRule(response, cloudStackUser);
+            String createFirewallRuleJobId = doCreateFirewallRule(response, cloudStackUser);
 
-        setAsyncRequestInstanceSecondStep(response, asyncRequestInstanceState, createFirewallRuleJobId);
+            setAsyncRequestInstanceSecondStep(response, asyncRequestInstanceState, createFirewallRuleJobId);
+        } catch (HttpResponseException e) {
+            throw CloudStackHttpToFogbowExceptionMapper.get(e);
+        }
     }
 
     /**
@@ -279,8 +283,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     void finishAsyncRequestInstanceSteps(@NotNull AsyncRequestInstanceState asyncRequestInstanceState) {
         asyncRequestInstanceState.setState(AsyncRequestInstanceState.StateType.READY);
         LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
-                asyncRequestInstanceState.getOrderInstanceId(),
-                AsyncRequestInstanceState.StateType.READY));
+                asyncRequestInstanceState.getOrderInstanceId(), AsyncRequestInstanceState.StateType.READY));
     }
 
     @NotNull

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -247,7 +247,10 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         String instanceId = getInstanceId(publicIpOrder);
         AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(
                 AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS, jobId, computeId);
+        asyncRequestInstanceState.setOrderInstanceId(instanceId);
         this.asyncRequestInstanceStateMap.put(instanceId, asyncRequestInstanceState);
+        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+                instanceId, AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS));
     }
 
     /**
@@ -267,11 +270,17 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         asyncRequestInstanceState.setIp(ip);
         asyncRequestInstanceState.setCurrentJobId(createFirewallRuleJobId);
         asyncRequestInstanceState.setState(AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE);
+        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+                asyncRequestInstanceState.getOrderInstanceId(),
+                AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE));
     }
 
     @VisibleForTesting
     void finishAsyncRequestInstanceSteps(@NotNull AsyncRequestInstanceState asyncRequestInstanceState) {
         asyncRequestInstanceState.setState(AsyncRequestInstanceState.StateType.READY);
+        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+                asyncRequestInstanceState.getOrderInstanceId(),
+                AsyncRequestInstanceState.StateType.READY));
     }
 
     @NotNull

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
@@ -6,6 +6,16 @@ import com.google.gson.annotations.SerializedName;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_RESPONSE;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_KEY_JSON;
 
+/**
+ * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
+ *
+ * Response Example:
+ * {
+ *   "createfirewallruleresponse":{
+ *     "jobid":"7568bb4f-d925-437e-80b0-b2d984d225d4"
+ *   }
+ * }
+ */
 public class CreateFirewallRuleAsyncResponse {
 
     @SerializedName(CREATE_FIREWALL_RULE_RESPONSE)
@@ -16,9 +26,7 @@ public class CreateFirewallRuleAsyncResponse {
     }
 
     public static CreateFirewallRuleAsyncResponse fromJson(String json) {
-        CreateFirewallRuleAsyncResponse createFirewallRuleAsyncResponse =
-                GsonHolder.getInstance().fromJson(json, CreateFirewallRuleAsyncResponse.class);
-        return createFirewallRuleAsyncResponse;
+        return GsonHolder.getInstance().fromJson(json, CreateFirewallRuleAsyncResponse.class);
     }
 
     private class CreateFirewallRuleResponse {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
@@ -16,7 +16,9 @@ public class CreateFirewallRuleAsyncResponse {
     }
 
     public static CreateFirewallRuleAsyncResponse fromJson(String json) {
-        return GsonHolder.getInstance().fromJson(json, CreateFirewallRuleAsyncResponse.class);
+        CreateFirewallRuleAsyncResponse createFirewallRuleAsyncResponse =
+                GsonHolder.getInstance().fromJson(json, CreateFirewallRuleAsyncResponse.class);
+        return createFirewallRuleAsyncResponse;
     }
 
     private class CreateFirewallRuleResponse {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -8,11 +8,10 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
  * <p>
- * Request Example:
+ * Request Example: {url_cloudstack}?command=createFirewallRule&protocol={protocol}&startport={startport} /
+ *  * &endport={endport}&ipaddressid={ipaddressid}&cidrlist={cidrlist}&apikey={apiKey}&secret_key={secretKey}
  */
 public class CreateFirewallRuleRequest extends CloudStackRequest {
-
-    public static final String CREATE_FIREWALL_RULE_COMMAND = "createFirewallRule";
 
     protected CreateFirewallRuleRequest(Builder builder) throws InvalidParameterException {
         super(builder.cloudStackUrl);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequest.java
@@ -3,17 +3,15 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
+import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.DISASSOCIATE_IP_ADDRESS_COMMAND;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.ID_KEY_JSON;
 
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/disassociateIpAddress.html
  * 
- * Request Example: 
- *
+ * Request Example: {url_cloudstack}?command=disassociateIpAddress&id={id}&apikey={apiKey}&secret_key={secretKey}
  */	
 public class DisassociateIpAddressRequest extends CloudStackRequest {
-
-	public static final String DISASSOCIATE_IP_ADDRESS_COMMAND = "disassociateIpAddress";
 
 	protected DisassociateIpAddressRequest(Builder builder) throws InvalidParameterException {
 		super(builder.cloudStackUrl);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequest.java
@@ -8,7 +8,8 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/enableStaticNat.html
  * <p>
- * Request Example:
+ * Request Example: {url_cloudstack}?command=enableStaticNat&virtualmachineid={virtualmachineid} /
+ * &ipaddressid={ipaddressid}&apikey={apiKey}&secret_key={secretKey}
  */
 public class EnableStaticNatRequest extends CloudStackRequest {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponse.java
@@ -1,7 +1,9 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 
 import cloud.fogbow.common.util.GsonHolder;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackErrorResponse;
 import com.google.gson.annotations.SerializedName;
+import org.apache.http.client.HttpResponseException;
 
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 
@@ -31,11 +33,14 @@ public class SuccessfulAssociateIpAddressResponse {
 		return this.response.jobResult.ipAddress;
 	}
 	
-    public static SuccessfulAssociateIpAddressResponse fromJson(String json) {
-        return GsonHolder.getInstance().fromJson(json, SuccessfulAssociateIpAddressResponse.class);
+    public static SuccessfulAssociateIpAddressResponse fromJson(String json) throws HttpResponseException {
+        SuccessfulAssociateIpAddressResponse successfulAssociateIpAddressResponse =
+                GsonHolder.getInstance().fromJson(json, SuccessfulAssociateIpAddressResponse.class);
+        successfulAssociateIpAddressResponse.response.checkErrorExistence();
+        return successfulAssociateIpAddressResponse;
     }
 
-    private class QueryAsyncJobResultResponse {
+    private class QueryAsyncJobResultResponse extends CloudStackErrorResponse {
 
         @SerializedName(JOB_STATUS_KEY_JSON)
         private int jobStatus;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponse.java
@@ -11,7 +11,6 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/associateIpAddress.html
  * 
  * Response Example: 
- *
  *{
  *  "queryasyncjobresultresponse":{
  *     "jobresult":{
@@ -22,7 +21,6 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
  *     }
  *   }
  * }
- *
  */
 public class SuccessfulAssociateIpAddressResponse {
 
@@ -36,11 +34,11 @@ public class SuccessfulAssociateIpAddressResponse {
     public static SuccessfulAssociateIpAddressResponse fromJson(String json) throws HttpResponseException {
         SuccessfulAssociateIpAddressResponse successfulAssociateIpAddressResponse =
                 GsonHolder.getInstance().fromJson(json, SuccessfulAssociateIpAddressResponse.class);
-        successfulAssociateIpAddressResponse.response.checkErrorExistence();
+        successfulAssociateIpAddressResponse.response.jobResult.checkErrorExistence();
         return successfulAssociateIpAddressResponse;
     }
 
-    private class QueryAsyncJobResultResponse extends CloudStackErrorResponse {
+    private class QueryAsyncJobResultResponse {
 
         @SerializedName(JOB_STATUS_KEY_JSON)
         private int jobStatus;
@@ -50,7 +48,7 @@ public class SuccessfulAssociateIpAddressResponse {
 
     }
 
-    private class JobResult {
+    private class JobResult extends CloudStackErrorResponse {
 
         @SerializedName(IP_ADDRESS_KEY_JSON)
         private IpAddress ipAddress;

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
@@ -56,6 +56,11 @@ public class CloudstackTestUtils {
     private static final String LIST_TEMPLATES_RESPONSE = "listtemplatesresponse.json";
     private static final String LIST_TEMPLATES_ERROR_RESPONSE = "listtemplatesresponse_error.json";
     private static final String LIST_TEMPLATES_EMPTY_RESPONSE = "listtemplatesresponse_empty.json";
+    private static final String ASSOCIATE_IP_ADDRESS_RESPONSE = "associateipaddressresponse.json";
+    private static final String CREATE_FIREWALL_RULE_ADDRESS_RESPONSE = "createfirewallruleresponse.json";
+    private static final String ASYNC_ASSOCIATE_IP_ADDRESS_RESPONSE = "queryasyncassociateipaddressresponse.json";
+    private static final String ASYNC_ASSOCIATE_IP_ADDRESS_ERROR_RESPONSE =
+            "queryasyncassociateipaddressresponse_error.json";
 
     public static final CloudStackUser CLOUD_STACK_USER =
             new CloudStackUser("id", "", "", "", new HashMap<>());
@@ -324,6 +329,42 @@ public class CloudstackTestUtils {
                 + LIST_TEMPLATES_ERROR_RESPONSE);
 
         return String.format(rawJson, errorCode, errorText);
+    }
+
+    public static String createAssociateIpAddressAsyncResponseJson(String jobId)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + ASSOCIATE_IP_ADDRESS_RESPONSE);
+
+        return String.format(rawJson, jobId);
+    }
+
+    public static String createFirewallRuleAsyncResponseJson(String jobId)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + CREATE_FIREWALL_RULE_ADDRESS_RESPONSE);
+
+        return String.format(rawJson, jobId);
+    }
+
+    public static String createAsyncAssociateIpAddressErrorResponseJson(int errorCode, String errorText)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + ASYNC_ASSOCIATE_IP_ADDRESS_ERROR_RESPONSE);
+
+        return String.format(rawJson, errorCode, errorText);
+    }
+
+    public static String createAsyncAssociateIpAddressResponseJson(String id, String idAddress)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + ASYNC_ASSOCIATE_IP_ADDRESS_RESPONSE);
+
+        return String.format(rawJson, id, idAddress);
     }
 
     private static String readFileAsString(final String fileName) throws IOException {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
@@ -12,6 +12,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.Cr
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.DeleteNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.GetNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.DisassociateIpAddressRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.EnableStaticNatRequest;
 import org.mockito.ArgumentMatcher;
 
@@ -108,4 +109,9 @@ public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher
         }
     }
 
+    public static class DisassociateIpAddress extends RequestMatcher<DisassociateIpAddressRequest> {
+        public DisassociateIpAddress(CloudStackRequest cloudStackRequest) {
+            super(cloudStackRequest);
+        }
+    }
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
@@ -11,6 +11,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.image.v4_9.GetA
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.CreateNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.DeleteNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.GetNetworkRequest;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.AssociateIpAddressRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.DisassociateIpAddressRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.EnableStaticNatRequest;
@@ -114,4 +115,11 @@ public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher
             super(cloudStackRequest);
         }
     }
+
+    public static class AssociateIpAddress extends RequestMatcher<AssociateIpAddressRequest> {
+        public AssociateIpAddress(CloudStackRequest cloudStackRequest) {
+            super(cloudStackRequest);
+        }
+    }
+
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponseTest.java
@@ -1,0 +1,28 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AssociateIpAddressAsyncJobIdResponseTest {
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right AssociateIpAddressAsyncJobIdResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String jobId = "1";
+        String associateIpAddressAsyncResponseJson =
+                CloudstackTestUtils.createAssociateIpAddressAsyncResponseJson(jobId);
+
+        // execute
+        AssociateIpAddressAsyncJobIdResponse associateIpAddressAsyncJobIdResponse =
+                AssociateIpAddressAsyncJobIdResponse.fromJson(associateIpAddressAsyncResponseJson);
+
+        // verify
+        Assert.assertEquals(jobId, associateIpAddressAsyncJobIdResponse.getJobId());
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequestTest.java
@@ -1,0 +1,51 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AssociateIpAddressRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.ASSOCIATE_IP_ADDRESS_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String networkId = "networkId";
+
+        String networkIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.NETWORK_ID_KEY_JSON, networkId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                networkIdStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        AssociateIpAddressRequest associateIpAddressRequest = new AssociateIpAddressRequest.Builder()
+                .networkId(networkId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String associateIpAddressRequestUrl = associateIpAddressRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, associateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new AssociateIpAddressRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -23,7 +23,10 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackState
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.RequestMatcher;
 import org.apache.http.client.HttpResponseException;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 import org.mockito.internal.verification.VerificationModeFactory;
@@ -84,7 +87,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         Mockito.when(publicIpOrder.getComputeId()).thenReturn(computeIdExpected);
         String jobId = "jobId";
 
-        String messageExpected = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        String messageExpected = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 instanceIdExpected, AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS);
 
         // verify before
@@ -157,7 +160,8 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestIpAddressAssociationFail() throws FogbowException, HttpResponseException {
         // set up
-        AssociateIpAddressRequest request = new AssociateIpAddressRequest.Builder().build("");
+        AssociateIpAddressRequest request = new AssociateIpAddressRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
@@ -176,14 +180,15 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestIpAddressAssociationSuccessfully() throws FogbowException, HttpResponseException {
         // set up
-        AssociateIpAddressRequest request = new AssociateIpAddressRequest.Builder().build("");
+        AssociateIpAddressRequest request = new AssociateIpAddressRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
-        String jsonResponse = "anything";
+        String jsonResponse = TestUtils.ANY_VALUE;
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
                 thenReturn(jsonResponse);
 
-        String jobIdExpected = "jobId";
+        String jobIdExpected = "jobIdExpected";
         AssociateIpAddressAsyncJobIdResponse response = Mockito.mock(AssociateIpAddressAsyncJobIdResponse.class);
         Mockito.when(response.getJobId()).thenReturn(jobIdExpected);
         PowerMockito.mockStatic(AssociateIpAddressAsyncJobIdResponse.class);
@@ -202,7 +207,8 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestDisassociateIpAddressFail() throws FogbowException, HttpResponseException {
         // set up
-        DisassociateIpAddressRequest request = new DisassociateIpAddressRequest.Builder().build("");
+        DisassociateIpAddressRequest request = new DisassociateIpAddressRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
@@ -221,11 +227,12 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestDisassociateIpAddressSuccessfully() throws FogbowException, HttpResponseException {
         // set up
-        DisassociateIpAddressRequest request = new DisassociateIpAddressRequest.Builder().build("");
+        DisassociateIpAddressRequest request = new DisassociateIpAddressRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
-                thenReturn("");
+                thenReturn(TestUtils.EMPTY_STRING);
 
         // exercise
         this.plugin.requestDisassociateIpAddress(request, this.cloudStackUser);
@@ -317,7 +324,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         // set up
         AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(null, null , null);
 
-        String messageExpected = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        String messageExpected = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 asyncRequestInstanceState.getOrderInstanceId(),
                 AsyncRequestInstanceState.StateType.READY);
 
@@ -350,7 +357,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(null, null , null);
         String createFirewallRuleJobId = "jobId";
 
-        String messageExpexted = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        String messageExpexted = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 asyncRequestInstanceState.getOrderInstanceId(),
                 AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE);
 
@@ -377,7 +384,8 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestCreateFirewallRuleFail() throws FogbowException, HttpResponseException {
         // set up
-        CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder().build("");
+        CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
@@ -396,9 +404,10 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestCreateFirewallRuleSuccessfully() throws FogbowException, HttpResponseException {
         // set up
-        CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder().build("");
+        CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
-        String jsonResponse = "";
+        String jsonResponse = TestUtils.ANY_VALUE;
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(
                 Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(jsonResponse);
@@ -425,7 +434,8 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestEnableStaticNatFail() throws FogbowException, HttpResponseException {
         // set up
-        EnableStaticNatRequest request = new EnableStaticNatRequest.Builder().build("");
+        EnableStaticNatRequest request = new EnableStaticNatRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
@@ -444,11 +454,11 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestEnableStaticNatSuccessfully() throws FogbowException, HttpResponseException {
         // set up
-        EnableStaticNatRequest request = new EnableStaticNatRequest.Builder().build("");
+        EnableStaticNatRequest request = new EnableStaticNatRequest.Builder().build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(
-                Mockito.any(), Mockito.any(), Mockito.any())).thenReturn("");
+                Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(TestUtils.EMPTY_STRING);
 
         // exercise
         this.plugin.requestEnableStaticNat(request, this.cloudStackUser);
@@ -536,7 +546,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         SuccessfulAssociateIpAddressResponse response = Mockito.mock(SuccessfulAssociateIpAddressResponse.class);
         Mockito.when(response.getIpAddress()).thenReturn(ipAddress);
 
-        String jobIdExpected = "jobId";
+        String jobIdExpected = "jobIdExpected";
         Mockito.doReturn(jobIdExpected).when(this.plugin).requestCreateFirewallRule(Mockito.any(), Mockito.any());
 
         CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder()
@@ -587,9 +597,27 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
                 .requestEnableStaticNat(Mockito.argThat(matcher), Mockito.eq(this.cloudStackUser));
     }
 
-    @Ignore
+    // test case: When calling the doCreatingFirewallOperation method with secondary methods mocked
+    // and It occurs a HttpResponseException. it must verify if It throws a FogbowException.
     @Test
-    public void testDoCreatingFirewallOperationFailWhenThrowHttpResponseExeption() {}
+    public void testDoCreatingFirewallOperationFailWhenThrowHttpResponseExeption()
+            throws FogbowException, HttpResponseException {
+
+        // set up
+        AsyncRequestInstanceState asyncRequestInstanceState = Mockito.mock(AsyncRequestInstanceState.class);
+        String jsonResponse = "jsonResponse";
+
+        PowerMockito.mockStatic(SuccessfulAssociateIpAddressResponse.class);
+        PowerMockito.when(SuccessfulAssociateIpAddressResponse.fromJson(Mockito.eq(jsonResponse))).
+                thenThrow(CloudstackTestUtils.createBadRequestHttpResponse());
+
+        // verify
+        this.expectedException.expect(FogbowException.class);
+        this.expectedException.expectMessage(CloudstackTestUtils.BAD_REQUEST_MSG);
+
+        // exercise
+        this.plugin.doCreatingFirewallOperation(asyncRequestInstanceState, this.cloudStackUser, jsonResponse);
+    }
 
     // test case: When calling the doCreatingFirewallOperation method with secondary methods mocked
     // and It occurs a FogbowException. it must verify if It throws the same exception.

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -44,7 +44,7 @@ import static cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip
         CreateFirewallRuleAsyncResponse.class, AssociateIpAddressAsyncJobIdResponse.class})
 public class CloudStackPublicIpPluginTest extends BaseUnitTests {
 
-    private final int FIRST_POSITION = 1;
+    private final int FIRST_POSITION_LOG = 1;
 
     @Rule
     private ExpectedException expectedException = ExpectedException.none();
@@ -87,6 +87,9 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         Mockito.when(publicIpOrder.getComputeId()).thenReturn(computeIdExpected);
         String jobId = "jobId";
 
+        String messageExpected = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+                instanceIdExpected, AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS);
+
         // verify before
         AsyncRequestInstanceState asyncRequestInstanceState = this.asyncRequestInstanceStateMapMocked.get(instanceIdExpected);
         Assert.assertNull(asyncRequestInstanceState);
@@ -100,6 +103,8 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
                 asyncRequestInstanceState.getState());
         Assert.assertEquals(jobId, asyncRequestInstanceState.getCurrentJobId());
         Assert.assertEquals(computeIdExpected, asyncRequestInstanceState.getComputeInstanceId());
+        Assert.assertEquals(instanceIdExpected, asyncRequestInstanceState.getOrderInstanceId());
+        this.loggerTestChecking.assertEquals(FIRST_POSITION_LOG, Level.INFO, messageExpected);
     }
 
     // test case: When calling the doRequestInstance method and occurs any exception,
@@ -315,6 +320,10 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         // set up
         AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(null, null , null);
 
+        String messageExpected = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+                asyncRequestInstanceState.getOrderInstanceId(),
+                AsyncRequestInstanceState.StateType.READY);
+
         // verify before
         Assert.assertNull(asyncRequestInstanceState.getState());
 
@@ -323,6 +332,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
 
         // verify after
         Assert.assertEquals(AsyncRequestInstanceState.StateType.READY, asyncRequestInstanceState.getState());
+        this.loggerTestChecking.assertEquals(FIRST_POSITION_LOG, Level.INFO, messageExpected);
     }
 
     // test case: When calling the setAsyncRequestInstanceSecondStep method, it must verify if It
@@ -343,6 +353,10 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(null, null , null);
         String createFirewallRuleJobId = "jobId";
 
+        String messageExpexted = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+                asyncRequestInstanceState.getOrderInstanceId(),
+                AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE);
+
         // verify before
         Assert.assertNull(asyncRequestInstanceState.getIpInstanceId());
         Assert.assertNull(asyncRequestInstanceState.getIp());
@@ -358,6 +372,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         Assert.assertEquals(AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE,
                 asyncRequestInstanceState.getState());
         Assert.assertEquals(createFirewallRuleJobId, asyncRequestInstanceState.getCurrentJobId());
+        this.loggerTestChecking.assertEquals(FIRST_POSITION_LOG, Level.INFO, messageExpexted);
     }
 
     // test case: When calling the requestCreateFirewallRule method and occurs a HttpResponseException,
@@ -758,7 +773,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
 
         // verify
         Assert.assertNull(publicIpInstance);
-        this.loggerTestChecking.assertEquals(FIRST_POSITION, Level.ERROR, Messages.Error.UNEXPECTED_JOB_STATUS);
+        this.loggerTestChecking.assertEquals(FIRST_POSITION_LOG, Level.ERROR, Messages.Error.UNEXPECTED_JOB_STATUS);
     }
 
     // test case: When calling the buildCurrentPublicIpInstance method with secondary methods mocked
@@ -823,7 +838,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         Assert.assertEquals(CloudStackStateMapper.FAILURE_STATUS, publicIpInstance.getCloudState());
         String errorExpected = String.format(Messages.Error.ERROR_WHILE_REMOVING_RESOURCE,
                 PUBLIC_IP_RESOURCE, publicIpOrder.getInstanceId());
-        this.loggerTestChecking.assertEquals(FIRST_POSITION, Level.ERROR, errorExpected);
+        this.loggerTestChecking.assertEquals(FIRST_POSITION_LOG, Level.ERROR, errorExpected);
     }
 
     // test case: When calling the buildCurrentPublicIpInstance method with secondary methods mocked
@@ -930,7 +945,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         // verify
         Assert.assertEquals(CloudStackStateMapper.FAILURE_STATUS, publicIpInstance.getCloudState());
         String errorExpected = Messages.Error.ERROR_WHILE_PROCESSING_ASYNCHRONOUS_REQUEST_INSTANCE_STEP;
-        this.loggerTestChecking.assertEquals(FIRST_POSITION, Level.ERROR, errorExpected);
+        this.loggerTestChecking.assertEquals(FIRST_POSITION_LOG, Level.ERROR, errorExpected);
     }
 
     // test case: When calling the buildCurrentPublicIpInstance method with secondary methods mocked

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -23,10 +23,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackState
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.RequestMatcher;
 import org.apache.http.client.HttpResponseException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 import org.mockito.internal.verification.VerificationModeFactory;
@@ -590,10 +587,14 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
                 .requestEnableStaticNat(Mockito.argThat(matcher), Mockito.eq(this.cloudStackUser));
     }
 
+    @Ignore
+    @Test
+    public void testDoCreatingFirewallOperationFailWhenThrowHttpResponseExeption() {}
+
     // test case: When calling the doCreatingFirewallOperation method with secondary methods mocked
     // and It occurs a FogbowException. it must verify if It throws the same exception.
     @Test
-    public void testDoCreatingFirewallOperationFail() throws FogbowException {
+    public void testDoCreatingFirewallOperationFail() throws FogbowException, HttpResponseException {
         // set up
         AsyncRequestInstanceState asyncRequestInstanceState = Mockito.mock(AsyncRequestInstanceState.class);
         String jsonResponse = "jsonResponse";
@@ -616,7 +617,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     // test case: When calling the doCreatingFirewallOperation method with secondary methods mocked,
     // it must verify if It goes through all methods.
     @Test
-    public void testDoCreatingFirewallOperationSuccessfully() throws FogbowException {
+    public void testDoCreatingFirewallOperationSuccessfully() throws FogbowException, HttpResponseException {
         // set up
         AsyncRequestInstanceState asyncRequestInstanceState = Mockito.mock(AsyncRequestInstanceState.class);
         String jsonResponse = "jsonResponse";

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponseTest.java
@@ -1,0 +1,28 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class CreateFirewallRuleAsyncResponseTest {
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right CreateFirewallRuleAsyncResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String jobId = "1";
+        String firewallRuleAsyncResponseJson =
+                CloudstackTestUtils.createFirewallRuleAsyncResponseJson(jobId);
+
+        // execute
+        CreateFirewallRuleAsyncResponse createFirewallRuleAsyncResponse =
+                CreateFirewallRuleAsyncResponse.fromJson(firewallRuleAsyncResponseJson);
+
+        // verify
+        Assert.assertEquals(jobId, createFirewallRuleAsyncResponse.getJobId());
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequestTest.java
@@ -1,0 +1,71 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CreateFirewallRuleRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String cirdList = "cirdList";
+        String protocol = "protocol";
+        String startPort = "startPort";
+        String endPort = "endPort";
+        String ipAddressId = "ipAdressId";
+
+        String protocolStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.PROTOCOL_KEY_JSON, protocol);
+        String cirdListStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.CIDR_LIST_KEY_JSON, cirdList);
+        String startPortStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.STARTPORT_KEY_JSON, startPort);
+        String endPortStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.ENDPORT_KEY_JSON, endPort);
+        String ipAddressIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.IP_ADDRESS_ID_KEY_JSON, ipAddressId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                protocolStructureUrl,
+                startPortStructureUrl,
+                endPortStructureUrl,
+                ipAddressIdStructureUrl,
+                cirdListStructureUrl,
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        CreateFirewallRuleRequest createFirewallRuleRequest = new CreateFirewallRuleRequest.Builder()
+                .cidrList(cirdList)
+                .protocol(protocol)
+                .startPort(startPort)
+                .endPort(endPort)
+                .ipAddressId(ipAddressId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String associateIpAddressRequestUrl = createFirewallRuleRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, associateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new CreateFirewallRuleRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequestTest.java
@@ -1,0 +1,51 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DisassociateIpAddressRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.DISASSOCIATE_IP_ADDRESS_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String id = "id";
+
+        String idStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.ID_KEY_JSON, id);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                idStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        DisassociateIpAddressRequest disassociateIpAddressRequest = new DisassociateIpAddressRequest.Builder()
+                .id(id)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String disassociateIpAddressRequestUrl = disassociateIpAddressRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, disassociateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new DisassociateIpAddressRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequestTest.java
@@ -1,0 +1,56 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EnableStaticNatRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.ENABLE_STATIC_NAT_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String virtualMachineId = "virtualMachineId";
+        String ipAddressId = "ipAdressId";
+
+        String virtualMachineIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.VM_ID_KEY_JSON, virtualMachineId);
+        String ipAddressIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.IP_ADDRESS_ID_KEY_JSON, ipAddressId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                virtualMachineIdStructureUrl,
+                ipAddressIdStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        EnableStaticNatRequest enableStaticNatRequest = new EnableStaticNatRequest.Builder()
+                .virtualMachineId(virtualMachineId)
+                .ipAddressId(ipAddressId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String associateIpAddressRequestUrl = enableStaticNatRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, associateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new EnableStaticNatRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponseTest.java
@@ -1,0 +1,54 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpResponseException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+public class SuccessfulAssociateIpAddressResponseTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right SuccessfulAssociateIpAddressResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String id = "id";
+        String ipAddress = "ipAddress";
+        String asyncAssociateIpAddressResponseJson =
+                CloudstackTestUtils.createAsyncAssociateIpAddressResponseJson(id, ipAddress);
+
+        // execute
+        SuccessfulAssociateIpAddressResponse successfulAssociateIpAddressResponse =
+                SuccessfulAssociateIpAddressResponse.fromJson(asyncAssociateIpAddressResponseJson);
+
+        // verify
+        Assert.assertEquals(id, successfulAssociateIpAddressResponse.getIpAddress().getId());
+        Assert.assertEquals(ipAddress, successfulAssociateIpAddressResponse.getIpAddress().getIpAddress());
+    }
+
+    // test case: When calling the fromJson method with error json response,
+    // it must verify if It returns the rigth CloudStackErrorResponse.
+    @Test
+    public void testFromJsonFail() throws IOException {
+        // set up
+        String errorText = "anyString";
+        Integer errorCode = HttpStatus.SC_BAD_REQUEST;
+        String asyncAssociateIpAddressErrorResponseJson = CloudstackTestUtils
+                .createAsyncAssociateIpAddressErrorResponseJson(errorCode, errorText);
+
+        this.expectedException.expect(HttpResponseException.class);
+        this.expectedException.expectMessage(errorText);
+
+        // execute
+        SuccessfulAssociateIpAddressResponse.fromJson(asyncAssociateIpAddressErrorResponseJson);
+    }
+
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/associateipaddressresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/associateipaddressresponse.json
@@ -1,0 +1,5 @@
+{
+  "associateipaddressresponse": {
+    "jobid": "%s"
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
@@ -1,0 +1,5 @@
+{
+  "createfirewallruleresponse": {
+    "jobid": "%s"
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse.json
@@ -1,0 +1,10 @@
+{
+  "queryasyncjobresultresponse": {
+    "jobresult": {
+      "ipaddress": {
+        "id": "%s",
+        "ipaddress": "%s"
+      }
+    }
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse_error.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse_error.json
@@ -1,0 +1,8 @@
+{
+  "queryasyncjobresultresponse": {
+    "jobresult":{
+      "errorcode": %s,
+      "errortext": "%s"
+    }
+  }
+}


### PR DESCRIPTION
# Description
Refactoring the Cloudstack Public Ip Plugin context.
Note: I didn't touch in the architecture created previously related to the asynchronous request. I think It is not intuitive. Can you review and give your opinion?

# Proposed changes
- Refactoring "request Instance" and "get Instance" tests context. 

# Additional information
- This branch depends on a branch in the Fogbow Common (cloudstack-publicip-test-refator)

# PR Slices
[x] One: Refactoring in the Cloudstack Public IP Plugin
[x] Two: Refactoring "get Instance" tests context.
[x] Three: Refactoring "request Instance" and "get Instance" tests context. 
[] Four: Implementing Cloudstack Requests and Responses tests.

# Reminding
PRs order:
develop < PR1 < **PR2 < PR3** < PR4