### PR TITLE
Cloudstack publicip test refactor pr four

### DIFF
--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -121,8 +121,8 @@ public class Messages {
         public static final String STARTING_THREADS = "Starting processor threads.";
         public static final String SUCCESS = "Successfully executed operation.";
         public static final String XMPP_HANDLERS_SET = "XMPP handlers set.";
-        public static final String ASYNCHRONOUS_PUBLIC_IP_STAGE =
-                "The asynchronous public ip request %s is in the stage %s.";
+        public static final String ASYNCHRONOUS_PUBLIC_IP_STATE =
+                "The asynchronous public ip request %s is in the state %s.";
     }
 
     public static class Error {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponse.java
@@ -9,7 +9,7 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.ASSOCIA
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_KEY_JSON;
 
 /**
- * Documentation:
+ * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/associateIpAddress.html
  *
  * Response Example:
  * {
@@ -28,10 +28,7 @@ public class AssociateIpAddressAsyncJobIdResponse {
     }
 
     public static AssociateIpAddressAsyncJobIdResponse fromJson(String json) throws HttpResponseException {
-        AssociateIpAddressAsyncJobIdResponse associateIpAddressAsyncJobIdResponse =
-                GsonHolder.getInstance().fromJson(json, AssociateIpAddressAsyncJobIdResponse.class);
-        associateIpAddressAsyncJobIdResponse.response.checkErrorExistence();
-        return associateIpAddressAsyncJobIdResponse;
+        return GsonHolder.getInstance().fromJson(json, AssociateIpAddressAsyncJobIdResponse.class);
     }
 
     public class AssociateIpAddressResponse extends CloudStackErrorResponse {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequest.java
@@ -9,7 +9,7 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.NETWORK
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/associateIpAddress.html
  *
- * Request Example:
+ * Request Example: {url_cloudstack}?command=associateIpAddress&networkid={networkid}&apikey={apiKey}&secret_key={secretKey}
  */
 public class AssociateIpAddressRequest extends CloudStackRequest {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -241,8 +241,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     /**
-     * Set the asynchronous request instance to the first stage; This stage consist of
-     * wait the asynchronous Associating Ip Address Operation finish in the Cloudstack.
+     * Set the asynchronous request instance to the first step; This step consist of
+     * wait the asynchronous Associating Ip Address Operation finishes in the Cloudstack.
      */
     @VisibleForTesting
     void setAsyncRequestInstanceFirstStep(String jobId, @NotNull PublicIpOrder publicIpOrder) {
@@ -257,8 +257,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     /**
-     * Set the asynchronous request instance to the second stage; This stage consist of
-     * wait the asynchronous Create Firewall Operation finish in the Cloudstack.
+     * Set the asynchronous request instance to the second step; This step consist of
+     * wait the asynchronous Create Firewall Operation finishes in the Cloudstack.
      */
     @VisibleForTesting
     void setAsyncRequestInstanceSecondStep(@NotNull SuccessfulAssociateIpAddressResponse response,
@@ -278,6 +278,9 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
                 AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE));
     }
 
+    /**
+     * Finish the cycle and set as Ready the asynchronous request instance.
+     */
     @VisibleForTesting
     void finishAsyncRequestInstanceSteps(@NotNull AsyncRequestInstanceState asyncRequestInstanceState) {
         asyncRequestInstanceState.setState(AsyncRequestInstanceState.StateType.READY);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -253,7 +253,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
                 AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS, jobId, computeId);
         asyncRequestInstanceState.setOrderInstanceId(instanceId);
         this.asyncRequestInstanceStateMap.put(instanceId, asyncRequestInstanceState);
-        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 instanceId, AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS));
     }
 
@@ -274,7 +274,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         asyncRequestInstanceState.setIp(ip);
         asyncRequestInstanceState.setCurrentJobId(createFirewallRuleJobId);
         asyncRequestInstanceState.setState(AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE);
-        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 asyncRequestInstanceState.getOrderInstanceId(),
                 AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE));
     }
@@ -282,7 +282,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     @VisibleForTesting
     void finishAsyncRequestInstanceSteps(@NotNull AsyncRequestInstanceState asyncRequestInstanceState) {
         asyncRequestInstanceState.setState(AsyncRequestInstanceState.StateType.READY);
-        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        LOGGER.info(String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 asyncRequestInstanceState.getOrderInstanceId(), AsyncRequestInstanceState.StateType.READY));
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -184,7 +184,6 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
                 }
             case CloudStackQueryJobResult.FAILURE:
                 try {
-                    // any failure should lead to a disassociation of the ip address
                     doDeleteInstance(publicIpOrder, cloudStackUser);
                 } catch (FogbowException e) {
                     LOGGER.error(String.format(Messages.Error.ERROR_WHILE_REMOVING_RESOURCE,
@@ -428,7 +427,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     void setAsyncRequestInstanceStateMap(
             Map<String, AsyncRequestInstanceState> asyncRequestInstanceStateMap) {
 
-        CloudStackPublicIpPlugin.asyncRequestInstanceStateMap = asyncRequestInstanceStateMap;
+        this.asyncRequestInstanceStateMap = asyncRequestInstanceStateMap;
     }
 
     // TODO(chico) - This method will be removed after the Cloudstack Security Rule PR is accepted.

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
@@ -6,6 +6,16 @@ import com.google.gson.annotations.SerializedName;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_RESPONSE;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_KEY_JSON;
 
+/**
+ * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
+ *
+ * Response Example:
+ * {
+ *   "createfirewallruleresponse":{
+ *     "jobid":"7568bb4f-d925-437e-80b0-b2d984d225d4"
+ *   }
+ * }
+ */
 public class CreateFirewallRuleAsyncResponse {
 
     @SerializedName(CREATE_FIREWALL_RULE_RESPONSE)
@@ -16,9 +26,7 @@ public class CreateFirewallRuleAsyncResponse {
     }
 
     public static CreateFirewallRuleAsyncResponse fromJson(String json) {
-        CreateFirewallRuleAsyncResponse createFirewallRuleAsyncResponse =
-                GsonHolder.getInstance().fromJson(json, CreateFirewallRuleAsyncResponse.class);
-        return createFirewallRuleAsyncResponse;
+        return GsonHolder.getInstance().fromJson(json, CreateFirewallRuleAsyncResponse.class);
     }
 
     private class CreateFirewallRuleResponse {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -8,11 +8,10 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
  * <p>
- * Request Example:
+ * Request Example: {url_cloudstack}?command=createFirewallRule&protocol={protocol}&startport={startport} /
+ *  * &endport={endport}&ipaddressid={ipaddressid}&cidrlist={cidrlist}&apikey={apiKey}&secret_key={secretKey}
  */
 public class CreateFirewallRuleRequest extends CloudStackRequest {
-
-    public static final String CREATE_FIREWALL_RULE_COMMAND = "createFirewallRule";
 
     protected CreateFirewallRuleRequest(Builder builder) throws InvalidParameterException {
         super(builder.cloudStackUrl);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequest.java
@@ -3,17 +3,15 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
+import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.DISASSOCIATE_IP_ADDRESS_COMMAND;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.ID_KEY_JSON;
 
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/disassociateIpAddress.html
  * 
- * Request Example: 
- *
+ * Request Example: {url_cloudstack}?command=disassociateIpAddress&id={id}&apikey={apiKey}&secret_key={secretKey}
  */	
 public class DisassociateIpAddressRequest extends CloudStackRequest {
-
-	public static final String DISASSOCIATE_IP_ADDRESS_COMMAND = "disassociateIpAddress";
 
 	protected DisassociateIpAddressRequest(Builder builder) throws InvalidParameterException {
 		super(builder.cloudStackUrl);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequest.java
@@ -8,7 +8,8 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/enableStaticNat.html
  * <p>
- * Request Example:
+ * Request Example: {url_cloudstack}?command=enableStaticNat&virtualmachineid={virtualmachineid} /
+ * &ipaddressid={ipaddressid}&apikey={apiKey}&secret_key={secretKey}
  */
 public class EnableStaticNatRequest extends CloudStackRequest {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponse.java
@@ -11,7 +11,6 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/associateIpAddress.html
  * 
  * Response Example: 
- *
  *{
  *  "queryasyncjobresultresponse":{
  *     "jobresult":{
@@ -22,7 +21,6 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
  *     }
  *   }
  * }
- *
  */
 public class SuccessfulAssociateIpAddressResponse {
 
@@ -36,11 +34,11 @@ public class SuccessfulAssociateIpAddressResponse {
     public static SuccessfulAssociateIpAddressResponse fromJson(String json) throws HttpResponseException {
         SuccessfulAssociateIpAddressResponse successfulAssociateIpAddressResponse =
                 GsonHolder.getInstance().fromJson(json, SuccessfulAssociateIpAddressResponse.class);
-        successfulAssociateIpAddressResponse.response.checkErrorExistence();
+        successfulAssociateIpAddressResponse.response.jobResult.checkErrorExistence();
         return successfulAssociateIpAddressResponse;
     }
 
-    private class QueryAsyncJobResultResponse extends CloudStackErrorResponse {
+    private class QueryAsyncJobResultResponse {
 
         @SerializedName(JOB_STATUS_KEY_JSON)
         private int jobStatus;
@@ -50,7 +48,7 @@ public class SuccessfulAssociateIpAddressResponse {
 
     }
 
-    private class JobResult {
+    private class JobResult extends CloudStackErrorResponse {
 
         @SerializedName(IP_ADDRESS_KEY_JSON)
         private IpAddress ipAddress;

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
@@ -56,6 +56,7 @@ public class CloudstackTestUtils {
     private static final String LIST_TEMPLATES_RESPONSE = "listtemplatesresponse.json";
     private static final String LIST_TEMPLATES_ERROR_RESPONSE = "listtemplatesresponse_error.json";
     private static final String LIST_TEMPLATES_EMPTY_RESPONSE = "listtemplatesresponse_empty.json";
+    private static final String ASSOCIATE_IP_ADDRESS_RESPONSE = "associateipaddressresponse.json";
 
     public static final CloudStackUser CLOUD_STACK_USER =
             new CloudStackUser("id", "", "", "", new HashMap<>());
@@ -324,6 +325,15 @@ public class CloudstackTestUtils {
                 + LIST_TEMPLATES_ERROR_RESPONSE);
 
         return String.format(rawJson, errorCode, errorText);
+    }
+
+    public static String createAssociateIpAddressAsyncResponseJson(String jobId)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + ASSOCIATE_IP_ADDRESS_RESPONSE);
+
+        return String.format(rawJson, jobId);
     }
 
     private static String readFileAsString(final String fileName) throws IOException {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
@@ -58,6 +58,9 @@ public class CloudstackTestUtils {
     private static final String LIST_TEMPLATES_EMPTY_RESPONSE = "listtemplatesresponse_empty.json";
     private static final String ASSOCIATE_IP_ADDRESS_RESPONSE = "associateipaddressresponse.json";
     private static final String CREATE_FIREWALL_RULE_ADDRESS_RESPONSE = "createfirewallruleresponse.json";
+    private static final String ASYNC_ASSOCIATE_IP_ADDRESS_RESPONSE = "queryasyncassociateipaddressresponse.json";
+    private static final String ASYNC_ASSOCIATE_IP_ADDRESS_ERROR_RESPONSE =
+            "queryasyncassociateipaddressresponse_error.json";
 
     public static final CloudStackUser CLOUD_STACK_USER =
             new CloudStackUser("id", "", "", "", new HashMap<>());
@@ -344,6 +347,24 @@ public class CloudstackTestUtils {
                 + CREATE_FIREWALL_RULE_ADDRESS_RESPONSE);
 
         return String.format(rawJson, jobId);
+    }
+
+    public static String createAsyncAssociateIpAddressErrorResponseJson(int errorCode, String errorText)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + ASYNC_ASSOCIATE_IP_ADDRESS_ERROR_RESPONSE);
+
+        return String.format(rawJson, errorCode, errorText);
+    }
+
+    public static String createAsyncAssociateIpAddressResponseJson(String id, String idAddress)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + ASYNC_ASSOCIATE_IP_ADDRESS_RESPONSE);
+
+        return String.format(rawJson, id, idAddress);
     }
 
     private static String readFileAsString(final String fileName) throws IOException {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
@@ -57,6 +57,7 @@ public class CloudstackTestUtils {
     private static final String LIST_TEMPLATES_ERROR_RESPONSE = "listtemplatesresponse_error.json";
     private static final String LIST_TEMPLATES_EMPTY_RESPONSE = "listtemplatesresponse_empty.json";
     private static final String ASSOCIATE_IP_ADDRESS_RESPONSE = "associateipaddressresponse.json";
+    private static final String CREATE_FIREWALL_RULE_ADDRESS_RESPONSE = "createfirewallruleresponse.json";
 
     public static final CloudStackUser CLOUD_STACK_USER =
             new CloudStackUser("id", "", "", "", new HashMap<>());
@@ -332,6 +333,15 @@ public class CloudstackTestUtils {
 
         String rawJson = readFileAsString(getPathCloudstackFile()
                 + ASSOCIATE_IP_ADDRESS_RESPONSE);
+
+        return String.format(rawJson, jobId);
+    }
+
+    public static String createFirewallRuleAsyncResponseJson(String jobId)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + CREATE_FIREWALL_RULE_ADDRESS_RESPONSE);
 
         return String.format(rawJson, jobId);
     }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressAsyncJobIdResponseTest.java
@@ -1,0 +1,28 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AssociateIpAddressAsyncJobIdResponseTest {
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right AssociateIpAddressAsyncJobIdResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String jobId = "1";
+        String associateIpAddressAsyncResponseJson =
+                CloudstackTestUtils.createAssociateIpAddressAsyncResponseJson(jobId);
+
+        // execute
+        AssociateIpAddressAsyncJobIdResponse associateIpAddressAsyncJobIdResponse =
+                AssociateIpAddressAsyncJobIdResponse.fromJson(associateIpAddressAsyncResponseJson);
+
+        // verify
+        Assert.assertEquals(jobId, associateIpAddressAsyncJobIdResponse.getJobId());
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/AssociateIpAddressRequestTest.java
@@ -1,0 +1,51 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AssociateIpAddressRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.ASSOCIATE_IP_ADDRESS_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String networkId = "networkId";
+
+        String networkIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.NETWORK_ID_KEY_JSON, networkId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                networkIdStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        AssociateIpAddressRequest associateIpAddressRequest = new AssociateIpAddressRequest.Builder()
+                .networkId(networkId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String associateIpAddressRequestUrl = associateIpAddressRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, associateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new AssociateIpAddressRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -84,7 +84,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         Mockito.when(publicIpOrder.getComputeId()).thenReturn(computeIdExpected);
         String jobId = "jobId";
 
-        String messageExpected = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        String messageExpected = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 instanceIdExpected, AsyncRequestInstanceState.StateType.ASSOCIATING_IP_ADDRESS);
 
         // verify before
@@ -317,7 +317,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         // set up
         AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(null, null , null);
 
-        String messageExpected = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        String messageExpected = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 asyncRequestInstanceState.getOrderInstanceId(),
                 AsyncRequestInstanceState.StateType.READY);
 
@@ -350,7 +350,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(null, null , null);
         String createFirewallRuleJobId = "jobId";
 
-        String messageExpexted = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STAGE,
+        String messageExpexted = String.format(Messages.Info.ASYNCHRONOUS_PUBLIC_IP_STATE,
                 asyncRequestInstanceState.getOrderInstanceId(),
                 AsyncRequestInstanceState.StateType.CREATING_FIREWALL_RULE);
 

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPluginTest.java
@@ -160,7 +160,8 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestIpAddressAssociationFail() throws FogbowException, HttpResponseException {
         // set up
-        AssociateIpAddressRequest request = new AssociateIpAddressRequest.Builder().build("");
+        AssociateIpAddressRequest request = new AssociateIpAddressRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
@@ -179,14 +180,15 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestIpAddressAssociationSuccessfully() throws FogbowException, HttpResponseException {
         // set up
-        AssociateIpAddressRequest request = new AssociateIpAddressRequest.Builder().build("");
+        AssociateIpAddressRequest request = new AssociateIpAddressRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
-        String jsonResponse = "anything";
+        String jsonResponse = TestUtils.ANY_VALUE;
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
                 thenReturn(jsonResponse);
 
-        String jobIdExpected = "jobId";
+        String jobIdExpected = "jobIdExpected";
         AssociateIpAddressAsyncJobIdResponse response = Mockito.mock(AssociateIpAddressAsyncJobIdResponse.class);
         Mockito.when(response.getJobId()).thenReturn(jobIdExpected);
         PowerMockito.mockStatic(AssociateIpAddressAsyncJobIdResponse.class);
@@ -205,7 +207,8 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestDisassociateIpAddressFail() throws FogbowException, HttpResponseException {
         // set up
-        DisassociateIpAddressRequest request = new DisassociateIpAddressRequest.Builder().build("");
+        DisassociateIpAddressRequest request = new DisassociateIpAddressRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
@@ -224,11 +227,12 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestDisassociateIpAddressSuccessfully() throws FogbowException, HttpResponseException {
         // set up
-        DisassociateIpAddressRequest request = new DisassociateIpAddressRequest.Builder().build("");
+        DisassociateIpAddressRequest request = new DisassociateIpAddressRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
-                thenReturn("");
+                thenReturn(TestUtils.EMPTY_STRING);
 
         // exercise
         this.plugin.requestDisassociateIpAddress(request, this.cloudStackUser);
@@ -380,7 +384,8 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestCreateFirewallRuleFail() throws FogbowException, HttpResponseException {
         // set up
-        CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder().build("");
+        CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
@@ -399,9 +404,10 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestCreateFirewallRuleSuccessfully() throws FogbowException, HttpResponseException {
         // set up
-        CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder().build("");
+        CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
-        String jsonResponse = "";
+        String jsonResponse = TestUtils.ANY_VALUE;
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(
                 Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(jsonResponse);
@@ -428,7 +434,8 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestEnableStaticNatFail() throws FogbowException, HttpResponseException {
         // set up
-        EnableStaticNatRequest request = new EnableStaticNatRequest.Builder().build("");
+        EnableStaticNatRequest request = new EnableStaticNatRequest.Builder().
+                build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(Mockito.any(), Mockito.any(), Mockito.any())).
@@ -447,11 +454,11 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
     @Test
     public void testRequestEnableStaticNatSuccessfully() throws FogbowException, HttpResponseException {
         // set up
-        EnableStaticNatRequest request = new EnableStaticNatRequest.Builder().build("");
+        EnableStaticNatRequest request = new EnableStaticNatRequest.Builder().build(TestUtils.EMPTY_STRING);
 
         PowerMockito.mockStatic(CloudStackCloudUtils.class);
         PowerMockito.when(CloudStackCloudUtils.doRequest(
-                Mockito.any(), Mockito.any(), Mockito.any())).thenReturn("");
+                Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(TestUtils.EMPTY_STRING);
 
         // exercise
         this.plugin.requestEnableStaticNat(request, this.cloudStackUser);
@@ -539,7 +546,7 @@ public class CloudStackPublicIpPluginTest extends BaseUnitTests {
         SuccessfulAssociateIpAddressResponse response = Mockito.mock(SuccessfulAssociateIpAddressResponse.class);
         Mockito.when(response.getIpAddress()).thenReturn(ipAddress);
 
-        String jobIdExpected = "jobId";
+        String jobIdExpected = "jobIdExpected";
         Mockito.doReturn(jobIdExpected).when(this.plugin).requestCreateFirewallRule(Mockito.any(), Mockito.any());
 
         CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder()

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponseTest.java
@@ -1,0 +1,28 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class CreateFirewallRuleAsyncResponseTest {
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right CreateFirewallRuleAsyncResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String jobId = "1";
+        String firewallRuleAsyncResponseJson =
+                CloudstackTestUtils.createFirewallRuleAsyncResponseJson(jobId);
+
+        // execute
+        CreateFirewallRuleAsyncResponse createFirewallRuleAsyncResponse =
+                CreateFirewallRuleAsyncResponse.fromJson(firewallRuleAsyncResponseJson);
+
+        // verify
+        Assert.assertEquals(jobId, createFirewallRuleAsyncResponse.getJobId());
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequestTest.java
@@ -1,0 +1,71 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CreateFirewallRuleRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String cirdList = "cirdList";
+        String protocol = "protocol";
+        String startPort = "startPort";
+        String endPort = "endPort";
+        String ipAddressId = "ipAdressId";
+
+        String protocolStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.PROTOCOL_KEY_JSON, protocol);
+        String cirdListStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.CIDR_LIST_KEY_JSON, cirdList);
+        String startPortStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.STARTPORT_KEY_JSON, startPort);
+        String endPortStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.ENDPORT_KEY_JSON, endPort);
+        String ipAddressIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.IP_ADDRESS_ID_KEY_JSON, ipAddressId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                protocolStructureUrl,
+                startPortStructureUrl,
+                endPortStructureUrl,
+                ipAddressIdStructureUrl,
+                cirdListStructureUrl,
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        CreateFirewallRuleRequest createFirewallRuleRequest = new CreateFirewallRuleRequest.Builder()
+                .cidrList(cirdList)
+                .protocol(protocol)
+                .startPort(startPort)
+                .endPort(endPort)
+                .ipAddressId(ipAddressId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String associateIpAddressRequestUrl = createFirewallRuleRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, associateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new CreateFirewallRuleRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/DisassociateIpAddressRequestTest.java
@@ -1,0 +1,51 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DisassociateIpAddressRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.DISASSOCIATE_IP_ADDRESS_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String id = "id";
+
+        String idStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.ID_KEY_JSON, id);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                idStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        DisassociateIpAddressRequest disassociateIpAddressRequest = new DisassociateIpAddressRequest.Builder()
+                .id(id)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String disassociateIpAddressRequestUrl = disassociateIpAddressRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, disassociateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new DisassociateIpAddressRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/EnableStaticNatRequestTest.java
@@ -1,0 +1,56 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EnableStaticNatRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.ENABLE_STATIC_NAT_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String virtualMachineId = "virtualMachineId";
+        String ipAddressId = "ipAdressId";
+
+        String virtualMachineIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.VM_ID_KEY_JSON, virtualMachineId);
+        String ipAddressIdStructureUrl = String.format(
+                "%s=%s", CloudStackConstants.PublicIp.IP_ADDRESS_ID_KEY_JSON, ipAddressId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                virtualMachineIdStructureUrl,
+                ipAddressIdStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        EnableStaticNatRequest enableStaticNatRequest = new EnableStaticNatRequest.Builder()
+                .virtualMachineId(virtualMachineId)
+                .ipAddressId(ipAddressId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String associateIpAddressRequestUrl = enableStaticNatRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, associateIpAddressRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new EnableStaticNatRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/SuccessfulAssociateIpAddressResponseTest.java
@@ -1,0 +1,54 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpResponseException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+public class SuccessfulAssociateIpAddressResponseTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right SuccessfulAssociateIpAddressResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String id = "id";
+        String ipAddress = "ipAddress";
+        String asyncAssociateIpAddressResponseJson =
+                CloudstackTestUtils.createAsyncAssociateIpAddressResponseJson(id, ipAddress);
+
+        // execute
+        SuccessfulAssociateIpAddressResponse successfulAssociateIpAddressResponse =
+                SuccessfulAssociateIpAddressResponse.fromJson(asyncAssociateIpAddressResponseJson);
+
+        // verify
+        Assert.assertEquals(id, successfulAssociateIpAddressResponse.getIpAddress().getId());
+        Assert.assertEquals(ipAddress, successfulAssociateIpAddressResponse.getIpAddress().getIpAddress());
+    }
+
+    // test case: When calling the fromJson method with error json response,
+    // it must verify if It returns the rigth CloudStackErrorResponse.
+    @Test
+    public void testFromJsonFail() throws IOException {
+        // set up
+        String errorText = "anyString";
+        Integer errorCode = HttpStatus.SC_BAD_REQUEST;
+        String asyncAssociateIpAddressErrorResponseJson = CloudstackTestUtils
+                .createAsyncAssociateIpAddressErrorResponseJson(errorCode, errorText);
+
+        this.expectedException.expect(HttpResponseException.class);
+        this.expectedException.expectMessage(errorText);
+
+        // execute
+        SuccessfulAssociateIpAddressResponse.fromJson(asyncAssociateIpAddressErrorResponseJson);
+    }
+
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/associateipaddressresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/associateipaddressresponse.json
@@ -1,0 +1,5 @@
+{
+  "associateipaddressresponse": {
+    "jobid": "%s"
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
@@ -1,0 +1,5 @@
+{
+  "createfirewallruleresponse": {
+    "jobid": "%s"
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse.json
@@ -1,0 +1,10 @@
+{
+  "queryasyncjobresultresponse": {
+    "jobresult": {
+      "ipaddress": {
+        "id": "%s",
+        "ipaddress": "%s"
+      }
+    }
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse_error.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/queryasyncassociateipaddressresponse_error.json
@@ -1,0 +1,8 @@
+{
+  "queryasyncjobresultresponse": {
+    "jobresult":{
+      "errorcode": %s,
+      "errortext": "%s"
+    }
+  }
+}


### PR DESCRIPTION
# Description
Refactoring the Cloudstack Public Ip Plugin context.
Note: I didn't touch in the architecture created previously related to the asynchronous request. I think It is not intuitive. Can you review and give your opinion?

# Proposed changes
- Implementing Cloudstack Requests and Responses tests.

# Additional information
- This branch depends on a branch in the Fogbow Common (cloudstack-publicip-test-refator)

# PR Slices
[x] One: Refactoring in the Cloudstack Public IP Plugin
[x] Two: Refactoring "get Instance" tests context.
[x] Three: Refactoring "request Instance" and "get Instance" tests context. 
[x] Four: Implementing Cloudstack Requests and Responses tests.

# Reminding
PRs order:
develop < PR1 < **PR2 < PR3** < PR4