### PR TITLE
Cloudstack securityrule test refactor (Complete)

### DIFF
--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -86,6 +86,7 @@ public class Messages {
         public static final String UNABLE_TO_LOCATE_ORDER_S_S = "Unable to locate order <%s> notified by <%s>.";
         public static final String UNABLE_TO_NOTIFY_REQUESTING_PROVIDER = "Unable to notify requesting provider %s for request %s.";
         public static final String UNABLE_TO_RETRIEVE_ROOT_VOLUME = "Unable to retrieve root volume for virtual machine %s; assigning -1 to disk size.";
+        public static final String THREAD_INTERRUPTED = "Thread waiting was interrupted";
     }
 
     public static class Info {

--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -86,7 +86,7 @@ public class Messages {
         public static final String UNABLE_TO_LOCATE_ORDER_S_S = "Unable to locate order <%s> notified by <%s>.";
         public static final String UNABLE_TO_NOTIFY_REQUESTING_PROVIDER = "Unable to notify requesting provider %s for request %s.";
         public static final String UNABLE_TO_RETRIEVE_ROOT_VOLUME = "Unable to retrieve root volume for virtual machine %s; assigning -1 to disk size.";
-        public static final String THREAD_INTERRUPTED = "Thread waiting was interrupted";
+        public static final String SLEEP_THREAD_INTERRUPTED = "Thread's not able to sleep.";
     }
 
     public static class Info {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -108,7 +108,7 @@ public class CloudStackCloudUtils {
         try {
             Thread.sleep(ONE_SECOND_IN_MILIS);
         } catch (InterruptedException e) {
-            LOGGER.warn(Messages.Warn.THREAD_INTERRUPTED, e);
+            LOGGER.warn(Messages.Warn.SLEEP_THREAD_INTERRUPTED, e);
         }
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -6,7 +6,6 @@ import cloud.fogbow.common.models.CloudStackUser;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackHttpClient;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackQueryAsyncJobResponse;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackQueryJobResult;
-import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
 import cloud.fogbow.ras.constants.Messages;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.http.HttpStatus;
@@ -105,14 +104,9 @@ public class CloudStackCloudUtils {
     }
 
     @VisibleForTesting
-    static long getTimeSleepThread() {
-        return ONE_SECOND_IN_MILIS;
-    }
-
-    @VisibleForTesting
     static void sleepThread() {
         try {
-            Thread.sleep(getTimeSleepThread());
+            Thread.sleep(ONE_SECOND_IN_MILIS);
         } catch (InterruptedException e) {
             LOGGER.warn(Messages.Warn.THREAD_INTERRUPTED, e);
         }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -110,6 +110,7 @@ public class CloudStackCloudUtils {
         try {
             Thread.sleep(getTimeSleepThread());
         } catch (InterruptedException e) {
+            // TODO(chico) - use constants
             LOGGER.warn("Thread waiting was interrupeted", e);
         }
     }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -28,8 +28,8 @@ public class CloudStackCloudUtils {
     public static final String PENDING_STATE = "pending";
     public static final String FAILURE_STATE = "failure";
 
-    public static final int ONE_SECOND_IN_MILIS = 1000;
-    public static final int MAX_TRIES = 30;
+    private static final int ONE_SECOND_IN_MILIS = 1000;
+    private static final int MAX_TRIES = 30;
 
     /**
      * Request HTTP operations to Cloudstack and treat a possible FogbowException when
@@ -53,6 +53,7 @@ public class CloudStackCloudUtils {
      * Wait and process the Cloudstack asynchronous response in its asynchronous life cycle.
      * @throws FogbowException
      */
+    @NotNull
     public static String waitForResult(@NotNull CloudStackHttpClient client,
                                        String cloudStackUrl,
                                        String jobId,
@@ -74,6 +75,7 @@ public class CloudStackCloudUtils {
         return processJobResult(response, jobId);
     }
 
+    @NotNull
     @VisibleForTesting
     static String processJobResult(@NotNull CloudStackQueryAsyncJobResponse response,
                                    String jobId)
@@ -89,6 +91,7 @@ public class CloudStackCloudUtils {
         }
     }
 
+    @NotNull
     @VisibleForTesting
     public static CloudStackQueryAsyncJobResponse getAsyncJobResponse(@NotNull CloudStackHttpClient client,
                                                                       String cloudStackUrl,
@@ -110,8 +113,7 @@ public class CloudStackCloudUtils {
         try {
             Thread.sleep(getTimeSleepThread());
         } catch (InterruptedException e) {
-            // TODO(chico) - use constants
-            LOGGER.warn("Thread waiting was interrupeted", e);
+            LOGGER.warn(Messages.Warn.THREAD_INTERRUPTED, e);
         }
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -79,7 +79,7 @@ public class CloudStackCloudUtils {
         try {
             Thread.sleep(getTimeSleepThread());
         } catch (InterruptedException e) {
-            LOGGER.warn("", e);
+            LOGGER.warn("Waiting interrupeted", e);
         }
     }
 
@@ -88,8 +88,9 @@ public class CloudStackCloudUtils {
         return ONE_SECOND_IN_MILIS;
     }
 
-    public static String processJobResult(@NotNull CloudStackQueryAsyncJobResponse response,
-                                          String jobId)
+    @VisibleForTesting
+    static String processJobResult(@NotNull CloudStackQueryAsyncJobResponse response,
+                                   String jobId)
             throws FogbowException {
 
         switch (response.getJobStatus()){

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -25,7 +25,6 @@ public class CloudStackCloudUtils {
     public static final int JOB_STATUS_COMPLETE = 1;
     public static final int JOB_STATUS_PENDING = 0;
     public static final int JOB_STATUS_FAILURE = 2;
-    public static final int JOB_STATUS_INCONSISTENT = 3;
     public static final String PENDING_STATE = "pending";
     public static final String FAILURE_STATE = "failure";
 
@@ -51,7 +50,8 @@ public class CloudStackCloudUtils {
     }
 
     /**
-     * Wait and process the Cloudstack async response in its life cycle.
+     * Wait and process the Cloudstack asynchronous response in its asynchronous life cycle.
+     * @throws FogbowException
      */
     public static String waitForResult(@NotNull CloudStackHttpClient client,
                                        String cloudStackUrl,
@@ -66,26 +66,12 @@ public class CloudStackCloudUtils {
             if (countTries >= MAX_TRIES) {
                 throw new TimeoutCloudstackAsync(String.format(Messages.Exception.JOB_TIMEOUT, jobId));
             }
+            sleepThread();
             response = getAsyncJobResponse(client, cloudStackUrl, jobId, cloudStackUser);
             countTries++;
-            sleepThread();
         }
 
         return processJobResult(response, jobId);
-    }
-
-    @VisibleForTesting
-    static void sleepThread() {
-        try {
-            Thread.sleep(getTimeSleepThread());
-        } catch (InterruptedException e) {
-            LOGGER.warn("Waiting interrupeted", e);
-        }
-    }
-
-    @VisibleForTesting
-    static long getTimeSleepThread() {
-        return ONE_SECOND_IN_MILIS;
     }
 
     @VisibleForTesting
@@ -115,10 +101,25 @@ public class CloudStackCloudUtils {
         return CloudStackQueryAsyncJobResponse.fromJson(jsonResponse);
     }
 
+    @VisibleForTesting
+    protected static long getTimeSleepThread() {
+        return ONE_SECOND_IN_MILIS;
+    }
+
+    private static void sleepThread() {
+        try {
+            Thread.sleep(getTimeSleepThread());
+        } catch (InterruptedException e) {
+            LOGGER.warn("Thread waiting was interrupeted", e);
+        }
+    }
+
     public static class TimeoutCloudstackAsync extends FogbowException {
-        public TimeoutCloudstackAsync(String message) {
+
+        private TimeoutCloudstackAsync(String message) {
             super(message);
         }
+
     }
 
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -116,7 +116,7 @@ public class CloudStackCloudUtils {
 
     public static class TimeoutCloudstackAsync extends FogbowException {
 
-        private TimeoutCloudstackAsync(String message) {
+        public TimeoutCloudstackAsync(String message) {
             super(message);
         }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -16,7 +16,7 @@ import org.apache.log4j.Logger;
 import javax.validation.constraints.NotNull;
 
 public class CloudStackCloudUtils {
-    private static final Logger LOGGER = Logger.getLogger(CloudStackUrlUtil.class);
+    private static final Logger LOGGER = Logger.getLogger(CloudStackCloudUtils.class);
 
     public static final String CLOUDSTACK_URL_CONFIG = "cloudstack_api_url";
     public static final String NETWORK_OFFERING_ID_CONFIG = "network_offering_id";
@@ -28,8 +28,8 @@ public class CloudStackCloudUtils {
     public static final String PENDING_STATE = "pending";
     public static final String FAILURE_STATE = "failure";
 
-    private static final int ONE_SECOND_IN_MILIS = 1000;
-    private static final int MAX_TRIES = 30;
+    protected static final int ONE_SECOND_IN_MILIS = 1000;
+    protected static final int MAX_TRIES = 30;
 
     /**
      * Request HTTP operations to Cloudstack and treat a possible FogbowException when
@@ -105,11 +105,12 @@ public class CloudStackCloudUtils {
     }
 
     @VisibleForTesting
-    protected static long getTimeSleepThread() {
+    static long getTimeSleepThread() {
         return ONE_SECOND_IN_MILIS;
     }
 
-    private static void sleepThread() {
+    @VisibleForTesting
+    static void sleepThread() {
         try {
             Thread.sleep(getTimeSleepThread());
         } catch (InterruptedException e) {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtils.java
@@ -64,7 +64,7 @@ public class CloudStackCloudUtils {
                 client, cloudStackUrl, jobId, cloudStackUser);
         while(response.getJobStatus() == CloudStackQueryJobResult.PROCESSING) {
             if (countTries >= MAX_TRIES) {
-                throw new TimeoutCloudstackAsync(String.format(Messages.Exception.JOB_TIMEOUT, jobId));
+                throw new CloudStackTimeoutException(String.format(Messages.Exception.JOB_TIMEOUT, jobId));
             }
             sleepThread();
             response = getAsyncJobResponse(client, cloudStackUrl, jobId, cloudStackUser);
@@ -112,9 +112,9 @@ public class CloudStackCloudUtils {
         }
     }
 
-    public static class TimeoutCloudstackAsync extends FogbowException {
+    public static class CloudStackTimeoutException extends FogbowException {
 
-        public TimeoutCloudstackAsync(String message) {
+        public CloudStackTimeoutException(String message) {
             super(message);
         }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
@@ -6,6 +6,15 @@ import com.google.gson.annotations.SerializedName;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_RESPONSE;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_KEY_JSON;
 
+/**
+ * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
+ * <p>
+ * {
+ *  "createfirewallruleresponse": {
+ *      "jobstatus": 1,
+ *   }
+ * }
+ */
 public class CreateFirewallRuleAsyncResponse {
 
     @SerializedName(CREATE_FIREWALL_RULE_RESPONSE)

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
@@ -3,8 +3,8 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 import cloud.fogbow.common.util.GsonHolder;
 import com.google.gson.annotations.SerializedName;
 
-import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_RESPONSE;
-import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.JOB_ID_KEY_JSON;
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroupPlugin.CREATE_FIREWALL_RULE_RESPONSE;
+import static cloud.fogbow.common.constants.CloudStackConstants.JOB_ID_KEY_JSON;
 
 /**
  * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleAsyncResponse.java
@@ -3,7 +3,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 import cloud.fogbow.common.util.GsonHolder;
 import com.google.gson.annotations.SerializedName;
 
-import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroupPlugin.CREATE_FIREWALL_RULE_RESPONSE;
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroup.CREATE_FIREWALL_RULE_RESPONSE;
 import static cloud.fogbow.common.constants.CloudStackConstants.JOB_ID_KEY_JSON;
 
 /**

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -3,13 +3,13 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
-import static cloud.fogbow.common.constants.CloudStackConstants.Network.CREATE_FIREWALL_RULE_COMMAND;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
- * <p>
- * Request Example:
+ *
+ * Request Example: http://cloudstack?command=createFirewallRule&response=json&protocol=protocol /
+ * &startport=startPort&endport=endPort&ipaddressid=ipAddressId&cidrlist=cird
  */
 public class CreateFirewallRuleRequest extends CloudStackRequest {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -4,7 +4,7 @@ import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
-import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroupPlugin.CREATE_FIREWALL_RULE_COMMAND;
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroup.CREATE_FIREWALL_RULE_COMMAND;
 
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -4,6 +4,7 @@ import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroupPlugin.CREATE_FIREWALL_RULE_COMMAND;
 
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -8,8 +8,8 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/createFirewallRule.html
  *
- * Request Example: http://cloudstack?command=createFirewallRule&response=json&protocol=protocol /
- * &startport=startPort&endport=endPort&ipaddressid=ipAddressId&cidrlist=cird
+ * Request Example: {url_cloudstack}?command=createFirewallRule&response=json&protocol={protocol} /
+ * &startport={startPort}&endport={endPort}&ipaddressid={ipAddressId}&cidrlist={cird}
  */
 public class CreateFirewallRuleRequest extends CloudStackRequest {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CreateFirewallRuleRequest.java
@@ -3,6 +3,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9;
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
+import static cloud.fogbow.common.constants.CloudStackConstants.Network.CREATE_FIREWALL_RULE_COMMAND;
 import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
 
 /**
@@ -11,8 +12,6 @@ import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
  * Request Example:
  */
 public class CreateFirewallRuleRequest extends CloudStackRequest {
-
-    public static final String CREATE_FIREWALL_RULE_COMMAND = "createFirewallRule";
 
     protected CreateFirewallRuleRequest(Builder builder) throws InvalidParameterException {
         super(builder.cloudStackUrl);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -213,13 +213,13 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
     @VisibleForTesting
     SecurityRule.Protocol getFogbowProtocol(String protocol) {
         switch (protocol) {
-            case CloudStackConstants.SecurityGroupPlugin.TCP_VALUE_PROTOCOL:
+            case CloudStackConstants.SecurityGroup.TCP_VALUE_PROTOCOL:
                 return SecurityRule.Protocol.TCP;
-            case CloudStackConstants.SecurityGroupPlugin.UDP_VALUE_PROTOCOL:
+            case CloudStackConstants.SecurityGroup.UDP_VALUE_PROTOCOL:
                 return SecurityRule.Protocol.UDP;
-            case CloudStackConstants.SecurityGroupPlugin.ICMP_VALUE_PROTOCOL:
+            case CloudStackConstants.SecurityGroup.ICMP_VALUE_PROTOCOL:
                 return SecurityRule.Protocol.ICMP;
-            case CloudStackConstants.SecurityGroupPlugin.ALL_VALUE_PROTOCOL:
+            case CloudStackConstants.SecurityGroup.ALL_VALUE_PROTOCOL:
                 return SecurityRule.Protocol.ANY;
             default:
                 return null;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -142,8 +142,8 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
                 return CloudStackCloudUtils.waitForResult(
                         this.client, this.cloudStackUrl, response.getJobId(), cloudStackUser);
             } catch (CloudStackCloudUtils.TimeoutCloudstackAsync e) {
-                CloudStackQueryAsyncJobResponse asyncJobResponse = CloudStackCloudUtils.getAsyncJobResponse(client,
-                        cloudStackUrl, response.getJobId(), cloudStackUser);
+                CloudStackQueryAsyncJobResponse asyncJobResponse = CloudStackCloudUtils.getAsyncJobResponse(
+                        this.client, this.cloudStackUrl, response.getJobId(), cloudStackUser);
                 deleteSecurityRule(asyncJobResponse.getJobInstanceId(), cloudStackUser);
                 throw e;
             }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -115,7 +115,8 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         CloudStackUrlUtil.sign(uriRequest, cloudStackUser.getToken());
 
         try {
-            String jsonResponse = this.client.doGetRequest(uriRequest.toString(), cloudStackUser);
+            String jsonResponse = CloudStackCloudUtils.doRequest(this.client,
+                    uriRequest.toString(), cloudStackUser);
             DeleteFirewallRuleResponse response = DeleteFirewallRuleResponse.fromJson(jsonResponse);
             CloudStackCloudUtils.waitForResult(this.client, this.cloudStackUrl,
                     response.getJobId(), cloudStackUser);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -135,7 +135,8 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         CloudStackUrlUtil.sign(uriRequest, cloudStackUser.getToken());
 
         try {
-            String jsonResponse = this.client.doGetRequest(uriRequest.toString(), cloudStackUser);
+            String jsonResponse = CloudStackCloudUtils.doRequest(
+                    this.client, uriRequest.toString(), cloudStackUser);
             CreateFirewallRuleAsyncResponse response = CreateFirewallRuleAsyncResponse.fromJson(jsonResponse);
             try {
                 return CloudStackCloudUtils.waitForResult(

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -120,8 +120,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
                                         @NotNull Order majorOrder) throws InvalidParameterException {
 
         if (securityRule.getDirection() == SecurityRule.Direction.OUT) {
-            // TODO(chico) - check this exception. Does it make sense ?
-            throw new UnsupportedOperationException();
+            throw new InvalidParameterException(Messages.Exception.INVALID_PARAMETER);
         }
         if (majorOrder.getType() != ResourceType.PUBLIC_IP) {
             throw new InvalidParameterException(Messages.Exception.INVALID_RESOURCE);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -73,16 +73,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Info.GETTING_INSTANCE_S, majorOrder.getInstanceId()));
-        switch (majorOrder.getType()) {
-        	case PUBLIC_IP:
-                String publicIpId = CloudStackPublicIpPlugin.getPublicIpId(majorOrder.getId());
-                return getFirewallRules(publicIpId, cloudStackUser);
-        	case NETWORK:
-        		return new ArrayList<>();
-        	default:
-				String errorMsg = String.format(Messages.Error.INVALID_LIST_SECURITY_RULE_TYPE, majorOrder.getType());
-				throw new UnexpectedException(errorMsg);
-        }
+        return doGetSecurityRules(majorOrder, cloudStackUser);
     }
        
     @Override
@@ -95,6 +86,24 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
                 .build(this.cloudStackUrl);
 
         doDeleteInstance(request, cloudStackUser);
+    }
+
+    @NotNull
+    @VisibleForTesting
+    List<SecurityRuleInstance> doGetSecurityRules(@NotNull Order majorOrder,
+                                                  @NotNull CloudStackUser cloudStackUser)
+            throws FogbowException {
+
+        switch (majorOrder.getType()) {
+            case PUBLIC_IP:
+                String publicIpId = CloudStackPublicIpPlugin.getPublicIpId(majorOrder.getId());
+                return getFirewallRules(publicIpId, cloudStackUser);
+            case NETWORK:
+                return new ArrayList<>();
+            default:
+                String errorMsg = String.format(Messages.Error.INVALID_LIST_SECURITY_RULE_TYPE, majorOrder.getType());
+                throw new UnexpectedException(errorMsg);
+        }
     }
 
     @VisibleForTesting

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -75,7 +75,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         LOGGER.info(String.format(Messages.Info.GETTING_INSTANCE_S, majorOrder.getInstanceId()));
         return doGetSecurityRules(majorOrder, cloudStackUser);
     }
-       
+
     @Override
     public void deleteSecurityRule(String securityRuleId, @NotNull CloudStackUser cloudStackUser)
             throws FogbowException {
@@ -165,19 +165,19 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 
     @NotNull
     @VisibleForTesting
-	List<SecurityRuleInstance> getFirewallRules(String ipAddressId, @NotNull CloudStackUser cloudStackUser)
+    List<SecurityRuleInstance> getFirewallRules(String ipAddressId, @NotNull CloudStackUser cloudStackUser)
             throws FogbowException {
 
-		ListFirewallRulesRequest request = new ListFirewallRulesRequest.Builder()
-				.ipAddressId(ipAddressId)
-				.build(this.cloudStackUrl);
+        ListFirewallRulesRequest request = new ListFirewallRulesRequest.Builder()
+                .ipAddressId(ipAddressId)
+                .build(this.cloudStackUrl);
 
         URIBuilder uriRequest = request.getUriBuilder();
         CloudStackUrlUtil.sign(uriRequest, cloudStackUser.getToken());
 
-		try {
-			String jsonResponse = CloudStackCloudUtils.doRequest(
-			        this.client, uriRequest.toString(), cloudStackUser);
+        try {
+            String jsonResponse = CloudStackCloudUtils.doRequest(
+                    this.client, uriRequest.toString(), cloudStackUser);
             ListFirewallRulesResponse response = ListFirewallRulesResponse.fromJson(jsonResponse);
             List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse =
                     response.getSecurityRulesResponse();
@@ -185,57 +185,57 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         } catch (HttpResponseException e) {
             throw CloudStackHttpToFogbowExceptionMapper.get(e);
         }
-	}
+    }
 
-	@NotNull
+    @NotNull
     @VisibleForTesting
-	List<SecurityRuleInstance> convertToFogbowSecurityRules(
-	        @NotNull List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse) {
+    List<SecurityRuleInstance> convertToFogbowSecurityRules(
+            @NotNull List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse) {
 
-		List<SecurityRuleInstance> securityRuleInstances = new ArrayList<SecurityRuleInstance>();
-		for (ListFirewallRulesResponse.SecurityRuleResponse securityRuleResponse : securityRulesResponse) {
-			SecurityRule.Direction direction = securityRuleResponse.getDirection();
-			int portFrom = securityRuleResponse.getPortFrom();
-			int portTo = securityRuleResponse.getPortTo();
-			String cidr = securityRuleResponse.getCidr();
-			String ipAddress = securityRuleResponse.getIpAddress();
-			SecurityRule.EtherType etherType = inferEtherType(ipAddress);
-			SecurityRule.Protocol protocol = getFogbowProtocol(securityRuleResponse.getProtocol());
+        List<SecurityRuleInstance> securityRuleInstances = new ArrayList<SecurityRuleInstance>();
+        for (ListFirewallRulesResponse.SecurityRuleResponse securityRuleResponse : securityRulesResponse) {
+            SecurityRule.Direction direction = securityRuleResponse.getDirection();
+            int portFrom = securityRuleResponse.getPortFrom();
+            int portTo = securityRuleResponse.getPortTo();
+            String cidr = securityRuleResponse.getCidr();
+            String ipAddress = securityRuleResponse.getIpAddress();
+            SecurityRule.EtherType etherType = inferEtherType(ipAddress);
+            SecurityRule.Protocol protocol = getFogbowProtocol(securityRuleResponse.getProtocol());
             String instanceId = securityRuleResponse.getInstanceId();
 
             SecurityRuleInstance securityRuleInstance = new SecurityRuleInstance(instanceId, direction,
                     portFrom, portTo, cidr, etherType, protocol);
-			securityRuleInstances.add(securityRuleInstance);
-		}
-		return securityRuleInstances;
-	}
+            securityRuleInstances.add(securityRuleInstance);
+        }
+        return securityRuleInstances;
+    }
 
-	@VisibleForTesting
-	SecurityRule.Protocol getFogbowProtocol(String protocol) {
-		switch (protocol) {
-			case CloudStackConstants.SecurityGroupPlugin.TCP_VALUE_PROTOCOL:
-				return SecurityRule.Protocol.TCP;
-			case CloudStackConstants.SecurityGroupPlugin.UDP_VALUE_PROTOCOL:
-				return SecurityRule.Protocol.UDP;
-			case CloudStackConstants.SecurityGroupPlugin.ICMP_VALUE_PROTOCOL:
-				return SecurityRule.Protocol.ICMP;
-			case CloudStackConstants.SecurityGroupPlugin.ALL_VALUE_PROTOCOL:
-				return SecurityRule.Protocol.ANY;
-			default:
-				return null;
-		}
-	}
+    @VisibleForTesting
+    SecurityRule.Protocol getFogbowProtocol(String protocol) {
+        switch (protocol) {
+            case CloudStackConstants.SecurityGroupPlugin.TCP_VALUE_PROTOCOL:
+                return SecurityRule.Protocol.TCP;
+            case CloudStackConstants.SecurityGroupPlugin.UDP_VALUE_PROTOCOL:
+                return SecurityRule.Protocol.UDP;
+            case CloudStackConstants.SecurityGroupPlugin.ICMP_VALUE_PROTOCOL:
+                return SecurityRule.Protocol.ICMP;
+            case CloudStackConstants.SecurityGroupPlugin.ALL_VALUE_PROTOCOL:
+                return SecurityRule.Protocol.ANY;
+            default:
+                return null;
+        }
+    }
 
-	@VisibleForTesting
-	SecurityRule.EtherType inferEtherType(String ipAddress) {
-		if (CidrUtils.isIpv4(ipAddress)) {
-			return SecurityRule.EtherType.IPv4;
-		} else if (CidrUtils.isIpv6(ipAddress)) {
-			return SecurityRule.EtherType.IPv6;
-		} else {
-			return null;
-		}
-	}
+    @VisibleForTesting
+    SecurityRule.EtherType inferEtherType(String ipAddress) {
+        if (CidrUtils.isIpv4(ipAddress)) {
+            return SecurityRule.EtherType.IPv4;
+        } else if (CidrUtils.isIpv6(ipAddress)) {
+            return SecurityRule.EtherType.IPv6;
+        } else {
+            return null;
+        }
+    }
 
     @VisibleForTesting
     void setClient(CloudStackHttpClient client) {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -189,8 +189,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 	@NotNull
     @VisibleForTesting
 	List<SecurityRuleInstance> convertToFogbowSecurityRules(
-	        @NotNull List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse)
-            throws UnexpectedException {
+	        @NotNull List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse) {
 
 		List<SecurityRuleInstance> securityRuleInstances = new ArrayList<SecurityRuleInstance>();
 		for (ListFirewallRulesResponse.SecurityRuleResponse securityRuleResponse : securityRulesResponse) {
@@ -211,7 +210,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 	}
 
 	@VisibleForTesting
-	SecurityRule.Protocol getFogbowProtocol(String protocol) throws UnexpectedException {
+	SecurityRule.Protocol getFogbowProtocol(String protocol) {
 		switch (protocol) {
 			case CloudStackConstants.SecurityGroupPlugin.TCP_VALUE_PROTOCOL:
 				return SecurityRule.Protocol.TCP;
@@ -222,7 +221,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 			case CloudStackConstants.SecurityGroupPlugin.ALL_VALUE_PROTOCOL:
 				return SecurityRule.Protocol.ANY;
 			default:
-				throw new UnexpectedException(Messages.Exception.INVALID_CLOUDSTACK_PROTOCOL);
+				return null;
 		}
 	}
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -127,6 +127,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         }
     }
 
+    @NotNull
     @VisibleForTesting
     String doRequestInstance(@NotNull CreateFirewallRuleRequest request,
                              @NotNull CloudStackUser cloudStackUser) throws FogbowException {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -152,7 +152,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
             try {
                 return CloudStackCloudUtils.waitForResult(
                         this.client, this.cloudStackUrl, response.getJobId(), cloudStackUser);
-            } catch (CloudStackCloudUtils.TimeoutCloudstackAsync e) {
+            } catch (CloudStackCloudUtils.CloudStackTimeoutException e) {
                 CloudStackQueryAsyncJobResponse asyncJobResponse = CloudStackCloudUtils.getAsyncJobResponse(
                         this.client, this.cloudStackUrl, response.getJobId(), cloudStackUser);
                 deleteSecurityRule(asyncJobResponse.getJobInstanceId(), cloudStackUser);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -164,7 +164,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 
     @NotNull
     @VisibleForTesting
-	List<SecurityRuleInstance> getFirewallRules(String ipAddressId, @NotNull CloudStackUser cloudUser)
+	List<SecurityRuleInstance> getFirewallRules(String ipAddressId, @NotNull CloudStackUser cloudStackUser)
             throws FogbowException {
 
 		ListFirewallRulesRequest request = new ListFirewallRulesRequest.Builder()
@@ -172,10 +172,11 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
 				.build(this.cloudStackUrl);
 
         URIBuilder uriRequest = request.getUriBuilder();
-        CloudStackUrlUtil.sign(uriRequest, cloudUser.getToken());
+        CloudStackUrlUtil.sign(uriRequest, cloudStackUser.getToken());
 
 		try {
-			String jsonResponse = this.client.doGetRequest(uriRequest.toString(), cloudUser);
+			String jsonResponse = CloudStackCloudUtils.doRequest(
+			        this.client, uriRequest.toString(), cloudStackUser);
             ListFirewallRulesResponse response = ListFirewallRulesResponse.fromJson(jsonResponse);
             List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse =
                     response.getSecurityRulesResponse();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequest.java
@@ -3,7 +3,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
-import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroupPlugin.DELETE_FIREWALL_RULE_COMMAND;
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroup.DELETE_FIREWALL_RULE_COMMAND;
 import static cloud.fogbow.ras.core.plugins.interoperability.emulatedcloud.EmulatedCloudConstants.Plugins.PublicIp.ID_KEY_JSON;
 
 /**

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequest.java
@@ -3,7 +3,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
-import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.DELETE_FIREWALL_RULE_COMMAND;
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroupPlugin.DELETE_FIREWALL_RULE_COMMAND;
 import static cloud.fogbow.ras.core.plugins.interoperability.emulatedcloud.EmulatedCloudConstants.Plugins.PublicIp.ID_KEY_JSON;
 
 /**

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequest.java
@@ -3,23 +3,24 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
 
+import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.DELETE_FIREWALL_RULE_COMMAND;
+import static cloud.fogbow.ras.core.plugins.interoperability.emulatedcloud.EmulatedCloudConstants.Plugins.PublicIp.ID_KEY_JSON;
+
 /**
  * Documentation https://cloudstack.apache.org/api/apidocs-4.9/apis/deleteFirewallRule.html
  *
  * <p> Example URL: <clodstack_endpoint>?apikey=<you_api_key>&command=deleteFirewallRule&id=<id_of_rule>&response=json&signature=<signature> </p>
  */
 public class DeleteFirewallRuleRequest extends CloudStackRequest {
-    public static final String DELETE_RULE_COMMAND = "deleteFirewallRule";
-    public static final String RULE_ID = "id";
 
     protected DeleteFirewallRuleRequest(Builder builder) throws InvalidParameterException {
         super(builder.cloudStackUrl);
-        addParameter(RULE_ID, builder.ruleId);
+        addParameter(ID_KEY_JSON, builder.ruleId);
     }
 
     @Override
     public String getCommand() {
-        return DELETE_RULE_COMMAND;
+        return DELETE_FIREWALL_RULE_COMMAND;
     }
 
     public static class Builder {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleResponse.java
@@ -4,6 +4,8 @@ import cloud.fogbow.common.constants.CloudStackConstants;
 import cloud.fogbow.common.util.GsonHolder;
 import com.google.gson.annotations.SerializedName;
 
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroup.DELETE_FIREWALL_RULE_RESPONSE;
+
 /**
  * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/deleteFirewallRule.html
  *
@@ -19,7 +21,7 @@ import com.google.gson.annotations.SerializedName;
  */
 
 public class DeleteFirewallRuleResponse {
-    @SerializedName(CloudStackConstants.SecurityGroupPlugin.DELETE_FIREWALL_RULE_RESPONSE)
+    @SerializedName(DELETE_FIREWALL_RULE_RESPONSE)
     private FirewallRuleResponse response;
 
     public static class FirewallRuleResponse {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleResponse.java
@@ -7,16 +7,19 @@ import com.google.gson.annotations.SerializedName;
 /**
  * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/deleteFirewallRule.html
  *
- * Example repsonse:
- *
- * <p> {"deletefirewallruleresponse":{"jobid":"bcf3e901-a4a0-4b1c-bcb2-5d8972e30a88"}} </p>
+ * Example response:
+ * {
+ * "deletefirewallruleresponse": {
+ *     "jobid":"bcf3e901-a4a0-4b1c-bcb2-5d8972e30a88"
+ *   }
+ * }
  *
  * Considering this as a async call, will be needed
  * more requests to check the result of this operation
  */
 
 public class DeleteFirewallRuleResponse {
-    @SerializedName(CloudStackConstants.PublicIp.DELETE_FIREWALL_RULE_RESPOSNE)
+    @SerializedName(CloudStackConstants.SecurityGroupPlugin.DELETE_FIREWALL_RULE_RESPONSE)
     private FirewallRuleResponse response;
 
     public static class FirewallRuleResponse {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequest.java
@@ -21,7 +21,6 @@ public class ListFirewallRulesRequest extends CloudStackRequest {
 	public String getCommand() {
 		return CloudStackConstants.SecurityGroupPlugin.LIST_FIREWALL_RULES_COMMAND;
 	}
-	
 
     public static class Builder {
         private String cloudStackUrl;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequest.java
@@ -1,8 +1,10 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
 
-import cloud.fogbow.common.constants.CloudStackConstants;
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackRequest;
+
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroup.IP_ADDRESS_ID_KEY_JSON;
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroup.LIST_FIREWALL_RULES_COMMAND;
 
 /**
  * Documentation : https://cloudstack.apache.org/api/apidocs-4.9/apis/listFirewallRules.html
@@ -14,12 +16,12 @@ public class ListFirewallRulesRequest extends CloudStackRequest {
 
 	protected ListFirewallRulesRequest(Builder builder) throws InvalidParameterException {
         super(builder.cloudStackUrl);
-		addParameter(CloudStackConstants.SecurityGroupPlugin.IP_ADDRESS_ID_KEY_JSON, builder.ipAddressId);
+		addParameter(IP_ADDRESS_ID_KEY_JSON, builder.ipAddressId);
 	}
 
 	@Override
 	public String getCommand() {
-		return CloudStackConstants.SecurityGroupPlugin.LIST_FIREWALL_RULES_COMMAND;
+		return LIST_FIREWALL_RULES_COMMAND;
 	}
 
     public static class Builder {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesResponse.java
@@ -1,18 +1,20 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
 
-import cloud.fogbow.common.constants.CloudStackConstants;
 import cloud.fogbow.common.util.GsonHolder;
 import cloud.fogbow.ras.api.parameters.SecurityRule;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackErrorResponse;
 import com.google.gson.annotations.SerializedName;
+import org.apache.http.client.HttpResponseException;
 
 import java.util.List;
+
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroupPlugin.*;
 
 /**
  * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/listFirewallRules.html
  * 
  * Response example:
- * 
- * {  
+ * {
  *  "listfirewallrulesresponse":{  
  *    "firewallrule":[  
  *      {  
@@ -21,7 +23,7 @@ import java.util.List;
  *        "startport":23,
  *        "endport":24,
  *        "ipaddress" : "0.0.0.1",
- *        "cidrList":"0.0.0.0/0",
+ *        "cidrlist":"0.0.0.0/0",
  *      },
  *      {  
  *        "id":"0bd00d5f-5550-4e06-880a-893de7a13082",
@@ -29,7 +31,7 @@ import java.util.List;
  *        "startport":22,
  *        "endport":22,
  *        "ipaddress" : "0.0.0.2",
- *        "cidrList":"0.0.0.0/0",
+ *        "cidrlist":"0.0.0.0/0",
  *      }
  *    ]
  *   }
@@ -38,37 +40,40 @@ import java.util.List;
  */
 public class ListFirewallRulesResponse {
 
-	@SerializedName(CloudStackConstants.SecurityGroupPlugin.LIST_FIREWALL_RULES_KEY_JSON)
+	@SerializedName(LIST_FIREWALL_RULES_KEY_JSON)
 	private ListFirewallRules response;
 
-	public static ListFirewallRulesResponse fromJson(String jsonResponse) {
-		return GsonHolder.getInstance().fromJson(jsonResponse, ListFirewallRulesResponse.class);
+	public static ListFirewallRulesResponse fromJson(String jsonResponse) throws HttpResponseException {
+		ListFirewallRulesResponse listFirewallRulesResponse =
+				GsonHolder.getInstance().fromJson(jsonResponse, ListFirewallRulesResponse.class);
+		listFirewallRulesResponse.response.checkErrorExistence();
+		return listFirewallRulesResponse;
 	}
 
 	public List<SecurityRuleResponse> getSecurityRulesResponse() {
 		return this.response.securityRulesResponse;
 	}
 	
-	private class ListFirewallRules {
+	private class ListFirewallRules extends CloudStackErrorResponse {
 
-		@SerializedName(CloudStackConstants.SecurityGroupPlugin.FIREWALL_RULE_KEY_JSON)
+		@SerializedName(FIREWALL_RULE_KEY_JSON)
 		private List<SecurityRuleResponse> securityRulesResponse;
 
 	}
 
     public class SecurityRuleResponse {
 
-    	@SerializedName(CloudStackConstants.SecurityGroupPlugin.ID_KEY_JSON)
+    	@SerializedName(ID_KEY_JSON)
         private String instanceId;
-    	@SerializedName(CloudStackConstants.SecurityGroupPlugin.CIDR_LIST_KEY_JSON)
+    	@SerializedName(CIDR_LIST_KEY_JSON)
         private String cidr;
-    	@SerializedName(CloudStackConstants.SecurityGroupPlugin.START_PORT_KEY_JSON)
+    	@SerializedName(START_PORT_KEY_JSON)
         private int portFrom;
-    	@SerializedName(CloudStackConstants.SecurityGroupPlugin.END_PORT_KEY_JSON)
+    	@SerializedName(END_PORT_KEY_JSON)
         private int portTo;
-        @SerializedName(CloudStackConstants.SecurityGroupPlugin.PROPOCOL_KEY_JSON)
+        @SerializedName(PROPOCOL_KEY_JSON)
 		private String protocol;
-        @SerializedName(CloudStackConstants.SecurityGroupPlugin.IP_ADDRESS_KEY_JSON)
+        @SerializedName(IP_ADDRESS_KEY_JSON)
         private String ipAddress;
         
 		public String getInstanceId() {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesResponse.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesResponse.java
@@ -8,7 +8,7 @@ import org.apache.http.client.HttpResponseException;
 
 import java.util.List;
 
-import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroupPlugin.*;
+import static cloud.fogbow.common.constants.CloudStackConstants.SecurityGroup.*;
 
 /**
  * Documentation: https://cloudstack.apache.org/api/apidocs-4.9/apis/listFirewallRules.html

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtilsTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtilsTest.java
@@ -112,7 +112,7 @@ public class CloudStackCloudUtilsTest {
                 .thenReturn(CloudStackQueryJobResult.PROCESSING)
                 .thenReturn(CloudStackQueryJobResult.SUCCESS);
 
-        mockGetTimeSleepThread();
+        mockSleepThread();
 
         // exercise
         String jobInstanceId = CloudStackCloudUtils.waitForResult(client, url, jobId, cloudStackUser);
@@ -140,7 +140,7 @@ public class CloudStackCloudUtilsTest {
         Mockito.when(response.getJobStatus())
                 .thenReturn(CloudStackQueryJobResult.SUCCESS);
 
-        mockGetTimeSleepThread();
+        mockSleepThread();
 
         // exercise
         String jobInstanceId = CloudStackCloudUtils.waitForResult(client, url, jobId, cloudStackUser);
@@ -170,7 +170,7 @@ public class CloudStackCloudUtilsTest {
         Mockito.when(response.getJobInstanceId()).thenReturn(jobInstanceIdExpected);
         Mockito.when(response.getJobStatus()).thenReturn(CloudStackQueryJobResult.PROCESSING);
 
-        mockGetTimeSleepThread();
+        mockSleepThread();
 
         // verify
         this.expectedException.expect(CloudStackCloudUtils.TimeoutCloudstackAsync.class);
@@ -242,7 +242,7 @@ public class CloudStackCloudUtilsTest {
     @Test
     public void testGetAsyncJobResponse() throws FogbowException {
         // set up
-        CloudStackHttpClient client =  Mockito.mock(CloudStackHttpClient.class);;
+        CloudStackHttpClient client =  Mockito.mock(CloudStackHttpClient.class);
         String cloudstackUrl = "cloudstackUrl";
         String jobId = "jobId";
         CloudStackUser cloudstackUser = CloudstackTestUtils.CLOUD_STACK_USER;
@@ -301,10 +301,10 @@ public class CloudStackCloudUtilsTest {
         return response;
     }
 
-    private void mockGetTimeSleepThread() {
-        long TINY_VALUE = 1L;
-        PowerMockito.spy(CloudStackCloudUtils.class);
-        PowerMockito.when(CloudStackCloudUtils.getTimeSleepThread()).thenReturn(TINY_VALUE);
+    private void mockSleepThread() throws InterruptedException {
+        PowerMockito.mockStatic(Thread.class);
+        PowerMockito.doNothing().when(Thread.class);
+        Thread.sleep(Mockito.anyLong());
     }
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtilsTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtilsTest.java
@@ -173,7 +173,7 @@ public class CloudStackCloudUtilsTest {
         mockSleepThread();
 
         // verify
-        this.expectedException.expect(CloudStackCloudUtils.TimeoutCloudstackAsync.class);
+        this.expectedException.expect(CloudStackCloudUtils.CloudStackTimeoutException.class);
 
         // exercise
         try {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtilsTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackCloudUtilsTest.java
@@ -282,7 +282,7 @@ public class CloudStackCloudUtilsTest {
         CloudStackCloudUtils.sleepThread();
 
         // verify
-        this.loggerTestChecking.assertEquals(1, Level.WARN, Messages.Warn.THREAD_INTERRUPTED);
+        this.loggerTestChecking.assertEquals(1, Level.WARN, Messages.Warn.SLEEP_THREAD_INTERRUPTED);
     }
 
     private CloudStackQueryAsyncJobResponse mockGetAsyncJobResponse() throws FogbowException {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
@@ -59,6 +59,7 @@ public class CloudstackTestUtils {
             "listfirewallrulesresponse_error.json";
     private static final String LIST_FIREWALL_RULES_EMPTY_RESPONSE =
             "listfirewallrulesresponse_empty.json";
+    private static final String DELETE_FIREWALL_RULE_RESPONSE = "deletefirewallruleresponse.json";
 
     public static final CloudStackUser CLOUD_STACK_USER =
             new CloudStackUser("id", "", "", "", new HashMap<>());
@@ -342,6 +343,13 @@ public class CloudstackTestUtils {
                 + LIST_FIREWALL_RULES_ERROR_RESPONSE);
 
         return String.format(rawJson, errorCode, errorText);
+    }
+
+    public static String deleteFirewallRuleAsyncResponseJson(String jobId) throws IOException {
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + DELETE_FIREWALL_RULE_RESPONSE);
+
+        return String.format(rawJson, jobId);
     }
 
     private static String getPathCloudstackFile() {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
@@ -54,6 +54,11 @@ public class CloudstackTestUtils {
     private static final String ASYNC_ATTACH_VOLUME_RESPONSE = "queryasyncattachvolumeresponse.json";
     private static final String ASYNC_ERROR_RESPONSE = "queryasyncresponse_error.json";
     private static final String CREATE_FIREWALL_RULE_RESPONSE = "createfirewallruleresponse.json";
+    private static final String LIST_FIREWALL_RULES_RESPONSE = "listfirewallrulesresponse.json";
+    private static final String LIST_FIREWALL_RULES_ERROR_RESPONSE =
+            "listfirewallrulesresponse_error.json";
+    private static final String LIST_FIREWALL_RULES_EMPTY_RESPONSE =
+            "listfirewallrulesresponse_empty.json";
 
     public static final CloudStackUser CLOUD_STACK_USER =
             new CloudStackUser("id", "", "", "", new HashMap<>());
@@ -311,6 +316,32 @@ public class CloudstackTestUtils {
         byte[] bytes = Files.readAllBytes(path);
         String data = new String(bytes);
         return data;
+    }
+
+    public static String createListFirewallRulesResponseJson(String id, String protocol, int startPort,
+                                                      int endPort, String ipaddress, String cird)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + LIST_FIREWALL_RULES_RESPONSE);
+
+        return String.format(rawJson, id, protocol, startPort, endPort, ipaddress, cird);
+    }
+
+    public static String createListFirewallRulesEmptyResponseJson() throws IOException {
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + LIST_FIREWALL_RULES_EMPTY_RESPONSE);
+
+        return String.format(rawJson);
+    }
+
+    public static String createListFirewallRulesErrorResponseJson(int errorCode, String errorText)
+            throws IOException {
+
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + LIST_FIREWALL_RULES_ERROR_RESPONSE);
+
+        return String.format(rawJson, errorCode, errorText);
     }
 
     private static String getPathCloudstackFile() {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudstackTestUtils.java
@@ -53,6 +53,7 @@ public class CloudstackTestUtils {
     private static final String DETACH_VOLUME_ERROR_RESPONSE = "detachvolumeresponse_error.json";
     private static final String ASYNC_ATTACH_VOLUME_RESPONSE = "queryasyncattachvolumeresponse.json";
     private static final String ASYNC_ERROR_RESPONSE = "queryasyncresponse_error.json";
+    private static final String CREATE_FIREWALL_RULE_RESPONSE = "createfirewallruleresponse.json";
 
     public static final CloudStackUser CLOUD_STACK_USER =
             new CloudStackUser("id", "", "", "", new HashMap<>());
@@ -296,6 +297,13 @@ public class CloudstackTestUtils {
                 + ASYNC_ERROR_RESPONSE);
 
         return String.format(rawJson, jobStatus, errorCode, errorText);
+    }
+
+    public static String createFirewallRuleAsyncResponseJson(String jobId) throws IOException {
+        String rawJson = readFileAsString(getPathCloudstackFile()
+                + CREATE_FIREWALL_RULE_RESPONSE);
+
+        return String.format(rawJson, jobId);
     }
 
     private static String readFileAsString(final String fileName) throws IOException {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
@@ -10,6 +10,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.compute.v4_9.Ge
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.CreateNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.DeleteNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.GetNetworkRequest;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
 import org.mockito.ArgumentMatcher;
 
 public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher<T> {
@@ -83,6 +84,12 @@ public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher
 
     public static class AttachmentJobStatus extends RequestMatcher<AttachmentJobStatusRequest> {
         public AttachmentJobStatus(CloudStackRequest cloudStackRequest) {
+            super(cloudStackRequest);
+        }
+    }
+
+    public static class CreateFirewallRule extends RequestMatcher<CreateFirewallRuleRequest> {
+        public CreateFirewallRule(CloudStackRequest cloudStackRequest) {
             super(cloudStackRequest);
         }
     }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/RequestMatcher.java
@@ -11,6 +11,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.Cr
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.DeleteNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.GetNetworkRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9.DeleteFirewallRuleRequest;
 import org.mockito.ArgumentMatcher;
 
 public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher<T> {
@@ -90,6 +91,12 @@ public class RequestMatcher<T extends CloudStackRequest> extends ArgumentMatcher
 
     public static class CreateFirewallRule extends RequestMatcher<CreateFirewallRuleRequest> {
         public CreateFirewallRule(CloudStackRequest cloudStackRequest) {
+            super(cloudStackRequest);
+        }
+    }
+
+    public static class DeleteFirewallRule extends RequestMatcher<DeleteFirewallRuleRequest> {
+        public DeleteFirewallRule(CloudStackRequest cloudStackRequest) {
             super(cloudStackRequest);
         }
     }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -18,29 +18,28 @@ import cloud.fogbow.ras.core.SharedOrderHolders;
 import cloud.fogbow.ras.core.TestUtils;
 import cloud.fogbow.ras.core.datastore.DatabaseManager;
 import cloud.fogbow.ras.core.models.ResourceType;
-import cloud.fogbow.ras.core.models.orders.ComputeOrder;
-import cloud.fogbow.ras.core.models.orders.NetworkOrder;
 import cloud.fogbow.ras.core.models.orders.Order;
-import cloud.fogbow.ras.core.models.orders.PublicIpOrder;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudStackCloudUtils;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.RequestMatcher;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CloudStackPublicIpPlugin;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleAsyncResponse;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
-import com.google.gson.Gson;
-import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpResponseException;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.mockito.internal.verification.VerificationModeFactory;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
 
 @PowerMockIgnore({"javax.net.ssl.*", "javax.crypto.*" })
 @PrepareForTest({SharedOrderHolders.class, DatabaseManager.class, CloudStackUrlUtil.class,
@@ -49,24 +48,9 @@ import java.util.*;
         ListFirewallRulesResponse.class})
 public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
 
-    private static String FAKE_JOB_ID = "fake-job-id";
-    private static String FAKE_SECURITY_RULE_ID = "fake-rule-id";
-    private static final String JSON = "json";
-    private static final String RESPONSE_KEY = "response";
-    private static final String ID_KEY = "id";
-    private static final HashMap<String, String> FAKE_COOKIE_HEADER = new HashMap<>();
-
-    private static final String FAKE_USER_ID = "fake-user-id";
-    private static final String FAKE_USERNAME = "fake-username";
-    private static final String FAKE_DOMAIN = "fake-domain";
-    private static final String FAKE_TOKEN_VALUE = "x" + CloudStackConstants.KEY_VALUE_SEPARATOR + "y";
-
-    private static final CloudStackUser FAKE_CLOUD_USER = new CloudStackUser(FAKE_USER_ID, FAKE_USERNAME, FAKE_TOKEN_VALUE, FAKE_DOMAIN, FAKE_COOKIE_HEADER);
-
     @Rule
     private ExpectedException expectedException = ExpectedException.none();
 
-    private CloudStackQueryJobResult queryJobResult;
     private CloudStackSecurityRulePlugin plugin;
     private CloudStackHttpClient client;
     private CloudStackUser cloudStackUser;
@@ -79,11 +63,6 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
         this.cloudStackUrl = properties.getProperty(CloudStackCloudUtils.CLOUDSTACK_URL_CONFIG);
         this.cloudStackUser = CloudstackTestUtils.CLOUD_STACK_USER;
 
-        // we dont want HttpRequestUtil code to be executed in this test
-        PowerMockito.mockStatic(CloudStackHttpClient.class);
-        PowerMockito.mockStatic(CloudStackQueryJobResult.class);
-
-        this.queryJobResult = Mockito.mock(CloudStackQueryJobResult.class);
         this.client = Mockito.mock(CloudStackHttpClient.class);
         this.plugin = Mockito.spy(new CloudStackSecurityRulePlugin(cloudStackConfFilePath));
         this.plugin.setClient(this.client);
@@ -394,7 +373,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
         PowerMockito.when(CloudStackPublicIpPlugin.getPublicIpId(Mockito.eq(orderId)))
                 .thenReturn(publicIpId);
 
-        List<SecurityRuleInstance> securityRulesExpected = new ArrayList();
+        List<SecurityRuleInstance> securityRulesExpected = new ArrayList<>();
         Mockito.doReturn(securityRulesExpected).when(this.plugin).getFirewallRules(
                 Mockito.eq(publicIpId), Mockito.eq(this.cloudStackUser));
 
@@ -624,366 +603,4 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
         Assert.assertNull(fogbowProtocol);
     }
 
-    // # ------- old code --------- @
-
-    // test case: success case
-    @Test
-    public void testGetFirewallRules() throws FogbowException, HttpResponseException {
-        // setup
-        Order publicIpOrder = new PublicIpOrder();
-        String instanceId = "instanceId";
-        publicIpOrder.setInstanceId(instanceId);
-
-        // create firewall rules response
-        int portFrom = 20;
-        int portTo = 30;
-        String cidr = "0.0.0.0/0";
-        SecurityRule.EtherType etherType = SecurityRule.EtherType.IPv4;
-        SecurityRule.Protocol protocol = SecurityRule.Protocol.TCP;
-        List<SecurityRuleInstance> securityRulesExpected = new ArrayList<SecurityRuleInstance>();
-        securityRulesExpected.add(new SecurityRuleInstance("instance1", SecurityRule.Direction.IN, portFrom, portTo, cidr, etherType, protocol));
-        securityRulesExpected.add(new SecurityRuleInstance("instance2", SecurityRule.Direction.IN, portFrom, portTo, cidr, etherType, protocol));
-        String listFirewallRulesResponse = getListFirewallRulesResponseJson(securityRulesExpected, etherType);
-
-        Mockito.when(this.client.doGetRequest(
-                Mockito.anyString(), Mockito.any(CloudStackUser.class)))
-                .thenReturn(listFirewallRulesResponse);
-
-        CloudStackPublicIpPlugin.setOrderidToInstanceIdMapping(publicIpOrder.getId(), instanceId);
-
-        // exercise
-        List<SecurityRuleInstance> securityRules = this.plugin.getSecurityRules(publicIpOrder, FAKE_CLOUD_USER);
-
-        //verify
-        Assert.assertEquals(securityRulesExpected.size(), securityRules.size());
-        Assert.assertEquals(securityRulesExpected.get(0).toString(), securityRules.get(0).toString());
-        Assert.assertEquals(securityRulesExpected.get(1).toString(), securityRules.get(1).toString());
-    }
-
-    // test case: throw exception when trying to request to the cloudstack
-    @Test
-    public void testGetFirewallRulesExceptionInComunication()
-            throws FogbowException, HttpResponseException {
-        // setup
-        Order publicIpOrder = new PublicIpOrder();
-
-        HttpResponseException badRequestException = new HttpResponseException(HttpStatus.SC_BAD_REQUEST, "");
-        Mockito.doThrow(badRequestException).when(this.client).doGetRequest(
-                Mockito.anyString(), Mockito.any(CloudStackUser.class));
-
-        CloudStackPublicIpPlugin.setOrderidToInstanceIdMapping(publicIpOrder.getId(), publicIpOrder.getId());
-
-        // exercise
-        List<SecurityRuleInstance> securityRuleInstances = null;
-        try {
-            this.plugin.getSecurityRules(publicIpOrder, FAKE_CLOUD_USER);
-            Assert.fail();
-        } catch (FogbowException e) {
-        }
-
-
-        // verify
-        Assert.assertNull(securityRuleInstances);
-        Mockito.verify(this.client, Mockito.times(1)).doGetRequest(
-                Mockito.anyString(),
-                Mockito.eq(FAKE_CLOUD_USER));
-    }
-
-    // test case: unsupported network order
-    @Ignore
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetFirewallRulesNetworkOrder() throws FogbowException {
-        // setup
-        Order networkOrder = new NetworkOrder();
-
-        // exercise
-        this.plugin.getSecurityRules(networkOrder, FAKE_CLOUD_USER);
-    }
-
-    // test case: throw exception when the order is different of the options: network, publicip
-    @Test(expected = UnexpectedException.class)
-    public void testGetFirewallRulesOrderIrregular() throws FogbowException {
-        // setup
-        Order irregularOrder = new ComputeOrder();
-
-        // exercise
-        this.plugin.getSecurityRules(irregularOrder, FAKE_CLOUD_USER);
-    }
-
-    @Ignore // TODO(chico) - It make no more sense
-    // test case: Test waitForJobResult method, when max tries is reached.
-    @Test
-    public void testWaitForJobResultUntilMaxTries() throws FogbowException {
-        // set up
-        Mockito.doNothing().when(plugin).deleteSecurityRule(Mockito.anyString(), Mockito.any(CloudStackUser.class));
-        String processingJobResponse = getProcessingJobResponse(CloudStackQueryJobResult.PROCESSING);
-        BDDMockito.given(this.queryJobResult.getQueryJobResult(
-                Mockito.any(CloudStackHttpClient.class), Mockito.anyString(), Mockito.anyString(), Mockito.any(CloudStackUser.class))).
-                willReturn(processingJobResponse);
-
-        // exercise
-        try {
-            CloudStackCloudUtils.waitForResult(this.client, this.cloudStackUrl, FAKE_JOB_ID, Mockito.mock(CloudStackUser.class));
-            Assert.fail();
-        } catch (FogbowException e) {
-            // verify
-            Mockito.verify(this.plugin, Mockito.times(1)).deleteSecurityRule(Mockito.anyString(),
-                    Mockito.any(CloudStackUser.class));
-        }
-    }
-
-    // test case: Test waitForJobResult method, after getting processing status for 5 seconds it will fail and test if
-    // catches a FogbowException.
-    @Test
-    public void testWaitForJobResultWillReturnFailedJob() throws FogbowException {
-        // set up
-        Mockito.doNothing().when(plugin).deleteSecurityRule(Mockito.anyString(), Mockito.any(CloudStackUser.class));
-
-        String processingJobResponse = getProcessingJobResponse(CloudStackQueryJobResult.PROCESSING);
-        BDDMockito.given(this.queryJobResult.getQueryJobResult(
-                Mockito.any(CloudStackHttpClient.class), Mockito.anyString(), Mockito.anyString(), Mockito.any(CloudStackUser.class))).
-                willReturn(processingJobResponse);
-
-        // exercise
-        try {
-            TimerTask timerTask = getTimerTask(CloudStackQueryJobResult.FAILURE);
-            new Timer().schedule(timerTask, 5 * CloudStackCloudUtils.ONE_SECOND_IN_MILIS);
-            CloudStackCloudUtils.waitForResult(Mockito.mock(CloudStackHttpClient.class), this.cloudStackUrl,
-                    FAKE_JOB_ID, Mockito.mock(CloudStackUser.class));
-            Assert.fail();
-        } catch (FogbowException e) {
-            // verify
-            Mockito.verify(this.plugin, Mockito.times(0)).deleteSecurityRule(Mockito.anyString(),
-                    Mockito.any(CloudStackUser.class));
-        }
-    }
-
-    // test case: Test waitForJobResult method, after getting 'processing' status for 5 seconds, it will be attended
-    // and test if returns the instanceId.
-    @Test
-    public void testWaitForJobResultWillReturnSuccessJob() throws FogbowException {
-        // set up
-        String processingJobResponse = getProcessingJobResponse(CloudStackQueryJobResult.PROCESSING);
-        BDDMockito.given(this.queryJobResult.getQueryJobResult(
-                Mockito.any(CloudStackHttpClient.class), Mockito.anyString(), Mockito.anyString(), Mockito.any(CloudStackUser.class))).
-                willReturn(processingJobResponse);
-
-        // exercise
-        TimerTask timerTask = getTimerTask(CloudStackQueryJobResult.SUCCESS);
-        new Timer().schedule(timerTask, 5 * CloudStackCloudUtils.ONE_SECOND_IN_MILIS);
-        String instanceId = CloudStackCloudUtils.waitForResult(Mockito.mock(CloudStackHttpClient.class),
-                this.cloudStackUrl, FAKE_JOB_ID, Mockito.mock(CloudStackUser.class));
-
-        // verify
-        Assert.assertEquals(FAKE_SECURITY_RULE_ID, instanceId);
-    }
-
-    // test case: Test waitForJobResult method receives a failed job and test if catches a FogbowException.
-    @Test
-    public void testWaitForJobResultFailedJob() throws FogbowException {
-        // set up
-        Mockito.doNothing().when(plugin).deleteSecurityRule(Mockito.anyString(), Mockito.any(CloudStackUser.class));
-
-        String processingJobResponse = getProcessingJobResponse(CloudStackQueryJobResult.FAILURE);
-        BDDMockito.given(this.queryJobResult.getQueryJobResult(
-                Mockito.any(CloudStackHttpClient.class), Mockito.anyString(), Mockito.anyString(), Mockito.any(CloudStackUser.class))).
-                willReturn(processingJobResponse);
-
-        // exercise
-        try {
-            CloudStackCloudUtils.waitForResult(Mockito.mock(CloudStackHttpClient.class),
-                    this.cloudStackUrl, FAKE_JOB_ID, Mockito.mock(CloudStackUser.class));
-            Assert.fail();
-        } catch (FogbowException e) {
-            // verify
-            Mockito.verify(this.plugin, Mockito.times(0)).deleteSecurityRule(Mockito.anyString(),
-                    Mockito.any(CloudStackUser.class));
-        }
-    }
-
-    // test case: Test waitForJobResult method receives a sucessful job and test if returns the instanceId.
-    @Test
-    public void testWaitForJobResultSuccessJob() throws FogbowException {
-        // set up
-        String processingJobResponse = getProcessingJobResponse(CloudStackQueryJobResult.PROCESSING);
-        String successJobResponse = getProcessingJobResponse(CloudStackQueryJobResult.SUCCESS);
-        BDDMockito.given(this.queryJobResult.getQueryJobResult(
-                Mockito.any(CloudStackHttpClient.class), Mockito.anyString(), Mockito.anyString(), Mockito.any(CloudStackUser.class))).
-                willReturn(processingJobResponse, successJobResponse);
-
-        // exercise
-        String instanceId = CloudStackCloudUtils.waitForResult(Mockito.mock(CloudStackHttpClient.class),
-                this.cloudStackUrl, FAKE_JOB_ID, Mockito.mock(CloudStackUser.class));
-
-        // verify
-        Assert.assertEquals(FAKE_SECURITY_RULE_ID, instanceId);
-    }
-
-    // test case: Test delete security rule success operation should make at least three http get request: one for the
-    // delete operation itself; one to get the processing job status and the last one to get the success job status.
-    @Test
-    public void testDeleteSecurityRule() throws FogbowException, HttpResponseException {
-        // set up
-        String processingJobResponse = getProcessingJobResponse(CloudStackQueryJobResult.PROCESSING);
-        String successJobResponse = getProcessingJobResponse(CloudStackQueryJobResult.SUCCESS);
-        BDDMockito.given(this.queryJobResult.getQueryJobResult(
-                Mockito.any(CloudStackHttpClient.class), Mockito.anyString(), Mockito.anyString(), Mockito.any(CloudStackUser.class)))
-                .willReturn(processingJobResponse)
-                .willReturn(successJobResponse);
-
-        String deleteRuleCommand = DeleteFirewallRuleRequest.DELETE_RULE_COMMAND;
-        String expectedDeleteRuleRequestUrl = generateExpectedUrl(this.cloudStackUrl, deleteRuleCommand,
-                RESPONSE_KEY, JSON,
-                ID_KEY, FAKE_SECURITY_RULE_ID);
-        String fakeResponse = getDeleteFirewallRuleResponse(FAKE_JOB_ID);
-
-        PowerMockito.mockStatic(CloudStackUrlUtil.class);
-        PowerMockito.when(CloudStackUrlUtil.createURIBuilder(Mockito.anyString(), Mockito.anyString())).thenCallRealMethod();
-        Mockito.when(this.client.doGetRequest(Mockito.eq(expectedDeleteRuleRequestUrl), Mockito.eq(FAKE_CLOUD_USER)))
-                .thenReturn(fakeResponse);
-
-        // exercise
-        this.plugin.deleteSecurityRule(FAKE_SECURITY_RULE_ID, FAKE_CLOUD_USER);
-
-        // verify
-        Mockito.verify(this.client, Mockito.times(1))
-                .doGetRequest(expectedDeleteRuleRequestUrl, FAKE_CLOUD_USER);
-    }
-
-    @Ignore
-    @Test(expected = FogbowException.class)
-    public void testDeleteSecurityRuleTimeoutFail() throws FogbowException, HttpResponseException {
-        // set up
-        String processingJobResponse = getProcessingJobResponse(CloudStackQueryJobResult.PROCESSING);
-        BDDMockito.given(this.queryJobResult.getQueryJobResult(
-                Mockito.any(CloudStackHttpClient.class), Mockito.anyString(), Mockito.anyString(), Mockito.any(CloudStackUser.class)))
-                .willReturn(processingJobResponse);
-
-        String deleteRuleCommand = DeleteFirewallRuleRequest.DELETE_RULE_COMMAND;
-        String expectedDeleteRuleRequestUrl = generateExpectedUrl(this.cloudStackUrl, deleteRuleCommand,
-                RESPONSE_KEY, JSON,
-                ID_KEY, FAKE_SECURITY_RULE_ID);
-        String fakeResponse = getDeleteFirewallRuleResponse(FAKE_JOB_ID);
-
-        PowerMockito.mockStatic(CloudStackUrlUtil.class);
-        PowerMockito.when(CloudStackUrlUtil.createURIBuilder(Mockito.anyString(), Mockito.anyString())).thenCallRealMethod();
-        Mockito.when(this.client.doGetRequest(Mockito.eq(expectedDeleteRuleRequestUrl), Mockito.eq(FAKE_CLOUD_USER)))
-                .thenReturn(fakeResponse);
-
-        // exercise
-        this.plugin.deleteSecurityRule(FAKE_SECURITY_RULE_ID, FAKE_CLOUD_USER);
-
-        // verify
-        Mockito.verify(this.client, Mockito.times(1))
-                .doGetRequest(expectedDeleteRuleRequestUrl, FAKE_CLOUD_USER);
-    }
-
-    // Test case: http request fail on deleting security rule
-    @Test(expected = FogbowException.class)
-    public void testDeleteSecurityRuleHttpFail() throws FogbowException, HttpResponseException {
-        // set up
-        String deleteRuleCommand = DeleteFirewallRuleRequest.DELETE_RULE_COMMAND;
-        String expectedDeleteRuleRequestUrl = generateExpectedUrl(this.cloudStackUrl, deleteRuleCommand,
-                RESPONSE_KEY, JSON,
-                ID_KEY, FAKE_SECURITY_RULE_ID);
-
-        PowerMockito.mockStatic(CloudStackUrlUtil.class);
-        PowerMockito.when(CloudStackUrlUtil.createURIBuilder(Mockito.anyString(), Mockito.anyString())).thenCallRealMethod();
-
-        // Delete response is unused
-        Mockito.when(this.client.doGetRequest(expectedDeleteRuleRequestUrl, FAKE_CLOUD_USER)).thenThrow(
-                new HttpResponseException(503, "service unavailable"));
-
-        // exercise
-        this.plugin.deleteSecurityRule(FAKE_SECURITY_RULE_ID, FAKE_CLOUD_USER);
-
-        Mockito.verify(this.client, Mockito.times(1))
-                .doGetRequest(expectedDeleteRuleRequestUrl, FAKE_CLOUD_USER);
-    }
-
-    private String getProcessingJobResponse(int processing) {
-        return "{\n" +
-                "  \"queryasyncjobresultresponse\": {\n" +
-                "    \"jobstatus\": " + processing + ", \n" +
-                "    \"jobinstanceid\": \"" + FAKE_SECURITY_RULE_ID + "\"\n" +
-                "  }\n" +
-                "}";
-    }
-
-    private TimerTask getTimerTask(int status) {
-        return new TimerTask() {
-            @Override
-            public void run() {
-                String processingJobResponse = getProcessingJobResponse(status);
-                try {
-                    BDDMockito.given(CloudStackSecurityRulePluginTest.this.queryJobResult.getQueryJobResult(
-                            Mockito.any(CloudStackHttpClient.class), Mockito.anyString(), Mockito.anyString(), Mockito.any(CloudStackUser.class))).
-                            willReturn(processingJobResponse);
-                } catch (FogbowException e) {
-                    e.printStackTrace();
-                }
-            }
-        };
-    }
-
-    private SecurityRule createSecurityRule() {
-        SecurityRule securityRule = new SecurityRule(SecurityRule.Direction.IN, 10000, 10005, "10.0.0.0/24",
-                SecurityRule.EtherType.IPv4, SecurityRule.Protocol.TCP);
-        return securityRule;
-    }
-
-    private String getListFirewallRulesResponseJson(List<SecurityRuleInstance> securityRuleInstances, SecurityRule.EtherType etherType) {
-        List<Map<String, Object>> listFirewallRule = new ArrayList<Map<String, Object>>();
-        for (SecurityRuleInstance securityRuleInstance : securityRuleInstances) {
-            Map<String, Object> firewallRule = new HashMap<String, Object>();
-            firewallRule.put(CloudStackConstants.SecurityGroupPlugin.CIDR_LIST_KEY_JSON,
-                    securityRuleInstance.getCidr());
-            firewallRule.put(CloudStackConstants.SecurityGroupPlugin.ID_KEY_JSON,
-                    securityRuleInstance.getId());
-            firewallRule.put(CloudStackConstants.SecurityGroupPlugin.START_PORT_KEY_JSON,
-                    securityRuleInstance.getPortFrom());
-            firewallRule.put(CloudStackConstants.SecurityGroupPlugin.END_PORT_KEY_JSON,
-                    securityRuleInstance.getPortTo());
-            firewallRule.put(CloudStackConstants.SecurityGroupPlugin.PROPOCOL_KEY_JSON,
-                    securityRuleInstance.getProtocol().toString());
-            if (etherType.equals(SecurityRule.EtherType.IPv4)) {
-                firewallRule.put(CloudStackConstants.SecurityGroupPlugin.IP_ADDRESS_KEY_JSON, "0.0.0.0");
-            } else {
-                firewallRule.put(CloudStackConstants.SecurityGroupPlugin.IP_ADDRESS_KEY_JSON,
-                        "FE80:0000:0000:0000:0202:B3FF:FE1E:8329");
-            }
-
-            listFirewallRule.add(firewallRule);
-        }
-        Map<String, List<Map<String, Object>>> firewallRules = new HashMap<String, List<Map<String, Object>>>();
-        firewallRules.put(CloudStackConstants.SecurityGroupPlugin.FIREWALL_RULE_KEY_JSON, listFirewallRule);
-
-        Map<String, Object> floatingipJsonKey = new HashMap<String, Object>();
-        floatingipJsonKey.put(CloudStackConstants.SecurityGroupPlugin.LIST_FIREWALL_RULES_KEY_JSON, firewallRules);
-
-        Gson gson = new Gson();
-        return gson.toJson(floatingipJsonKey);
-    }
-
-    private String generateExpectedUrl(String endpoint, String command, String... keysAndValues) {
-        if (keysAndValues.length % 2 != 0) {
-            // there should be one value for each key
-            return null;
-        }
-
-        String url = String.format("%s?command=%s", endpoint, command);
-        for (int i = 0; i < keysAndValues.length; i += 2) {
-            String key = keysAndValues[i];
-            String value = keysAndValues[i + 1];
-            url += String.format("&%s=%s", key, value);
-        }
-
-        return url;
-    }
-
-    private String getDeleteFirewallRuleResponse(String id) {
-        String response = "{\"deletefirewallruleresponse\":{\"jobid\":\"%s\"}}";
-
-        return String.format(response, id);
-    }
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -87,7 +87,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
     // it must verify if the doRequestInstance is called with the right parameters;
     // this includes the checking of the Cloudstack request.
     @Test
-    public void testRequestSecurityRule() throws FogbowException {
+    public void testRequestSecurityRuleSuccessfully() throws FogbowException {
         // set up
         String cidr = "10.10.10.10/20";
         int portFromExpected = 22;

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -554,6 +554,76 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
         Assert.assertTrue(securityRuleInstances.isEmpty());
     }
 
+    // test case: When calling the getFogbowProtocol method and the protocol is TCP,
+    // it must verify if It return a TPC FogbowProtocol.
+    @Test
+    public void testGetFogbowProtocolWheIsTcp() {
+        // set up
+        String protocol = CloudStackConstants.SecurityGroupPlugin.TCP_VALUE_PROTOCOL;
+
+        // exercise
+        SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
+
+        // verify
+        Assert.assertEquals(SecurityRule.Protocol.TCP, fogbowProtocol);
+    }
+
+    // test case: When calling the getFogbowProtocol method and the protocol is UDP,
+    // it must verify if It return a UDP FogbowProtocol.
+    @Test
+    public void testGetFogbowProtocolWhenIsUdp() {
+        // set up
+        String protocol = CloudStackConstants.SecurityGroupPlugin.UDP_VALUE_PROTOCOL;
+
+        // exercise
+        SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
+
+        // verify
+        Assert.assertEquals(SecurityRule.Protocol.UDP, fogbowProtocol);
+    }
+
+    // test case: When calling the getFogbowProtocol method and the protocol is IMCP,
+    // it must verify if It return a IMCP FogbowProtocol.
+    @Test
+    public void testGetFogbowProtocolWhenIsImcp() {
+        // set up
+        String protocol = CloudStackConstants.SecurityGroupPlugin.ICMP_VALUE_PROTOCOL;
+
+        // exercise
+        SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
+
+        // verify
+        Assert.assertEquals(SecurityRule.Protocol.ICMP, fogbowProtocol);
+    }
+
+    // test case: When calling the getFogbowProtocol method and the protocol is any,
+    // it must verify if It return a ANY FogbowProtocol.
+    @Test
+    public void testGetFogbowProtocolWhenIsAny() {
+        // set up
+        String protocol = CloudStackConstants.SecurityGroupPlugin.ALL_VALUE_PROTOCOL;
+
+        // exercise
+        SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
+
+        // verify
+        Assert.assertEquals(SecurityRule.Protocol.ANY, fogbowProtocol);
+    }
+
+    // test case: When calling the getFogbowProtocol method and the protocol is unknown,
+    // it must verify if It return null.
+    @Test
+    public void testGetFogbowProtocolFail() {
+        // set up
+        String protocol = "unknown";
+
+        // exercise
+        SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
+
+        // verify
+        Assert.assertNull(fogbowProtocol);
+    }
+
     // # ------- old code --------- @
 
     // test case: success case

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -242,7 +242,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
     }
 
     // test case: When calling the doRequestInstance method with secondary methods mocked and occurs
-    // a TimeoutCloudstackAsync, it must verify if It will delete the instance and rethorws the
+    // a CloudStackTimeoutException, it must verify if It will delete the instance and rethorws the
     // exception.
     @Test
     public void testDoRequestInstanceFailWhenTimeout() throws FogbowException, HttpResponseException {
@@ -266,7 +266,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
         String errorMessage = "error";
         PowerMockito.when(CloudStackCloudUtils.waitForResult(Mockito.eq(this.client),
                 Mockito.eq(this.cloudStackUrl), Mockito.eq(jobId), Mockito.eq(this.cloudStackUser)))
-                .thenThrow(new CloudStackCloudUtils.TimeoutCloudstackAsync(errorMessage));
+                .thenThrow(new CloudStackCloudUtils.CloudStackTimeoutException(errorMessage));
 
         CloudStackQueryAsyncJobResponse responseAsync = Mockito.mock(CloudStackQueryAsyncJobResponse.class);
         String securityGroupId = "securityId";
@@ -279,7 +279,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
                 Mockito.eq(securityGroupId), Mockito.eq(this.cloudStackUser));
 
         // verify
-        this.expectedException.expect(CloudStackCloudUtils.TimeoutCloudstackAsync.class);
+        this.expectedException.expect(CloudStackCloudUtils.CloudStackTimeoutException.class);
         this.expectedException.expectMessage(errorMessage);
 
         // exercise

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -26,10 +26,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.C
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleAsyncResponse;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
 import org.apache.http.client.HttpResponseException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 import org.mockito.internal.verification.VerificationModeFactory;
@@ -644,5 +641,9 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
         // verify
         Assert.assertNull(etherType);
     }
+
+    @Ignore
+    @Test
+    public void testDeleteSecurityRule() {}
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -548,7 +548,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
     }
 
     // test case: When calling the getFogbowProtocol method and the protocol is UDP,
-    // it must verify if It return a UDP FogbowProtocol.
+    // it must verify if It return an UDP FogbowProtocol.
     @Test
     public void testGetFogbowProtocolWhenIsUdp() {
         // set up
@@ -562,7 +562,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
     }
 
     // test case: When calling the getFogbowProtocol method and the protocol is IMCP,
-    // it must verify if It return a IMCP FogbowProtocol.
+    // it must verify if It return an IMCP FogbowProtocol.
     @Test
     public void testGetFogbowProtocolWhenIsImcp() {
         // set up
@@ -576,7 +576,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
     }
 
     // test case: When calling the getFogbowProtocol method and the protocol is any,
-    // it must verify if It return a ANY FogbowProtocol.
+    // it must verify if It return an ANY FogbowProtocol.
     @Test
     public void testGetFogbowProtocolWhenIsAny() {
         // set up
@@ -601,6 +601,48 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
 
         // verify
         Assert.assertNull(fogbowProtocol);
+    }
+
+    // test case: When calling the inferEtherType method with an IP Ipv4,
+    // it must verify if It returns an EtherType.IPv4.
+    @Test
+    public void testInferEtherTypeWhenIpv4() {
+        // set up
+        String ipAddress = "10.10.10.10";
+
+        // exercise
+        SecurityRule.EtherType etherType = this.plugin.inferEtherType(ipAddress);
+
+        // verify
+        Assert.assertEquals(SecurityRule.EtherType.IPv4, etherType);
+    }
+
+    // test case: When calling the inferEtherType method with an IP Ipv6,
+    // it must verify if It returns an EtherType.IPv6.
+    @Test
+    public void testInferEtherTypeWhenIpv6() {
+        // set up
+        String ipAddress = "2001:db8:85a3:8d3:1319:8a2e:370:7348";
+
+        // exercise
+        SecurityRule.EtherType etherType = this.plugin.inferEtherType(ipAddress);
+
+        // verify
+        Assert.assertEquals(SecurityRule.EtherType.IPv6, etherType);
+    }
+
+    // test case: When calling the inferEtherType method with an unknown value,
+    // it must verify if It returns null.
+    @Test
+    public void testInferEtherTypeFail() {
+        // set up
+        String ipAddress = "wrong";
+
+        // exercise
+        SecurityRule.EtherType etherType = this.plugin.inferEtherType(ipAddress);
+
+        // verify
+        Assert.assertNull(etherType);
     }
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -536,7 +536,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
     @Test
     public void testGetFogbowProtocolWheIsTcp() {
         // set up
-        String protocol = CloudStackConstants.SecurityGroupPlugin.TCP_VALUE_PROTOCOL;
+        String protocol = CloudStackConstants.SecurityGroup.TCP_VALUE_PROTOCOL;
 
         // exercise
         SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
@@ -550,7 +550,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
     @Test
     public void testGetFogbowProtocolWhenIsUdp() {
         // set up
-        String protocol = CloudStackConstants.SecurityGroupPlugin.UDP_VALUE_PROTOCOL;
+        String protocol = CloudStackConstants.SecurityGroup.UDP_VALUE_PROTOCOL;
 
         // exercise
         SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
@@ -564,7 +564,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
     @Test
     public void testGetFogbowProtocolWhenIsImcp() {
         // set up
-        String protocol = CloudStackConstants.SecurityGroupPlugin.ICMP_VALUE_PROTOCOL;
+        String protocol = CloudStackConstants.SecurityGroup.ICMP_VALUE_PROTOCOL;
 
         // exercise
         SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);
@@ -578,7 +578,7 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
     @Test
     public void testGetFogbowProtocolWhenIsAny() {
         // set up
-        String protocol = CloudStackConstants.SecurityGroupPlugin.ALL_VALUE_PROTOCOL;
+        String protocol = CloudStackConstants.SecurityGroup.ALL_VALUE_PROTOCOL;
 
         // exercise
         SecurityRule.Protocol fogbowProtocol = this.plugin.getFogbowProtocol(protocol);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePluginTest.java
@@ -559,8 +559,8 @@ public class CloudStackSecurityRulePluginTest extends BaseUnitTests {
         Assert.assertEquals(SecurityRule.Protocol.UDP, fogbowProtocol);
     }
 
-    // test case: When calling the getFogbowProtocol method and the protocol is IMCP,
-    // it must verify if It return an IMCP FogbowProtocol.
+    // test case: When calling the getFogbowProtocol method and the protocol is ICMP,
+    // it must verify if It return an ICMP FogbowProtocol.
     @Test
     public void testGetFogbowProtocolWhenIsImcp() {
         // set up

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleAsyncResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleAsyncResponseTest.java
@@ -1,4 +1,34 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
 
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleAsyncResponse;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
 public class CreateFirewallRuleAsyncResponseTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the fromJson method, it must verify
+    // if It returns the right CreateFirewallRuleAsyncResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws IOException {
+        // set up
+        String jobId = "1";
+        String createFirewallRuleResponseJson =
+                CloudstackTestUtils.createFirewallRuleAsyncResponseJson(jobId);
+
+        // execute
+        CreateFirewallRuleAsyncResponse response =
+                CreateFirewallRuleAsyncResponse.fromJson(createFirewallRuleResponseJson);
+
+        // verify
+        Assert.assertEquals(jobId, response.getJobId());
+    }
+
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleAsyncResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleAsyncResponseTest.java
@@ -1,0 +1,4 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
+
+public class CreateFirewallRuleAsyncResponseTest {
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
@@ -1,0 +1,74 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
+
+public class CreateFirewallRuleRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.Network.CREATE_FIREWALL_RULE_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String protocol = "protocol";
+        String startPort = "startPort";
+        String endPort = "endPort";
+        String ipAddressId = "ipAddressId";
+        String cird = "cird";
+
+        String protocolIdStructureUrl = String.format(
+                "%s=%s", PROTOCOL_KEY_JSON, protocol);
+        String startPortStructureUrl = String.format(
+                "%s=%s", STARTPORT_KEY_JSON, startPort);
+        String endPortStructureUrl = String.format(
+                "%s=%s", ENDPORT_KEY_JSON, endPort);
+        String ipAddressIdStructureUrl = String.format(
+                "%s=%s", IP_ADDRESS_ID_KEY_JSON, ipAddressId);
+        String cirdStructureUrl = String.format(
+                "%s=%s", CIDR_LIST_KEY_JSON, cird);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                protocolIdStructureUrl,
+                startPortStructureUrl,
+                endPortStructureUrl,
+                ipAddressIdStructureUrl,
+                cirdStructureUrl
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        CreateFirewallRuleRequest createFirewallRuleRequest = new CreateFirewallRuleRequest.Builder()
+                .startPort(startPort)
+                .endPort(endPort)
+                .protocol(protocol)
+                .ipAddressId(ipAddressId)
+                .cidrList(cird)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String createFireWallRequestUrl = createFirewallRuleRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, createFireWallRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new CreateFirewallRuleRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
@@ -19,7 +19,7 @@ public class CreateFirewallRuleRequestTest {
         // set up
         URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
                 CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
-                CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_COMMAND);
+                CloudStackConstants.SecurityGroupPlugin.CREATE_FIREWALL_RULE_COMMAND);
         String urlBaseExpected = uriBuilder.toString();
         String protocol = "protocol";
         String startPort = "startPort";

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
@@ -19,7 +19,7 @@ public class CreateFirewallRuleRequestTest {
         // set up
         URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
                 CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
-                CloudStackConstants.SecurityGroupPlugin.CREATE_FIREWALL_RULE_COMMAND);
+                CloudStackConstants.SecurityGroup.CREATE_FIREWALL_RULE_COMMAND);
         String urlBaseExpected = uriBuilder.toString();
         String protocol = "protocol";
         String startPort = "startPort";

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CreateFirewallRuleRequestTest.java
@@ -19,7 +19,7 @@ public class CreateFirewallRuleRequestTest {
         // set up
         URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
                 CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
-                CloudStackConstants.Network.CREATE_FIREWALL_RULE_COMMAND);
+                CloudStackConstants.PublicIp.CREATE_FIREWALL_RULE_COMMAND);
         String urlBaseExpected = uriBuilder.toString();
         String protocol = "protocol";
         String startPort = "startPort";

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequestTest.java
@@ -18,7 +18,7 @@ public class DeleteFirewallRuleRequestTest {
         // set up
         URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
                 CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
-                CloudStackConstants.PublicIp.DELETE_FIREWALL_RULE_COMMAND);
+                CloudStackConstants.SecurityGroupPlugin.DELETE_FIREWALL_RULE_COMMAND);
         String urlBaseExpected = uriBuilder.toString();
         String ruleId = "ruleId";
 

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequestTest.java
@@ -18,7 +18,7 @@ public class DeleteFirewallRuleRequestTest {
         // set up
         URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
                 CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
-                CloudStackConstants.SecurityGroupPlugin.DELETE_FIREWALL_RULE_COMMAND);
+                CloudStackConstants.SecurityGroup.DELETE_FIREWALL_RULE_COMMAND);
         String urlBaseExpected = uriBuilder.toString();
         String ruleId = "ruleId";
 

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleRequestTest.java
@@ -1,0 +1,53 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static cloud.fogbow.ras.core.plugins.interoperability.emulatedcloud.EmulatedCloudConstants.Plugins.PublicIp.ID_KEY_JSON;
+
+public class DeleteFirewallRuleRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.PublicIp.DELETE_FIREWALL_RULE_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String ruleId = "ruleId";
+
+        String ruleIdStructureUrl = String.format("%s=%s", ID_KEY_JSON, ruleId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                ruleIdStructureUrl,
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        DeleteFirewallRuleRequest deleteFirewallRuleRequest = new DeleteFirewallRuleRequest.Builder()
+                .ruleId(ruleId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String deleteFireWallRequestUrl = deleteFirewallRuleRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, deleteFireWallRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new DeleteFirewallRuleRequest.Builder().build(null);
+    }
+
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/DeleteFirewallRuleResponseTest.java
@@ -1,7 +1,6 @@
 package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
 
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
-import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleAsyncResponse;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -9,23 +8,23 @@ import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
-public class CreateFirewallRuleAsyncResponseTest {
+public class DeleteFirewallRuleResponseTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
     // test case: When calling the fromJson method, it must verify
-    // if It returns the right CreateFirewallRuleAsyncResponse.
+    // if It returns the right DeleteFirewallRuleAsyncResponse.
     @Test
     public void testFromJsonSuccessfully() throws IOException {
         // set up
         String jobId = "2";
-        String createFirewallRuleResponseJson =
-                CloudstackTestUtils.createFirewallRuleAsyncResponseJson(jobId);
+        String deleteFirewallRuleAsyncResponseJson =
+                CloudstackTestUtils.deleteFirewallRuleAsyncResponseJson(jobId);
 
         // execute
-        CreateFirewallRuleAsyncResponse response =
-                CreateFirewallRuleAsyncResponse.fromJson(createFirewallRuleResponseJson);
+        DeleteFirewallRuleResponse response =
+                DeleteFirewallRuleResponse.fromJson(deleteFirewallRuleAsyncResponseJson);
 
         // verify
         Assert.assertEquals(jobId, response.getJobId());

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequestTest.java
@@ -1,0 +1,54 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
+
+import cloud.fogbow.common.constants.CloudStackConstants;
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
+
+public class ListFirewallRulesRequestTest {
+
+    // test case: When calling the build method, it must verify if It generates the right URL.
+    @Test
+    public void testBuildSuccessfully() throws InvalidParameterException {
+        // set up
+        URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
+                CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
+                CloudStackConstants.SecurityGroupPlugin.LIST_FIREWALL_RULES_COMMAND);
+        String urlBaseExpected = uriBuilder.toString();
+        String ipAddressId = "ipAddressId";
+
+        String ipAddressIdStructureUrl = String.format(
+                "%s=%s", IP_ADDRESS_ID_KEY_JSON, ipAddressId);
+
+        String[] urlStructure = new String[] {
+                urlBaseExpected,
+                ipAddressIdStructureUrl,
+        };
+        String urlExpectedStr = String.join(
+                CloudstackTestUtils.AND_OPERATION_URL_PARAMETER, urlStructure);
+
+        // exercise
+        ListFirewallRulesRequest listFirewallRulesRequest = new ListFirewallRulesRequest.Builder()
+                .ipAddressId(ipAddressId)
+                .build(CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT);
+        String listFireWallRequestUrl = listFirewallRulesRequest.getUriBuilder().toString();
+
+        // verify
+        Assert.assertEquals(urlExpectedStr, listFireWallRequestUrl);
+    }
+
+    // test case: When calling the build method with a null parameter,
+    // it must verify if It throws an InvalidParameterException.
+    @Test(expected = InvalidParameterException.class)
+    public void testBuildFail() throws InvalidParameterException {
+        // exercise and verify
+        new ListFirewallRulesRequest.Builder().build(null);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequestTest.java
@@ -18,7 +18,7 @@ public class ListFirewallRulesRequestTest {
         // set up
         URIBuilder uriBuilder = CloudStackUrlUtil.createURIBuilder(
                 CloudstackTestUtils.CLOUDSTACK_URL_DEFAULT,
-                CloudStackConstants.SecurityGroupPlugin.LIST_FIREWALL_RULES_COMMAND);
+                CloudStackConstants.SecurityGroup.LIST_FIREWALL_RULES_COMMAND);
         String urlBaseExpected = uriBuilder.toString();
         String ipAddressId = "ipAddressId";
 

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequestTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesRequestTest.java
@@ -4,12 +4,11 @@ import cloud.fogbow.common.constants.CloudStackConstants;
 import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
 import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
-import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CreateFirewallRuleRequest;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.*;
+import static cloud.fogbow.common.constants.CloudStackConstants.PublicIp.IP_ADDRESS_ID_KEY_JSON;
 
 public class ListFirewallRulesRequestTest {
 

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesResponseTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/ListFirewallRulesResponseTest.java
@@ -1,0 +1,80 @@
+package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.securityrule.v4_9;
+
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.CloudstackTestUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.HttpResponseException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+public class ListFirewallRulesResponseTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the fromJson method, it must verify if It returns the right ListFirewallRulesResponse.
+    @Test
+    public void testFromJsonSuccessfully() throws Exception {
+        // set up
+        String instanceId = "1";
+        String protocol = "protocol";
+        int startPort = 1;
+        int endPort = 2;
+        String ipaddress = "ip";
+        String cird = "cird";
+        String listFirewallRulesResponseJson = CloudstackTestUtils.createListFirewallRulesResponseJson(
+                instanceId, protocol, startPort, endPort, ipaddress, cird);
+
+        // execute
+        ListFirewallRulesResponse listFirewallRulesResponse =
+                ListFirewallRulesResponse.fromJson(listFirewallRulesResponseJson);
+
+        // verify
+        ListFirewallRulesResponse.SecurityRuleResponse firstSecurityRule =
+                listFirewallRulesResponse.getSecurityRulesResponse().listIterator().next();
+        Assert.assertEquals(instanceId, firstSecurityRule.getInstanceId());
+        Assert.assertEquals(ipaddress, firstSecurityRule.getIpAddress());
+        Assert.assertEquals(protocol, firstSecurityRule.getProtocol());
+        Assert.assertEquals(startPort, firstSecurityRule.getPortFrom());
+        Assert.assertEquals(endPort, firstSecurityRule.getPortTo());
+        Assert.assertEquals(cird, firstSecurityRule.getCidr());
+    }
+
+    // test case: When calling the fromJson method with empty json response,
+    // it must verify if It returns the ListFirewallRulesResponse with null values.
+    @Test
+    public void testFromJsonWithEmptyValue() throws Exception {
+        // set up
+        String listFirewallRulesEmptyResponseJson = CloudstackTestUtils
+                .createListFirewallRulesEmptyResponseJson();
+
+        // execute
+        ListFirewallRulesResponse listFirewallRulesResponse =
+                ListFirewallRulesResponse.fromJson(listFirewallRulesEmptyResponseJson);
+
+        // verify
+        Assert.assertTrue(listFirewallRulesResponse.getSecurityRulesResponse().isEmpty());
+    }
+
+    // test case: When calling the fromJson method with error json response,
+    // it must verify if It throws a HttpResponseException.
+    @Test
+    public void testFromJsonFail() throws IOException {
+        // set up
+        String errorText = "anyString";
+        int errorCode = HttpStatus.SC_BAD_REQUEST;
+        String volumesErrorResponseJson = CloudstackTestUtils
+                .createListFirewallRulesErrorResponseJson(errorCode, errorText);
+
+        // verify
+        this.expectedException.expect(HttpResponseException.class);
+        this.expectedException.expectMessage(errorText);
+
+        // execute
+        ListFirewallRulesResponse.fromJson(volumesErrorResponseJson);
+    }
+
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
@@ -1,5 +1,5 @@
 {
   "createfirewallruleresponse": {
-    "jobid": 1
+    "jobid": %s
   }
 }

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/createfirewallruleresponse.json
@@ -1,0 +1,5 @@
+{
+  "createfirewallruleresponse": {
+    "jobid": 1
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/deletefirewallruleresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/deletefirewallruleresponse.json
@@ -1,0 +1,5 @@
+{
+  "deletefirewallruleresponse": {
+    "jobid": %s
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse.json
@@ -1,0 +1,14 @@
+{
+  "listfirewallrulesresponse": {
+    "firewallrule": [
+      {
+        "id": "%s",
+        "protocol": "%s",
+        "startport": %s,
+        "endport": %s,
+        "ipaddress": "%s",
+        "cidrlist": "%s"
+      }
+    ]
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse_empty.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse_empty.json
@@ -1,0 +1,5 @@
+{
+  "listfirewallrulesresponse": {
+    "firewallrule": []
+  }
+}

--- a/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse_error.json
+++ b/src/test/resources/cloud/plugins/interoperability/cloudstack/listfirewallrulesresponse_error.json
@@ -1,0 +1,6 @@
+{
+  "listfirewallrulesresponse": {
+    "errorcode":%s,
+    "errortext":"%s"
+  }
+}


### PR DESCRIPTION
# Description
Refactoring the Cloudstack Security Rules Plugin context.
This PR has all changes approved in previous Pull Requests. 

# Proposed changes
- Refactoring in the Cloudstack Security Rules Plugin.
- Migrating Cloudstack asynchronous operation to the Cloudstack Utils.
- Refactoring "request Instance" tests context.
- Refactoring "get Instance" tests context.
- Refactoring "delete instance" tests context.

# Additional information
This branch depends on a branch in the Fogbow Common (cloudstack-securityrules-test-refator)

# Reminding
PRs order:
develop  < PR5