### PR TITLE
Azure compute plugin one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,27 @@
             <artifactId>jackson-annotations</artifactId>
             <version>2.9.8</version>
         </dependency>
-
+        <!-- Azure -->
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-mgmt-compute</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-mgmt-resources</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-mgmt-network</artifactId>
+            <version>1.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -1,5 +1,7 @@
 package cloud.fogbow.ras.constants;
 
+import java.util.Locale;
+
 public class Messages {
 
     public static class Exception {
@@ -127,6 +129,8 @@ public class Messages {
         public static final String ASYNCHRONOUS_PUBLIC_IP_STATE =
                 "The asynchronous public ip request %s is in the state %s.";
         public static final String CREATING_AZURE_CLIENT = "Creating a new Azure client";
+        public static final String SEEK_VIRTUAL_MACHINE_SIZE_BY_NAME =
+                "Seek for the Virtual Machine Size by name %s at region %s";
     }
 
     public static class Error {

--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -131,6 +131,11 @@ public class Messages {
         public static final String CREATING_AZURE_CLIENT = "Creating a new Azure client";
         public static final String SEEK_VIRTUAL_MACHINE_SIZE_BY_NAME =
                 "Seek for the Virtual Machine Size by name %s at region %s";
+        public static final String END_CREATE_VM_ASYNC_BEHAVIOUR = "End asynchronous create virtual machine";
+        public static final String SEEK_VIRTUAL_MACHINE_SIZE_NAME =
+                "Seek for the Virtual Machine Size that fits with memory(%s) and vCpu(%s) at region %s";
+        public static final String END_DELETE_DISK_ASYNC_BEHAVIOUR = "End asynchronous delete disk";
+        public static final String END_DELETE_VM_ASYNC_BEHAVIOUR = "End asynchronous delete virtual machine";
     }
 
     public static class Error {
@@ -193,5 +198,12 @@ public class Messages {
         public static final String INSTANCE_OPERATIONAL_LOST_MEMORY_FAILURE =
                 "The instanceid %s had an operational failure due to the memory lost. It might left trash in the cloud.";
         public static final String ERROR_WHILE_CREATING_AZURE_CLIENT = "Error while creating a new Azure client";
+        public static final String ERROR_ID_LIMIT_SIZE_EXCEEDED =
+                "The resource name exceeded %s characters of the limit";
+        public static final String ERROR_DISK_PARAMETER_AZURE_POLICY = "The disk size must be greater than %sGB";;
+        public static final String ERROR_MULTIPLE_NETWORKS_NOT_ALLOWED = "Multiple networks not allowed";
+        public static final String ERROR_CREATE_VM_ASYNC_BEHAVIOUR = "Error while creating virtual machine asynchronously";
+        public static final String ERROR_DELETE_DISK_ASYNC_BEHAVIOUR = "Error while deleting disk asynchonously";
+        public static final String ERROR_DELETE_VM_ASYNC_BEHAVIOUR = "Error while deleting virtual machine asynchronously";
     }
 }

--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -126,6 +126,7 @@ public class Messages {
         public static final String XMPP_HANDLERS_SET = "XMPP handlers set.";
         public static final String ASYNCHRONOUS_PUBLIC_IP_STATE =
                 "The asynchronous public ip request %s is in the state %s.";
+        public static final String CREATING_AZURE_CLIENT = "Creating a new Azure client";
     }
 
     public static class Error {
@@ -187,5 +188,6 @@ public class Messages {
         public static final String UNSPECIFIED_PROJECT_ID = "Unspecified projectId.";
         public static final String INSTANCE_OPERATIONAL_LOST_MEMORY_FAILURE =
                 "The instanceid %s had an operational failure due to the memory lost. It might left trash in the cloud.";
+        public static final String ERROR_WHILE_CREATING_AZURE_CLIENT = "Error while creating a new Azure client";
     }
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureGetVirtualMachineRef.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureGetVirtualMachineRef.java
@@ -21,7 +21,7 @@ public class AzureGetVirtualMachineRef {
     }
 
     public String getId() {
-        return id;
+        return this.id;
     }
 
     private void setId(String id) {
@@ -29,7 +29,7 @@ public class AzureGetVirtualMachineRef {
     }
 
     public String getCloudState() {
-        return cloudState;
+        return this.cloudState;
     }
 
     private void setCloudState(String cloudState) {
@@ -37,7 +37,7 @@ public class AzureGetVirtualMachineRef {
     }
 
     public String getName() {
-        return name;
+        return this.name;
     }
 
     private void setName(String name) {
@@ -53,7 +53,7 @@ public class AzureGetVirtualMachineRef {
     }
 
     public int getMemory() {
-        return memory;
+        return this.memory;
     }
 
     private void setMemory(int memory) {
@@ -61,7 +61,7 @@ public class AzureGetVirtualMachineRef {
     }
 
     public int getDisk() {
-        return disk;
+        return this.disk;
     }
 
     private void setDisk(int disk) {
@@ -69,7 +69,7 @@ public class AzureGetVirtualMachineRef {
     }
 
     public List<String> getIpAddresses() {
-        return ipAddresses;
+        return this.ipAddresses;
     }
 
     private void setIpAddresses(List<String> ipAddresses) {
@@ -81,13 +81,13 @@ public class AzureGetVirtualMachineRef {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AzureGetVirtualMachineRef that = (AzureGetVirtualMachineRef) o;
-        return vCPU == that.vCPU &&
-                memory == that.memory &&
-                disk == that.disk &&
-                Objects.equals(id, that.id) &&
-                Objects.equals(cloudState, that.cloudState) &&
-                Objects.equals(name, that.name) &&
-                Objects.equals(ipAddresses, that.ipAddresses);
+        return this.vCPU == that.vCPU &&
+                this.memory == that.memory &&
+                this.disk == that.disk &&
+                Objects.equals(this.id, that.id) &&
+                Objects.equals(this.cloudState, that.cloudState) &&
+                Objects.equals(this.name, that.name) &&
+                Objects.equals(this.ipAddresses, that.ipAddresses);
     }
 
     public static class Builder extends GenericBuilder<AzureGetVirtualMachineRef> {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureGetVirtualMachineRef.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureGetVirtualMachineRef.java
@@ -1,0 +1,136 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.compute;
+
+import cloud.fogbow.ras.core.plugins.interoperability.azure.util.GenericBuilder;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class AzureGetVirtualMachineRef {
+
+    private String id;
+    private String cloudState;
+    private String name;
+    private int vCPU;
+    private int memory;
+    private int disk;
+    private List<String> ipAddresses;
+
+    public static Builder builder() {
+        return new Builder(AzureGetVirtualMachineRef::new);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    private void setId(String id) {
+        this.id = id;
+    }
+
+    public String getCloudState() {
+        return cloudState;
+    }
+
+    private void setCloudState(String cloudState) {
+        this.cloudState = cloudState;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    private void setName(String name) {
+        this.name = name;
+    }
+
+    public int getvCPU() {
+        return vCPU;
+    }
+
+    private void setvCPU(int vCPU) {
+        this.vCPU = vCPU;
+    }
+
+    public int getMemory() {
+        return memory;
+    }
+
+    private void setMemory(int memory) {
+        this.memory = memory;
+    }
+
+    public int getDisk() {
+        return disk;
+    }
+
+    private void setDisk(int disk) {
+        this.disk = disk;
+    }
+
+    public List<String> getIpAddresses() {
+        return ipAddresses;
+    }
+
+    private void setIpAddresses(List<String> ipAddresses) {
+        this.ipAddresses = ipAddresses;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AzureGetVirtualMachineRef that = (AzureGetVirtualMachineRef) o;
+        return vCPU == that.vCPU &&
+                memory == that.memory &&
+                disk == that.disk &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(cloudState, that.cloudState) &&
+                Objects.equals(name, that.name) &&
+                Objects.equals(ipAddresses, that.ipAddresses);
+    }
+
+    public static class Builder extends GenericBuilder<AzureGetVirtualMachineRef> {
+
+        protected Builder(Supplier<AzureGetVirtualMachineRef> instantiator) {
+            super(instantiator);
+        }
+
+        public Builder id(String id) {
+            with(AzureGetVirtualMachineRef::setId, id);
+            return this;
+        }
+
+        public Builder cloudState(String cloudState) {
+            with(AzureGetVirtualMachineRef::setCloudState, cloudState);
+            return this;
+        }
+
+        public Builder name(String name) {
+            with(AzureGetVirtualMachineRef::setName, name);
+            return this;
+        }
+
+        public Builder vCPU(int vCPU) {
+            with(AzureGetVirtualMachineRef::setvCPU, vCPU);
+            return this;
+        }
+
+        public Builder memory(int memory) {
+            with(AzureGetVirtualMachineRef::setMemory, memory);
+            return this;
+        }
+
+        public Builder disk(int disk) {
+            with(AzureGetVirtualMachineRef::setDisk, disk);
+            return this;
+        }
+
+        public Builder ipAddresses(List<String> ipAddresses) {
+            with(AzureGetVirtualMachineRef::setIpAddresses, ipAddresses);
+            return this;
+        }
+
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureVirtualMachineOperation.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureVirtualMachineOperation.java
@@ -5,12 +5,24 @@ import cloud.fogbow.common.exceptions.NoAvailableResourcesException;
 import cloud.fogbow.common.exceptions.UnauthenticatedUserException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureCreateVirtualMachineRef;
 
 public interface AzureVirtualMachineOperation {
+
+    void doCreateInstance(AzureCreateVirtualMachineRef azureCreateVirtualMachineRef,
+                          AzureUser azureCloudUser)
+            throws UnauthenticatedUserException, UnexpectedException, InstanceNotFoundException;
+
+    String findVirtualMachineSizeName(int memoryRequired, int vCpuRequired,
+                                      String regionName, AzureUser azureCloudUser)
+            throws UnauthenticatedUserException, NoAvailableResourcesException, UnexpectedException;
 
     AzureGetVirtualMachineRef doGetInstance(String azureInstanceId, AzureUser azureUser)
             throws UnauthenticatedUserException, UnexpectedException,
             NoAvailableResourcesException, InstanceNotFoundException;
+
+    void doDeleteInstance(String azureInstanceId, AzureUser azureCloudUser)
+            throws UnauthenticatedUserException, UnexpectedException, InstanceNotFoundException;
 
 }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureVirtualMachineOperation.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureVirtualMachineOperation.java
@@ -1,0 +1,16 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.compute;
+
+import cloud.fogbow.common.exceptions.InstanceNotFoundException;
+import cloud.fogbow.common.exceptions.NoAvailableResourcesException;
+import cloud.fogbow.common.exceptions.UnauthenticatedUserException;
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.AzureUser;
+
+public interface AzureVirtualMachineOperation {
+
+    AzureGetVirtualMachineRef doGetInstance(String azureInstanceId, AzureUser azureUser)
+            throws UnauthenticatedUserException, UnexpectedException,
+            NoAvailableResourcesException, InstanceNotFoundException;
+
+}
+

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePlugin.java
@@ -3,10 +3,21 @@ package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.models.AzureUser;
 import cloud.fogbow.ras.api.http.response.ComputeInstance;
+import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.models.orders.ComputeOrder;
 import cloud.fogbow.ras.core.plugins.interoperability.ComputePlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureGetVirtualMachineRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureIdBuilder;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.log4j.Logger;
+
+import java.util.List;
 
 public class AzureComputePlugin implements ComputePlugin<AzureUser> {
+
+    private static final Logger LOGGER = Logger.getLogger(AzureComputePlugin.class);
+
+    private AzureVirtualMachineOperation azureVirtualMachineOperation;
 
     @Override
     public boolean isReady(String instanceState) {
@@ -24,12 +35,36 @@ public class AzureComputePlugin implements ComputePlugin<AzureUser> {
     }
 
     @Override
-    public ComputeInstance getInstance(ComputeOrder computeOrder, AzureUser cloudUser) throws FogbowException {
-        return null;
+    public ComputeInstance getInstance(ComputeOrder computeOrder, AzureUser azureUser)
+            throws FogbowException {
+
+        LOGGER.info(String.format(Messages.Info.GETTING_INSTANCE_S, computeOrder.getInstanceId()));
+        String azureVirtualMachineId = computeOrder.getInstanceId();
+
+        AzureGetVirtualMachineRef azureGetVirtualMachineRef = this.azureVirtualMachineOperation
+                .doGetInstance(azureVirtualMachineId, azureUser);
+
+        return buildComputeInstance(azureGetVirtualMachineRef, azureUser);
+    }
+
+    @VisibleForTesting
+    ComputeInstance buildComputeInstance(AzureGetVirtualMachineRef azureGetVirtualMachineRef, AzureUser azureUser) {
+        String virtualMachineName = azureGetVirtualMachineRef.getName();
+        String virtualMachineId = AzureIdBuilder
+                .configure(azureUser)
+                .buildVirtualMachineId(virtualMachineName);
+        String cloudState = azureGetVirtualMachineRef.getCloudState();
+        int vCPU = azureGetVirtualMachineRef.getvCPU();
+        int memory = azureGetVirtualMachineRef.getMemory();
+        int disk = azureGetVirtualMachineRef.getDisk();
+        List<String> ipAddresses = azureGetVirtualMachineRef.getIpAddresses();
+
+        return new ComputeInstance(virtualMachineId, cloudState, virtualMachineName, vCPU, memory, disk, ipAddresses);
     }
 
     @Override
     public void deleteInstance(ComputeOrder computeOrder, AzureUser cloudUser) throws FogbowException {
 
     }
+
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePlugin.java
@@ -2,22 +2,30 @@ package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
 
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.ras.api.http.response.ComputeInstance;
 import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.models.orders.ComputeOrder;
 import cloud.fogbow.ras.core.plugins.interoperability.ComputePlugin;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureGetVirtualMachineRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureVirtualMachineOperation;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureIdBuilder;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
 import java.util.List;
+import java.util.Properties;
 
 public class AzureComputePlugin implements ComputePlugin<AzureUser> {
 
     private static final Logger LOGGER = Logger.getLogger(AzureComputePlugin.class);
 
     private AzureVirtualMachineOperation azureVirtualMachineOperation;
+
+    public AzureComputePlugin(String confFilePath) {
+        Properties properties = PropertiesUtil.readProperties(confFilePath);
+        this.azureVirtualMachineOperation = new AzureVirtualMachineOperationSDK();
+    }
 
     @Override
     public boolean isReady(String instanceState) {
@@ -30,7 +38,7 @@ public class AzureComputePlugin implements ComputePlugin<AzureUser> {
     }
 
     @Override
-    public String requestInstance(ComputeOrder computeOrder, AzureUser cloudUser) throws FogbowException {
+    public String requestInstance(ComputeOrder computeOrder, AzureUser azureUser) throws FogbowException {
         return null;
     }
 
@@ -63,8 +71,13 @@ public class AzureComputePlugin implements ComputePlugin<AzureUser> {
     }
 
     @Override
-    public void deleteInstance(ComputeOrder computeOrder, AzureUser cloudUser) throws FogbowException {
+    public void deleteInstance(ComputeOrder computeOrder, AzureUser azureUser) throws FogbowException {
 
+    }
+
+    @VisibleForTesting
+    void setAzureVirtualMachineOperation(AzureVirtualMachineOperation azureVirtualMachineOperation) {
+        this.azureVirtualMachineOperation = azureVirtualMachineOperation;
     }
 
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePlugin.java
@@ -1,15 +1,21 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
 
-import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.exceptions.*;
 import cloud.fogbow.common.models.AzureUser;
 import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.ras.api.http.response.ComputeInstance;
+import cloud.fogbow.ras.api.http.response.InstanceState;
 import cloud.fogbow.ras.constants.Messages;
+import cloud.fogbow.ras.core.models.ResourceType;
 import cloud.fogbow.ras.core.models.orders.ComputeOrder;
 import cloud.fogbow.ras.core.plugins.interoperability.ComputePlugin;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureGetVirtualMachineRef;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureVirtualMachineOperation;
-import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureIdBuilder;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureCreateVirtualMachineRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureGetImageRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.util.*;
+import cloud.fogbow.ras.core.plugins.interoperability.openstack.OpenStackStateMapper;
+import cloud.fogbow.ras.core.plugins.interoperability.util.DefaultLaunchCommandGenerator;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
@@ -21,25 +27,100 @@ public class AzureComputePlugin implements ComputePlugin<AzureUser> {
     private static final Logger LOGGER = Logger.getLogger(AzureComputePlugin.class);
 
     private AzureVirtualMachineOperation azureVirtualMachineOperation;
+    private final DefaultLaunchCommandGenerator launchCommandGenerator;
+    private final String defaultNetworkInterfaceName;
 
     public AzureComputePlugin(String confFilePath) {
         Properties properties = PropertiesUtil.readProperties(confFilePath);
+        this.defaultNetworkInterfaceName = properties.getProperty(AzureConstants.DEFAULT_NETWORK_INTERFACE_NAME_KEY);
+        this.launchCommandGenerator = new DefaultLaunchCommandGenerator();
         this.azureVirtualMachineOperation = new AzureVirtualMachineOperationSDK();
     }
 
     @Override
     public boolean isReady(String instanceState) {
-        return false;
+        return AzureStateMapper.map(ResourceType.COMPUTE, instanceState).equals(InstanceState.READY);
     }
 
     @Override
     public boolean hasFailed(String instanceState) {
-        return false;
+        return AzureStateMapper.map(ResourceType.COMPUTE, instanceState).equals(InstanceState.FAILED);
     }
 
     @Override
     public String requestInstance(ComputeOrder computeOrder, AzureUser azureUser) throws FogbowException {
-        return null;
+        LOGGER.info(Messages.Info.REQUESTING_INSTANCE_FROM_PROVIDER);
+
+        String networkInterfaceId = getNetworkInterfaceId(computeOrder, azureUser);
+        String virtualMachineSizeName = getVirtualMachineSizeName(computeOrder, azureUser);
+        int diskSize = AzureGeneralPolicy.getDisk(computeOrder);
+        AzureGetImageRef azureVirtualMachineImage = AzureImageOperationUtil
+                .buildAzureVirtualMachineImageBy(computeOrder.getImageId());
+        String virtualMachineName = AzureInstancePolicy
+                .generateAzureResourceNameBy(computeOrder, azureUser);
+        String userData = getUserData(computeOrder);
+        String osUserName = computeOrder.getId();
+        String osUserPassword = AzureGeneralPolicy.generatePassword();
+        String osComputeName = computeOrder.getId();
+        String regionName = azureUser.getRegionName();
+        String resourceGroupName = azureUser.getResourceGroupName();
+
+        AzureCreateVirtualMachineRef azureCreateVirtualMachineRef = AzureCreateVirtualMachineRef.builder()
+                .virtualMachineName(virtualMachineName)
+                .azureGetImageRef(azureVirtualMachineImage)
+                .networkInterfaceId(networkInterfaceId)
+                .diskSize(diskSize)
+                .size(virtualMachineSizeName)
+                .osComputeName(osComputeName)
+                .osUserName(osUserName)
+                .osUserPassword(osUserPassword)
+                .regionName(regionName)
+                .resourceGroupName(resourceGroupName)
+                .userData(userData)
+                .checkAndBuild();
+
+        return doRequestInstance(computeOrder, azureUser, azureCreateVirtualMachineRef);
+    }
+
+    @VisibleForTesting
+    String getUserData(ComputeOrder computeOrder) {
+        return this.launchCommandGenerator.createLaunchCommand(computeOrder);
+    }
+
+    @VisibleForTesting
+    String doRequestInstance(ComputeOrder computeOrder, AzureUser azureCloudUser,
+                             AzureCreateVirtualMachineRef azureCreateVirtualMachineRef)
+            throws UnauthenticatedUserException, UnexpectedException, InstanceNotFoundException, InvalidParameterException {
+
+        this.azureVirtualMachineOperation.doCreateInstance(azureCreateVirtualMachineRef, azureCloudUser);
+        return AzureInstancePolicy.generateFogbowInstanceIdBy(computeOrder, azureCloudUser);
+    }
+
+    @VisibleForTesting
+    String getNetworkInterfaceId(ComputeOrder computeOrder, AzureUser azureCloudUser)
+            throws FogbowException {
+
+        List<String> networkIds = computeOrder.getNetworkIds();
+        if (networkIds.isEmpty()) {
+            return AzureIdBuilder
+                    .configure(azureCloudUser)
+                    .buildNetworkInterfaceId(this.defaultNetworkInterfaceName);
+        } else {
+            if (networkIds.size() > AzureGeneralPolicy.MAXIMUM_NETWORK_PER_VIRTUAL_MACHINE) {
+                throw new FogbowException(Messages.Error.ERROR_MULTIPLE_NETWORKS_NOT_ALLOWED);
+            }
+
+            return networkIds.stream().findFirst().get();
+        }
+    }
+
+    @VisibleForTesting
+    String getVirtualMachineSizeName(ComputeOrder computeOrder, AzureUser azureCloudUser)
+            throws FogbowException {
+
+        return this.azureVirtualMachineOperation.findVirtualMachineSizeName(
+                computeOrder.getMemory(), computeOrder.getvCPU(),
+                azureCloudUser.getRegionName(), azureCloudUser);
     }
 
     @Override
@@ -71,8 +152,13 @@ public class AzureComputePlugin implements ComputePlugin<AzureUser> {
     }
 
     @Override
-    public void deleteInstance(ComputeOrder computeOrder, AzureUser azureUser) throws FogbowException {
+    public void deleteInstance(ComputeOrder computeOrder, AzureUser azureCloudUser)
+            throws FogbowException {
 
+        LOGGER.info(String.format(Messages.Info.DELETING_INSTANCE_S, computeOrder.getInstanceId()));
+
+        String azureVirtualMachineId = computeOrder.getInstanceId();
+        this.azureVirtualMachineOperation.doDeleteInstance(azureVirtualMachineId, azureCloudUser);
     }
 
     @VisibleForTesting

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePlugin.java
@@ -1,0 +1,35 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
+
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.api.http.response.ComputeInstance;
+import cloud.fogbow.ras.core.models.orders.ComputeOrder;
+import cloud.fogbow.ras.core.plugins.interoperability.ComputePlugin;
+
+public class AzureComputePlugin implements ComputePlugin<AzureUser> {
+
+    @Override
+    public boolean isReady(String instanceState) {
+        return false;
+    }
+
+    @Override
+    public boolean hasFailed(String instanceState) {
+        return false;
+    }
+
+    @Override
+    public String requestInstance(ComputeOrder computeOrder, AzureUser cloudUser) throws FogbowException {
+        return null;
+    }
+
+    @Override
+    public ComputeInstance getInstance(ComputeOrder computeOrder, AzureUser cloudUser) throws FogbowException {
+        return null;
+    }
+
+    @Override
+    public void deleteInstance(ComputeOrder computeOrder, AzureUser cloudUser) throws FogbowException {
+
+    }
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineOperationSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineOperationSDK.java
@@ -8,21 +8,134 @@ import cloud.fogbow.common.models.AzureUser;
 import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureGetVirtualMachineRef;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureVirtualMachineOperation;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureCreateVirtualMachineRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureGetImageRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.network.sdk.AzureNetworkSDK;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureClientCacheManager;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureSchedulerManager;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.volume.sdk.AzureVolumeSDK;
 import com.google.common.annotations.VisibleForTesting;
 import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.compute.VirtualMachineSize;
+import com.microsoft.azure.management.network.NetworkInterface;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import com.microsoft.azure.management.resources.fluentcore.model.Indexable;
 import org.apache.log4j.Logger;
+import rx.Completable;
+import rx.Observable;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 public class AzureVirtualMachineOperationSDK implements AzureVirtualMachineOperation {
 
     private static final Logger LOGGER = Logger.getLogger(AzureVirtualMachineOperationSDK.class);
+
+    private Scheduler scheduler;
+
+    public AzureVirtualMachineOperationSDK() {
+        ExecutorService virtualMachineExecutor = AzureSchedulerManager.getVirtualMachineExecutor();
+        this.scheduler = Schedulers.from(virtualMachineExecutor);
+    }
+
+    /**
+     * Create asynchronously because this operation takes a long time to finish.
+     */
+    @Override
+    public void doCreateInstance(AzureCreateVirtualMachineRef azureCreateVirtualMachineRef,
+                                 AzureUser azureCloudUser)
+            throws UnauthenticatedUserException, InstanceNotFoundException, UnexpectedException {
+
+        Azure azure = AzureClientCacheManager.getAzure(azureCloudUser);
+
+        Observable<Indexable> virtualMachineAsync = buildAzureVirtualMachineObservable(
+                azureCreateVirtualMachineRef, azure);
+
+        subscribeCreateVirtualMachine(virtualMachineAsync);
+    }
+
+    @VisibleForTesting
+    Observable<Indexable> buildAzureVirtualMachineObservable(
+            AzureCreateVirtualMachineRef azureCreateVirtualMachineRef,
+            Azure azure) throws InstanceNotFoundException, UnexpectedException {
+
+        String networkInterfaceId = azureCreateVirtualMachineRef.getNetworkInterfaceId();
+        NetworkInterface networkInterface = AzureNetworkSDK
+                .getNetworkInterface(azure, networkInterfaceId)
+                .orElseThrow(InstanceNotFoundException::new);
+        String resourceGroupName = azureCreateVirtualMachineRef.getResourceGroupName();
+        String regionName = azureCreateVirtualMachineRef.getRegionName();
+        String virtualMachineName = azureCreateVirtualMachineRef.getVirtualMachineName();
+        String osUserName = azureCreateVirtualMachineRef.getOsUserName();
+        String osUserPassword = azureCreateVirtualMachineRef.getOsUserPassword();
+        String osComputeName = azureCreateVirtualMachineRef.getOsComputeName();
+        String userData = azureCreateVirtualMachineRef.getUserData();
+        String size = azureCreateVirtualMachineRef.getSize();
+        int diskSize = azureCreateVirtualMachineRef.getDiskSize();
+        AzureGetImageRef azureVirtualMachineImage = azureCreateVirtualMachineRef.getAzureGetImageRef();
+        Region region = Region.findByLabelOrName(regionName);
+        String imagePublished = azureVirtualMachineImage.getPublisher();
+        String imageOffer = azureVirtualMachineImage.getOffer();
+        String imageSku = azureVirtualMachineImage.getSku();
+
+        return AzureVirtualMachineSDK.buildVirtualMachineObservable(
+                azure, virtualMachineName, region, resourceGroupName, networkInterface,
+                imagePublished, imageOffer, imageSku, osUserName, osUserPassword, osComputeName,
+                userData, diskSize, size);
+    }
+
+    /**
+     * Execute create Virtual Machine observable and set its behaviour.
+     */
+    @VisibleForTesting
+    void subscribeCreateVirtualMachine(Observable<Indexable> virtualMachineObservable) {
+        setCreateVirtualMachineBehaviour(virtualMachineObservable)
+                .subscribeOn(this.scheduler)
+                .subscribe();
+    }
+
+    private Observable<Indexable> setCreateVirtualMachineBehaviour(Observable<Indexable> virtualMachineObservable) {
+        return virtualMachineObservable
+                .onErrorReturn((error -> {
+                    LOGGER.error(Messages.Error.ERROR_CREATE_VM_ASYNC_BEHAVIOUR, error);
+                    return null;
+                }))
+                .doOnCompleted(() -> {
+                    LOGGER.info(Messages.Info.END_CREATE_VM_ASYNC_BEHAVIOUR);
+                });
+    }
+
+    @Override
+    public String findVirtualMachineSizeName(int memoryRequired, int vCpuRequired,
+                                             String regionName, AzureUser azureCloudUser)
+            throws UnauthenticatedUserException, NoAvailableResourcesException,
+            UnexpectedException {
+
+        LOGGER.debug(String.format(Messages.Info.SEEK_VIRTUAL_MACHINE_SIZE_NAME, memoryRequired, vCpuRequired, regionName));
+        Azure azure = AzureClientCacheManager.getAzure(azureCloudUser);
+
+        Region region = Region.findByLabelOrName(regionName);
+        PagedList<VirtualMachineSize> virtualMachineSizes =
+                AzureVirtualMachineSDK.getVirtualMachineSizes(azure, region);
+        VirtualMachineSize firstVirtualMachineSize = virtualMachineSizes.stream()
+                .filter((virtualMachineSize) ->
+                        virtualMachineSize.memoryInMB() >= memoryRequired &&
+                                virtualMachineSize.numberOfCores() >= vCpuRequired
+                )
+                .sorted(Comparator
+                        .comparingInt(VirtualMachineSize::memoryInMB)
+                        .thenComparingInt(VirtualMachineSize::numberOfCores))
+                .findFirst()
+                .orElseThrow(NoAvailableResourcesException::new);
+
+        return firstVirtualMachineSize.name();
+    }
 
     @Override
     public AzureGetVirtualMachineRef doGetInstance(String azureInstanceId, AzureUser azureCloudUser)
@@ -32,7 +145,7 @@ public class AzureVirtualMachineOperationSDK implements AzureVirtualMachineOpera
         Azure azure = AzureClientCacheManager.getAzure(azureCloudUser);
 
         VirtualMachine virtualMachine = AzureVirtualMachineSDK
-                .getVirtualMachineById(azure, azureInstanceId)
+                .getVirtualMachine(azure, azureInstanceId)
                 .orElseThrow(InstanceNotFoundException::new);
         String virtualMachineSizeName = virtualMachine.size().toString();
         String cloudState = virtualMachine.provisioningState();
@@ -67,7 +180,69 @@ public class AzureVirtualMachineOperationSDK implements AzureVirtualMachineOpera
         return virtualMachineSizes.stream()
                 .filter((virtualMachineSize) -> virtualMachineSizeNameWanted.equals(virtualMachineSize.name()))
                 .findFirst()
-                .orElseThrow(() -> new NoAvailableResourcesException());
+                .orElseThrow(NoAvailableResourcesException::new);
+    }
+
+    /**
+     * Delete asynchronously because this operation takes a long time to finish.
+     */
+    @Override
+    public void doDeleteInstance(String azureInstanceId, AzureUser azureCloudUser)
+            throws UnauthenticatedUserException, InstanceNotFoundException, UnexpectedException {
+
+        Azure azure = AzureClientCacheManager.getAzure(azureCloudUser);
+
+        Completable firstDeleteVirtualMachine = buildDeleteVirtualMachineCompletable(azure, azureInstanceId);
+        Completable secondDeleteVirtualMachineDisk = buildDeleteVirtualMachineDiskCompletable(azure, azureInstanceId);
+
+        Completable.concat(firstDeleteVirtualMachine, secondDeleteVirtualMachineDisk)
+                .subscribeOn(this.scheduler)
+                .subscribe();
+    }
+
+    @VisibleForTesting
+    Completable buildDeleteVirtualMachineDiskCompletable(Azure azure, String azureInstanceId)
+            throws InstanceNotFoundException, UnexpectedException {
+
+        VirtualMachine virtualMachine = AzureVirtualMachineSDK
+                .getVirtualMachine(azure, azureInstanceId)
+                .orElseThrow(InstanceNotFoundException::new);
+        String osDiskId = virtualMachine.osDiskId();
+        Completable deleteVirutalMachineDisk = AzureVolumeSDK.buildDeleteDiskCompletable(azure, osDiskId);
+
+        return setDeleteVirtualMachineDiskBehaviour(deleteVirutalMachineDisk);
+    }
+
+    @VisibleForTesting
+    Completable buildDeleteVirtualMachineCompletable(Azure azure, String azureInstanceId) {
+        Completable deleteVirtualMachine = AzureVirtualMachineSDK
+                .buildDeleteVirtualMachineCompletable(azure, azureInstanceId);
+        return setDeleteVirtualMachineBehaviour(deleteVirtualMachine);
+    }
+
+    private Completable setDeleteVirtualMachineDiskBehaviour(Completable deleteVirutalMachineDisk) {
+        return deleteVirutalMachineDisk
+                .doOnError((error -> {
+                    LOGGER.error(Messages.Error.ERROR_DELETE_DISK_ASYNC_BEHAVIOUR);
+                }))
+                .doOnCompleted(() -> {
+                    LOGGER.info(Messages.Info.END_DELETE_DISK_ASYNC_BEHAVIOUR);
+                });
+    }
+
+    private Completable setDeleteVirtualMachineBehaviour(Completable deleteVirtualMachineCompletable) {
+        return deleteVirtualMachineCompletable
+                .doOnError((error -> {
+                    LOGGER.error(Messages.Error.ERROR_DELETE_VM_ASYNC_BEHAVIOUR, error);
+                }))
+                .doOnCompleted(() -> {
+                    LOGGER.info(Messages.Info.END_DELETE_VM_ASYNC_BEHAVIOUR);
+                });
+    }
+
+    @VisibleForTesting
+    void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
     }
 
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineOperationSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineOperationSDK.java
@@ -1,0 +1,52 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
+
+import cloud.fogbow.common.exceptions.InstanceNotFoundException;
+import cloud.fogbow.common.exceptions.NoAvailableResourcesException;
+import cloud.fogbow.common.exceptions.UnauthenticatedUserException;
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureGetVirtualMachineRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureVirtualMachineOperation;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureClientCacheManager;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.compute.VirtualMachine;
+import com.microsoft.azure.management.compute.VirtualMachineSize;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AzureVirtualMachineOperationSDK implements AzureVirtualMachineOperation {
+
+    @Override
+    public AzureGetVirtualMachineRef doGetInstance(String azureInstanceId, AzureUser azureCloudUser)
+            throws UnauthenticatedUserException, UnexpectedException,
+            NoAvailableResourcesException, InstanceNotFoundException {
+
+        Azure azure = AzureClientCacheManager.getAzure(azureCloudUser);
+
+        VirtualMachine virtualMachine = AzureVirtualMachineSDK
+                .getVirtualMachineById(azure, azureInstanceId)
+                .orElseThrow(InstanceNotFoundException::new);
+        String virtualMachineSizeName = virtualMachine.size().toString();
+        String cloudState = virtualMachine.provisioningState();
+        String name = virtualMachine.name();
+        String primaryPrivateIp = virtualMachine.getPrimaryNetworkInterface().primaryPrivateIP();
+        List<String> ipAddresses = Arrays.asList(primaryPrivateIp);
+
+        String regionName = azureCloudUser.getRegionName();
+        VirtualMachineSize virtualMachineSize = findVirtualMachineSizeByName(virtualMachineSizeName, regionName, azure);
+        int vCPU = virtualMachineSize.numberOfCores();
+        int memory = virtualMachineSize.memoryInMB();
+        int disk = virtualMachine.osDiskSize();
+
+        return AzureGetVirtualMachineRef.builder()
+                .cloudState(cloudState)
+                .ipAddresses(ipAddresses)
+                .disk(disk)
+                .memory(memory)
+                .name(name)
+                .vCPU(vCPU)
+                .build();
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineOperationSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineOperationSDK.java
@@ -5,17 +5,24 @@ import cloud.fogbow.common.exceptions.NoAvailableResourcesException;
 import cloud.fogbow.common.exceptions.UnauthenticatedUserException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureGetVirtualMachineRef;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureVirtualMachineOperation;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureClientCacheManager;
+import com.google.common.annotations.VisibleForTesting;
+import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.compute.VirtualMachineSize;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import org.apache.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class AzureVirtualMachineOperationSDK implements AzureVirtualMachineOperation {
+
+    private static final Logger LOGGER = Logger.getLogger(AzureVirtualMachineOperationSDK.class);
 
     @Override
     public AzureGetVirtualMachineRef doGetInstance(String azureInstanceId, AzureUser azureCloudUser)
@@ -47,6 +54,20 @@ public class AzureVirtualMachineOperationSDK implements AzureVirtualMachineOpera
                 .name(name)
                 .vCPU(vCPU)
                 .build();
+    }
+
+    @VisibleForTesting
+    VirtualMachineSize findVirtualMachineSizeByName(String virtualMachineSizeNameWanted,
+                                                    String regionName, Azure azure)
+            throws NoAvailableResourcesException, UnexpectedException {
+
+        LOGGER.debug(String.format(Messages.Info.SEEK_VIRTUAL_MACHINE_SIZE_BY_NAME, virtualMachineSizeNameWanted, regionName));
+        Region region = Region.findByLabelOrName(regionName);
+        PagedList<VirtualMachineSize> virtualMachineSizes = AzureVirtualMachineSDK.getVirtualMachineSizes(azure, region);
+        return virtualMachineSizes.stream()
+                .filter((virtualMachineSize) -> virtualMachineSizeNameWanted.equals(virtualMachineSize.name()))
+                .findFirst()
+                .orElseThrow(() -> new NoAvailableResourcesException());
     }
 
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDK.java
@@ -2,9 +2,13 @@ package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
 
 import cloud.fogbow.common.exceptions.UnexpectedException;
 import com.google.common.annotations.VisibleForTesting;
+import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.VirtualMachine;
+import com.microsoft.azure.management.compute.VirtualMachineSize;
+import com.microsoft.azure.management.compute.VirtualMachineSizes;
 import com.microsoft.azure.management.compute.VirtualMachines;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 
 import java.util.Optional;
 
@@ -16,6 +20,18 @@ public class AzureVirtualMachineSDK {
         try {
             VirtualMachines virtualMachinesObject = getVirtualMachinesObject(azure);
             return Optional.ofNullable(virtualMachinesObject.getById(virtualMachineId));
+        } catch (RuntimeException e) {
+            throw new UnexpectedException(e.getMessage(), e);
+        }
+    }
+
+    static PagedList<VirtualMachineSize> getVirtualMachineSizes(Azure azure, Region region)
+            throws UnexpectedException {
+
+        try {
+            VirtualMachines virtualMachinesObject = getVirtualMachinesObject(azure);
+            VirtualMachineSizes sizes = virtualMachinesObject.sizes();
+            return sizes.listByRegion(region);
         } catch (RuntimeException e) {
             throw new UnexpectedException(e.getMessage(), e);
         }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDK.java
@@ -1,0 +1,31 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
+
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import com.google.common.annotations.VisibleForTesting;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.compute.VirtualMachine;
+import com.microsoft.azure.management.compute.VirtualMachines;
+
+import java.util.Optional;
+
+public class AzureVirtualMachineSDK {
+
+    static Optional<VirtualMachine> getVirtualMachineById(Azure azure, String virtualMachineId)
+            throws UnexpectedException {
+
+        try {
+            VirtualMachines virtualMachinesObject = getVirtualMachinesObject(azure);
+            return Optional.ofNullable(virtualMachinesObject.getById(virtualMachineId));
+        } catch (RuntimeException e) {
+            throw new UnexpectedException(e.getMessage(), e);
+        }
+    }
+
+    // This class is used only for test proposes.
+    // It is necessary because was not possible mock the Azure(final class)
+    @VisibleForTesting
+    static VirtualMachines getVirtualMachinesObject(Azure azure) {
+        return azure.virtualMachines();
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDK.java
@@ -8,17 +8,56 @@ import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.compute.VirtualMachineSize;
 import com.microsoft.azure.management.compute.VirtualMachineSizes;
 import com.microsoft.azure.management.compute.VirtualMachines;
+import com.microsoft.azure.management.network.NetworkInterface;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import com.microsoft.azure.management.resources.fluentcore.model.Indexable;
+import rx.Completable;
+import rx.Observable;
 
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class AzureVirtualMachineSDK {
 
-    static Optional<VirtualMachine> getVirtualMachineById(Azure azure, String virtualMachineId)
+    static Observable<Indexable> buildVirtualMachineObservable(Azure azure, String virtualMachineName, Region region,
+                                                               String resourceGroupName, NetworkInterface networkInterface,
+                                                               String imagePublished, String imageOffer, String imageSku,
+                                                               String osUserName, String osUserPassword, String osComputeName,
+                                                               String userData, int diskSize, String size) {
+
+        VirtualMachines virtualMachine = getVirtualMachinesSDK(azure);
+
+        VirtualMachine.DefinitionStages.WithOS osChoosen = virtualMachine
+                .define(virtualMachineName)
+                .withRegion(region)
+                .withExistingResourceGroup(resourceGroupName)
+                .withExistingPrimaryNetworkInterface(networkInterface);
+
+        VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged optionsManaged;
+        if (isWindowsImage(imageOffer, imageSku)) {
+            optionsManaged = osChoosen.withLatestWindowsImage(imagePublished, imageOffer, imageSku)
+                    .withAdminUsername(osUserName)
+                    .withAdminPassword(osUserPassword)
+                    .withComputerName(osComputeName);
+        } else {
+            optionsManaged = osChoosen.withLatestLinuxImage(imagePublished, imageOffer, imageSku)
+                    .withRootUsername(osUserName)
+                    .withRootPassword(osUserPassword)
+                    .withComputerName(osComputeName);
+        }
+        return optionsManaged
+                .withCustomData(userData)
+                .withOSDiskSizeInGB(diskSize)
+                .withSize(size)
+                .createAsync();
+    }
+
+    static Optional<VirtualMachine> getVirtualMachine(Azure azure, String virtualMachineId)
             throws UnexpectedException {
 
         try {
-            VirtualMachines virtualMachinesObject = getVirtualMachinesObject(azure);
+            VirtualMachines virtualMachinesObject = getVirtualMachinesSDK(azure);
             return Optional.ofNullable(virtualMachinesObject.getById(virtualMachineId));
         } catch (RuntimeException e) {
             throw new UnexpectedException(e.getMessage(), e);
@@ -29,7 +68,7 @@ public class AzureVirtualMachineSDK {
             throws UnexpectedException {
 
         try {
-            VirtualMachines virtualMachinesObject = getVirtualMachinesObject(azure);
+            VirtualMachines virtualMachinesObject = getVirtualMachinesSDK(azure);
             VirtualMachineSizes sizes = virtualMachinesObject.sizes();
             return sizes.listByRegion(region);
         } catch (RuntimeException e) {
@@ -37,10 +76,27 @@ public class AzureVirtualMachineSDK {
         }
     }
 
+    static Completable buildDeleteVirtualMachineCompletable(Azure azure, String virtualMachineId) {
+        return azure.virtualMachines().deleteByIdAsync(virtualMachineId);
+    }
+
+    @VisibleForTesting
+    static boolean isWindowsImage(String imageOffer, String imageSku) {
+        return constainsWindownsOn(imageOffer) || constainsWindownsOn(imageSku);
+    }
+
+    @VisibleForTesting
+    static boolean constainsWindownsOn(String text) {
+        String regex = ".*windows.*";
+        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        Matcher matcherOffer = pattern.matcher(text);
+        return matcherOffer.find();
+    }
+
     // This class is used only for test proposes.
     // It is necessary because was not possible mock the Azure(final class)
     @VisibleForTesting
-    static VirtualMachines getVirtualMachinesObject(Azure azure) {
+    static VirtualMachines getVirtualMachinesSDK(Azure azure) {
         return azure.virtualMachines();
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/model/AzureCreateVirtualMachineRef.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/model/AzureCreateVirtualMachineRef.java
@@ -1,0 +1,204 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model;
+
+import cloud.fogbow.ras.core.plugins.interoperability.azure.util.GenericBuilder;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class AzureCreateVirtualMachineRef {
+
+    @GenericBuilder.Required
+    private AzureGetImageRef azureGetImageRef;
+    @GenericBuilder.Required
+    private String networkInterfaceId;
+    @GenericBuilder.Required
+    private String resourceGroupName;
+    @GenericBuilder.Required
+    private String virtualMachineName;
+    @GenericBuilder.Required
+    private String osUserPassword;
+    @GenericBuilder.Required
+    private String osComputeName;
+    @GenericBuilder.Required
+    private String osUserName;
+    @GenericBuilder.Required
+    private String regionName;
+    private String userData;
+    @GenericBuilder.Required
+    private int diskSize;
+    @GenericBuilder.Required
+    private String size;
+
+    public static Builder builder() {
+        return new Builder(AzureCreateVirtualMachineRef::new);
+    }
+
+    public AzureGetImageRef getAzureGetImageRef() {
+        return this.azureGetImageRef;
+    }
+
+    private void setAzureGetImageRef(AzureGetImageRef azureGetImageRef) {
+        this.azureGetImageRef = azureGetImageRef;
+    }
+
+    public String getNetworkInterfaceId() {
+        return this.networkInterfaceId;
+    }
+
+    private void setNetworkInterfaceId(String networkInterfaceId) {
+        this.networkInterfaceId = networkInterfaceId;
+    }
+
+    public String getResourceGroupName() {
+        return this.resourceGroupName;
+    }
+
+    private void setResourceGroupName(String resourceGroupName) {
+        this.resourceGroupName = resourceGroupName;
+    }
+
+    public String getVirtualMachineName() {
+        return this.virtualMachineName;
+    }
+
+    private void setVirtualMachineName(String virtualMachineName) {
+        this.virtualMachineName = virtualMachineName;
+    }
+
+    public String getOsUserPassword() {
+        return this.osUserPassword;
+    }
+
+    private void setOsUserPassword(String osUserPassword) {
+        this.osUserPassword = osUserPassword;
+    }
+
+    public String getOsComputeName() {
+        return this.osComputeName;
+    }
+
+    private void setOsComputeName(String osComputeName) {
+        this.osComputeName = osComputeName;
+    }
+
+    public String getOsUserName() {
+        return this.osUserName;
+    }
+
+    private void setOsUserName(String osUserName) {
+        this.osUserName = osUserName;
+    }
+
+    public String getRegionName() {
+        return this.regionName;
+    }
+
+    private void setRegionName(String regionName) {
+        this.regionName = regionName;
+    }
+
+    public String getUserData() {
+        return this.userData;
+    }
+
+    private void setUserData(String userData) {
+        this.userData = userData;
+    }
+
+    public int getDiskSize() {
+        return this.diskSize;
+    }
+
+    private void setDiskSize(int diskSize) {
+        this.diskSize = diskSize;
+    }
+
+    public String getSize() {
+        return this.size;
+    }
+
+    private void setSize(String size) {
+        this.size = size;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AzureCreateVirtualMachineRef that = (AzureCreateVirtualMachineRef) o;
+        return this.diskSize == that.diskSize &&
+                Objects.equals(this.azureGetImageRef, that.azureGetImageRef) &&
+                Objects.equals(this.networkInterfaceId, that.networkInterfaceId) &&
+                Objects.equals(this.resourceGroupName, that.resourceGroupName) &&
+                Objects.equals(this.virtualMachineName, that.virtualMachineName) &&
+                Objects.equals(this.osUserPassword, that.osUserPassword) &&
+                Objects.equals(this.osComputeName, that.osComputeName) &&
+                Objects.equals(this.osUserName, that.osUserName) &&
+                Objects.equals(this.regionName, that.regionName) &&
+                Objects.equals(this.userData, that.userData) &&
+                Objects.equals(this.size, that.size);
+    }
+
+    public static class Builder extends GenericBuilder<AzureCreateVirtualMachineRef> {
+
+        Builder(Supplier instantiator) {
+            super(instantiator);
+        }
+
+        public Builder azureGetImageRef(AzureGetImageRef azureGetImageRef) {
+            with(AzureCreateVirtualMachineRef::setAzureGetImageRef, azureGetImageRef);
+            return this;
+        }
+
+        public Builder networkInterfaceId(String networkInterfaceId) {
+            with(AzureCreateVirtualMachineRef::setNetworkInterfaceId, networkInterfaceId);
+            return this;
+        }
+
+        public Builder resourceGroupName(String resourceGroupName) {
+            with(AzureCreateVirtualMachineRef::setResourceGroupName, resourceGroupName);
+            return this;
+        }
+
+        public Builder virtualMachineName(String virtualMachineName) {
+            with(AzureCreateVirtualMachineRef::setVirtualMachineName, virtualMachineName);
+            return this;
+        }
+
+        public Builder osUserPassword(String osUserPassword) {
+            with(AzureCreateVirtualMachineRef::setOsUserPassword, osUserPassword);
+            return this;
+        }
+
+        public Builder osComputeName(String osComputeName) {
+            with(AzureCreateVirtualMachineRef::setOsComputeName, osComputeName);
+            return this;
+        }
+
+        public Builder osUserName(String osUserName) {
+            with(AzureCreateVirtualMachineRef::setOsUserName, osUserName);
+            return this;
+        }
+
+        public Builder regionName(String regionName) {
+            with(AzureCreateVirtualMachineRef::setRegionName, regionName);
+            return this;
+        }
+
+        public Builder userData(String userData) {
+            with(AzureCreateVirtualMachineRef::setUserData, userData);
+            return this;
+        }
+
+        public Builder diskSize(int diskSize) {
+            with(AzureCreateVirtualMachineRef::setDiskSize, diskSize);
+            return this;
+        }
+
+        public Builder size(String size) {
+            with(AzureCreateVirtualMachineRef::setSize, size);
+            return this;
+        }
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/model/AzureGetImageRef.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/model/AzureGetImageRef.java
@@ -1,0 +1,39 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model;
+
+import java.util.Objects;
+
+public class AzureGetImageRef {
+
+    private String publisher;
+    private String offer;
+    private String sku;
+
+    public AzureGetImageRef(String publisher, String offer, String sku) {
+        this.publisher = publisher;
+        this.offer = offer;
+        this.sku = sku;
+    }
+
+    public String getOffer() {
+        return this.offer;
+    }
+
+    public String getPublisher() {
+        return this.publisher;
+    }
+
+    public String getSku() {
+        return this.sku;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AzureGetImageRef that = (AzureGetImageRef) o;
+        return Objects.equals(this.publisher, that.publisher) &&
+                Objects.equals(this.offer, that.offer) &&
+                Objects.equals(this.sku, that.sku);
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/network/sdk/AzureNetworkSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/network/sdk/AzureNetworkSDK.java
@@ -1,0 +1,28 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.network.sdk;
+
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.network.NetworkInterface;
+import com.microsoft.azure.management.network.NetworkInterfaces;
+
+import java.util.Optional;
+
+public class AzureNetworkSDK {
+
+    public static Optional<NetworkInterface> getNetworkInterface(Azure azure, String azureNetworkInterfaceId)
+            throws UnexpectedException {
+
+        try {
+            NetworkInterfaces networkInterfaces = getNetworkInterfacesSDK(azure);
+            NetworkInterface networkInterface = networkInterfaces.getById(azureNetworkInterfaceId);
+            return Optional.ofNullable(networkInterface);
+        } catch (RuntimeException e) {
+            throw new UnexpectedException(e.getMessage(), e);
+        }
+    }
+
+    public static NetworkInterfaces getNetworkInterfacesSDK(Azure azure) {
+        return azure.networkInterfaces();
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureClientCacheManager.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureClientCacheManager.java
@@ -1,0 +1,104 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.exceptions.UnauthenticatedUserException;
+import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.constants.Messages;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.microsoft.azure.AzureEnvironment;
+import com.microsoft.azure.credentials.ApplicationTokenCredentials;
+import com.microsoft.azure.credentials.AzureTokenCredentials;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.rest.LogLevel;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+public class AzureClientCacheManager {
+    private static final Logger LOGGER = Logger.getLogger(AzureClientCacheManager.class);
+
+    private static final long LIFE_TIME_IN_MINUTES = 30;
+
+    private final static LoadingCache<AzureUser, Azure> loadingCache;
+
+    static {
+        loadingCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(LIFE_TIME_IN_MINUTES, TimeUnit.MINUTES)
+                .build(new CacheLoader<AzureUser, Azure>() {
+                    @Override
+                    public Azure load(AzureUser azureUser) throws Exception {
+                        LOGGER.debug(Messages.Info.CREATING_AZURE_CLIENT);
+                        return createAzure(azureUser);
+                    }
+                });
+    }
+
+    public static Azure getAzure(AzureUser azureUser) throws UnauthenticatedUserException {
+        try {
+            return loadingCache.get(azureUser);
+        } catch (Exception e) {
+            throw new UnauthenticatedUserException(e.getMessage(), e);
+        }
+    }
+
+    @VisibleForTesting
+    static Azure createAzure(AzureUser azureUser) throws FogbowException {
+        try {
+            AzureTokenCredentials azureTokenCredentials = buildAzureTokenCredentials(azureUser);
+            return Azure.configure()
+                    .withLogLevel(LogLevel.BASIC)
+                    .authenticate(azureTokenCredentials)
+                    .withDefaultSubscription();
+        } catch (IOException | Error e) {
+            throw new FogbowException(Messages.Error.ERROR_WHILE_CREATING_AZURE_CLIENT, e);
+        }
+    }
+
+    @VisibleForTesting
+    static AzureTokenCredentials buildAzureTokenCredentials(AzureUser azureUser) {
+        String clientId = azureUser.getClientId();
+        String tenantId = azureUser.getTenantId();
+        String clientKey = azureUser.getClientKey();
+        String subscriptionId = azureUser.getSubscriptionId();
+
+        final String managementEndpoint = AzureEnvironment.AZURE.managementEndpoint();
+        final String activeDirectoryEndpoint = AzureEnvironment.AZURE.activeDirectoryEndpoint();
+        final String resourceManagerEndpoint = AzureEnvironment.AZURE.resourceManagerEndpoint();
+        final String graphEndpoint = AzureEnvironment.AZURE.graphEndpoint();
+        final String keyVaultDnsSuffix = AzureEnvironment.AZURE.keyVaultDnsSuffix();
+        AzureEnvironment azureEnvironment = getAzureEnvironment(managementEndpoint,
+                activeDirectoryEndpoint, resourceManagerEndpoint, graphEndpoint, keyVaultDnsSuffix);
+        return getApplicationTokenCredentials(clientId, tenantId, clientKey, azureEnvironment)
+                .withDefaultSubscriptionId(subscriptionId);
+    }
+
+    @VisibleForTesting
+    static AzureEnvironment getAzureEnvironment(String managementEndpoint, String activeDirectoryEndpoint,
+                                                String resourceManagerEndpoint, String graphEndpoint,
+                                                String keyVaultDnsSuffix) {
+
+        return new AzureEnvironment(new HashMap<String, String>() {
+            {
+                this.put(AzureEnvironment.Endpoint.ACTIVE_DIRECTORY.toString(), activeDirectoryEndpoint.endsWith("/") ? activeDirectoryEndpoint : activeDirectoryEndpoint + "/");
+                this.put(AzureEnvironment.Endpoint.MANAGEMENT.toString(), managementEndpoint);
+                this.put(AzureEnvironment.Endpoint.RESOURCE_MANAGER.toString(), resourceManagerEndpoint);
+                this.put(AzureEnvironment.Endpoint.GRAPH.toString(), graphEndpoint);
+                this.put(AzureEnvironment.Endpoint.KEYVAULT.toString(), keyVaultDnsSuffix);
+            }
+        });
+    }
+
+    @VisibleForTesting
+    static ApplicationTokenCredentials getApplicationTokenCredentials(String clientId, String tenantId,
+                                                                      String clientKey, AzureEnvironment azureEnvironment) {
+
+        return new ApplicationTokenCredentials(clientId, tenantId, clientKey, azureEnvironment);
+    }
+
+}
+

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureConstants.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureConstants.java
@@ -1,0 +1,7 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+public class AzureConstants {
+
+    public static final String DEFAULT_NETWORK_INTERFACE_NAME_KEY = "default_network_interface_name";
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureGeneralPolicy.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureGeneralPolicy.java
@@ -1,0 +1,41 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.ras.constants.Messages;
+import cloud.fogbow.ras.core.models.orders.ComputeOrder;
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class AzureGeneralPolicy {
+
+    public static final int MAXIMUM_NETWORK_PER_VIRTUAL_MACHINE = 1;
+    static final int MINIMUM_DISK = 30;
+    static final String PASSWORD_PREFIX = "P4ss@";
+
+    /**
+     * Azure Password Policy:
+     * 1) Contains an uppercase character
+     * 2) Contains a lowercase character
+     * 3) Contains a numeric digit
+     * 4) Contains a special character
+     * 5) Control characters are not allowed
+     */
+    public static String generatePassword() {
+        return PASSWORD_PREFIX + RandomStringUtils.randomAlphabetic(PASSWORD_PREFIX.length());
+    }
+
+    /**
+     * Azure Disk Policy
+     * 1) Greater than 30GB
+     */
+    public static int getDisk(ComputeOrder computeOrder) throws InvalidParameterException {
+        int disk = computeOrder.getDisk();
+        if (disk < MINIMUM_DISK) {
+            throw new InvalidParameterException(
+                    String.format(Messages.Error.ERROR_DISK_PARAMETER_AZURE_POLICY, MINIMUM_DISK));
+        }
+
+        return disk;
+    }
+
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureIdBuilder.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureIdBuilder.java
@@ -1,0 +1,38 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.common.models.AzureUser;
+import com.google.common.annotations.VisibleForTesting;
+
+public class AzureIdBuilder {
+
+    // /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{virtualMachineName}
+    @VisibleForTesting
+    static String VIRTUAL_MACHINE_STRUCTURE =
+            "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s";
+
+    public static AzureIdBuilderConfigured configure(AzureUser azureCloudUser) {
+        return new AzureIdBuilderConfigured(azureCloudUser);
+    }
+
+    public static class AzureIdBuilderConfigured {
+
+        private AzureUser azureUser;
+
+        public AzureIdBuilderConfigured(AzureUser azureCloudUser) {
+            this.azureUser = azureCloudUser;
+        }
+
+        public String buildVirtualMachineId(String virtualMachineName) {
+            return buildId(VIRTUAL_MACHINE_STRUCTURE, virtualMachineName);
+        }
+
+        @VisibleForTesting
+        String buildId(String structure, String name) {
+            String subscriptionId = this.azureUser.getSubscriptionId();
+            String resourceGroupName = this.azureUser.getResourceGroupName();
+            return String.format(structure, subscriptionId, resourceGroupName, name);
+        }
+
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureIdBuilder.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureIdBuilder.java
@@ -1,6 +1,9 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
 
+import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.constants.Messages;
+import cloud.fogbow.ras.core.models.orders.Order;
 import com.google.common.annotations.VisibleForTesting;
 
 public class AzureIdBuilder {
@@ -9,6 +12,11 @@ public class AzureIdBuilder {
     @VisibleForTesting
     static String VIRTUAL_MACHINE_STRUCTURE =
             "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s";
+    // /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}
+    @VisibleForTesting static String NETWORK_INTERFACE_STRUCTURE =
+            "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s";
+    // /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}
+    @VisibleForTesting static final String BIGGER_STRUCTURE = NETWORK_INTERFACE_STRUCTURE;
 
     public static AzureIdBuilderConfigured configure(AzureUser azureCloudUser) {
         return new AzureIdBuilderConfigured(azureCloudUser);
@@ -26,11 +34,29 @@ public class AzureIdBuilder {
             return buildId(VIRTUAL_MACHINE_STRUCTURE, virtualMachineName);
         }
 
+        public String buildNetworkInterfaceId(String networkInterfaceName) {
+            return buildId(NETWORK_INTERFACE_STRUCTURE, networkInterfaceName);
+        }
+
         @VisibleForTesting
         String buildId(String structure, String name) {
             String subscriptionId = this.azureUser.getSubscriptionId();
             String resourceGroupName = this.azureUser.getResourceGroupName();
             return String.format(structure, subscriptionId, resourceGroupName, name);
+        }
+
+        /**
+         * It checks the resource name size in relation to Database Instance Order Id Maximum Size.
+         * It happens because the resource name makes up the instance Id. Also, it might happen due
+         * to the fact that the user choose some values such as resourceName and resourceGroupName.
+         */
+        public void checkIdSizePolicy(String resourceName) throws InvalidParameterException {
+            String idBuilt = buildId(BIGGER_STRUCTURE, resourceName);
+            int sizeExceeded = idBuilt.length() - Order.FIELDS_MAX_SIZE;
+            if (sizeExceeded > 0) {
+                throw new InvalidParameterException(
+                        String.format(Messages.Error.ERROR_ID_LIMIT_SIZE_EXCEEDED, sizeExceeded));
+            }
         }
 
     }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtil.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtil.java
@@ -1,0 +1,50 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.ras.api.http.response.ImageSummary;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureGetImageRef;
+import org.apache.commons.lang3.StringUtils;
+
+public class AzureImageOperationUtil {
+
+    static final String IMAGE_SUMMARY_ID_SEPARATOR = "@#";
+    static final String IMAGE_SUMMARY_NAME_SEPARATOR = " - ";
+
+    private static final int SUMMARY_ID_PARAMETER_SIZE = 3;
+    private static final int PUBLISHER_ID_SUMMARY_POSITION = 0;
+    private static final int OFFER_ID_SUMMARY_POSITION = 1;
+    private static final int SKU_ID_SUMMARY_POSITION = 2;
+
+    private static final int SUMMARY_NAME_PARAMETER_SIZE = 2;
+    private static final int OFFER_NAME_SUMMARY_POSITION = 0;
+    private static final int SKU_NAME_SUMMARY_POSITION = 1;
+
+    static ImageSummary buildImageSummaryBy(AzureGetImageRef azureVirtualMachineImage) {
+        String id = convertToImageSummaryId(azureVirtualMachineImage);
+        String name = convertToImageSummaryName(azureVirtualMachineImage);
+        return new ImageSummary(id, name);
+    }
+
+    public static AzureGetImageRef buildAzureVirtualMachineImageBy(String imageSummaryId) {
+        String[] imageSummaryIdChunks = imageSummaryId.split(IMAGE_SUMMARY_ID_SEPARATOR);
+        String published = imageSummaryIdChunks[PUBLISHER_ID_SUMMARY_POSITION];
+        String offer = imageSummaryIdChunks[OFFER_ID_SUMMARY_POSITION];
+        String sku = imageSummaryIdChunks[SKU_ID_SUMMARY_POSITION];
+        return new AzureGetImageRef(published, offer, sku);
+    }
+
+    static String convertToImageSummaryId(AzureGetImageRef azureGetImageRef) {
+        String[] list = new String[SUMMARY_ID_PARAMETER_SIZE];
+        list[PUBLISHER_ID_SUMMARY_POSITION] = azureGetImageRef.getPublisher();
+        list[OFFER_ID_SUMMARY_POSITION] = azureGetImageRef.getOffer();
+        list[SKU_ID_SUMMARY_POSITION] = azureGetImageRef.getSku();
+        return StringUtils.join(list, IMAGE_SUMMARY_ID_SEPARATOR);
+    }
+
+    static String convertToImageSummaryName(AzureGetImageRef azureGetImageRef) {
+        String[] list = new String[SUMMARY_NAME_PARAMETER_SIZE];
+        list[OFFER_NAME_SUMMARY_POSITION] = azureGetImageRef.getOffer();
+        list[SKU_NAME_SUMMARY_POSITION] = azureGetImageRef.getSku();
+        return StringUtils.join(list, IMAGE_SUMMARY_NAME_SEPARATOR);
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureInstancePolicy.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureInstancePolicy.java
@@ -1,0 +1,63 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.constants.SystemConstants;
+import cloud.fogbow.ras.core.models.orders.ComputeOrder;
+import javax.annotation.Nullable;
+import java.util.function.BiFunction;
+
+public class AzureInstancePolicy {
+
+    /**
+     * Generate the Azure Resource Name and check if It's in accordance with the policy.
+     */
+    private static String generateAzureResourceNameBy(@Nullable String orderName, String orderId,
+                                                      AzureUser azureCloudUser)
+            throws InvalidParameterException {
+
+        if (orderName == null) {
+            orderName = SystemConstants.FOGBOW_INSTANCE_NAME_PREFIX + orderId;
+        }
+
+        AzureIdBuilder.configure(azureCloudUser).checkIdSizePolicy(orderName);
+        return orderName;
+    }
+
+    public static String generateAzureResourceNameBy(
+            ComputeOrder computeOrder, AzureUser azureCloudUser) throws InvalidParameterException {
+
+        return generateAzureResourceNameBy(computeOrder.getName(), computeOrder.getId(), azureCloudUser);
+    }
+
+    public static String generateAzureResourceNameBy(String orderId, AzureUser azureUser)
+            throws InvalidParameterException {
+
+        return generateAzureResourceNameBy(null, orderId, azureUser);
+    }
+
+    public static String generateFogbowInstanceIdBy(String orderId, AzureUser azureCloudUser,
+                                                    BiFunction<String, AzureUser, String> builderId)
+            throws InvalidParameterException {
+
+        String resourceName = generateAzureResourceNameBy(orderId, azureCloudUser);
+        return generateFogbowIstanceId(resourceName, azureCloudUser, builderId);
+    }
+
+    public static String generateFogbowInstanceIdBy(ComputeOrder computeOrder, AzureUser azureUser)
+            throws InvalidParameterException {
+
+        String resourceName = generateAzureResourceNameBy(computeOrder, azureUser);
+        return AzureIdBuilder
+                .configure(azureUser)
+                .buildVirtualMachineId(resourceName);
+    }
+
+    private static String generateFogbowIstanceId(String resourceName, AzureUser azureUser,
+                                                  BiFunction<String, AzureUser, String> builderId) {
+
+        return builderId.apply(resourceName, azureUser);
+    }
+
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureSchedulerManager.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureSchedulerManager.java
@@ -1,0 +1,14 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class AzureSchedulerManager {
+
+    private static final int VIRTUAL_MACHINE_POOL_SIZE = 2;
+
+    public static ExecutorService getVirtualMachineExecutor() {
+        return Executors.newFixedThreadPool(VIRTUAL_MACHINE_POOL_SIZE);
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureStateMapper.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureStateMapper.java
@@ -13,16 +13,19 @@ public class AzureStateMapper {
     private static final String COMPUTE_PLUGIN = AzureComputePlugin.class.getSimpleName();
     public static final String CREATING_STATE = "Creating";
     public static final String SUCCEEDED_STATE = "Succeeded";
+    public static final String FAILED_STATE = "Failed";
 
     public static InstanceState map(ResourceType type, String state) {
         switch (type) {
             case COMPUTE:
-                // cloud state values: [sreating, succeded]
+                // cloud state values: [creating, succeeded]
                 switch (state) {
                     case CREATING_STATE:
                         return InstanceState.CREATING;
                     case SUCCEEDED_STATE:
                         return InstanceState.READY;
+                    case FAILED_STATE:
+                        return InstanceState.FAILED;
                     default:
                         LOGGER.error(String.format(Messages.Error.UNDEFINED_INSTANCE_STATE_MAPPING, state, COMPUTE_PLUGIN));
                         return InstanceState.INCONSISTENT;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureStateMapper.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureStateMapper.java
@@ -1,0 +1,36 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.ras.api.http.response.InstanceState;
+import cloud.fogbow.ras.constants.Messages;
+import cloud.fogbow.ras.core.models.ResourceType;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.AzureComputePlugin;
+import org.apache.log4j.Logger;
+
+public class AzureStateMapper {
+
+    private static final Logger LOGGER = Logger.getLogger(AzureStateMapper.class);
+
+    private static final String COMPUTE_PLUGIN = AzureComputePlugin.class.getSimpleName();
+    public static final String CREATING_STATE = "Creating";
+    public static final String SUCCEEDED_STATE = "Succeeded";
+
+    public static InstanceState map(ResourceType type, String state) {
+        switch (type) {
+            case COMPUTE:
+                // cloud state values: [sreating, succeded]
+                switch (state) {
+                    case CREATING_STATE:
+                        return InstanceState.CREATING;
+                    case SUCCEEDED_STATE:
+                        return InstanceState.READY;
+                    default:
+                        LOGGER.error(String.format(Messages.Error.UNDEFINED_INSTANCE_STATE_MAPPING, state, COMPUTE_PLUGIN));
+                        return InstanceState.INCONSISTENT;
+                }
+            default:
+                LOGGER.error(Messages.Error.INSTANCE_TYPE_NOT_DEFINED);
+                return InstanceState.INCONSISTENT;
+        }
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/GenericBuilder.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/GenericBuilder.java
@@ -1,6 +1,7 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
 
 import cloud.fogbow.common.exceptions.InvalidParameterException;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
 import java.lang.annotation.ElementType;
@@ -17,7 +18,8 @@ import java.util.function.Supplier;
 public class GenericBuilder<T> {
 
     private static final Logger LOGGER = Logger.getLogger(GenericBuilder.class);
-    private static final String FIELD_REQUIRED_MESSAGE = "The field %s is required in the class %s.";
+    @VisibleForTesting
+    static final String FIELD_REQUIRED_MESSAGE = "The field %s is required in the class %s.";
     private static final String ILLEGAL_ACCESS_FIELD = "There is an illegal access on field %s";
 
     private final Supplier<T> instantiator;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/GenericBuilder.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/GenericBuilder.java
@@ -1,0 +1,81 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import org.apache.log4j.Logger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class GenericBuilder<T> {
+
+    private static final Logger LOGGER = Logger.getLogger(GenericBuilder.class);
+    private static final String FIELD_REQUIRED_MESSAGE = "The field %s is required in the class %s.";
+    private static final String ILLEGAL_ACCESS_FIELD = "There is an illegal access on field %s";
+
+    private final Supplier<T> instantiator;
+
+    private List<Consumer<T>> instanceModifiers = new ArrayList<>();
+
+    protected GenericBuilder(Supplier<T> instantiator) {
+        this.instantiator = instantiator;
+    }
+
+    protected static <T> GenericBuilder<T> of(Supplier<T> instantiator) {
+        return new GenericBuilder<T>(instantiator);
+    }
+
+    protected <U> GenericBuilder<T> with(BiConsumer<T, U> consumer, U value) {
+        Consumer<T> c = instance -> consumer.accept(instance, value);
+        this.instanceModifiers.add(c);
+        return this;
+    }
+
+    public T checkAndBuild() throws InvalidParameterException {
+        T object = build();
+        checkParametersRequired(object);
+        return object;
+    }
+
+    private void checkParametersRequired(T object) throws InvalidParameterException {
+        for (Field field : object.getClass().getDeclaredFields()) {
+            if (field.isAnnotationPresent(Required.class)) {
+                Object value = getFieldValue(object, field);
+                if (value == null) {
+                    String message = String.format(FIELD_REQUIRED_MESSAGE,
+                            field.getName(), object.getClass().getSimpleName());
+                    throw new InvalidParameterException(message);
+                }
+            }
+        }
+    }
+
+    private Object getFieldValue(T object, Field field) {
+        try {
+            field.setAccessible(true);
+            return field.get(object);
+        } catch (IllegalAccessException e) {
+            LOGGER.warn(String.format(ILLEGAL_ACCESS_FIELD, field.getName()), e);
+            return null;
+        }
+    }
+
+    public T build() {
+        T value = this.instantiator.get();
+        this.instanceModifiers.forEach(modifier -> modifier.accept(value));
+        this.instanceModifiers.clear();
+        return value;
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface Required {}
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/volume/sdk/AzureVolumeSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/volume/sdk/AzureVolumeSDK.java
@@ -1,0 +1,12 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.volume.sdk;
+
+import com.microsoft.azure.management.Azure;
+import rx.Completable;
+
+public class AzureVolumeSDK {
+
+    public static Completable buildDeleteDiskCompletable(Azure azure, String diskId) {
+        return azure.disks().deleteByIdAsync(diskId);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/LoggerAssert.java
+++ b/src/test/java/cloud/fogbow/ras/core/LoggerAssert.java
@@ -16,6 +16,7 @@ public class LoggerAssert {
 
     private Logger fooLogger;
     private ListAppender<ILoggingEvent> listAppender;
+    private int globalPosition = 1;
 
     public LoggerAssert(Class classToTest) {
         this.fooLogger = (Logger) LoggerFactory.getLogger(classToTest);
@@ -30,6 +31,17 @@ public class LoggerAssert {
         ILoggingEvent iLoggingEvent = list.get(getPositionList(logPosition));
         Assert.assertEquals(iLoggingEvent.getMessage(), message);
         Assert.assertEquals(iLoggingEvent.getLevel(), level);
+    }
+
+    public LoggerAssert assertEqualsInOrder(Level level, String message) {
+        assertEquals(this.globalPosition++, level, message);
+        return this;
+    }
+
+    public void verifyLogEnd() {
+        if (this.globalPosition <= this.listAppender.list.size()) {
+            Assert.fail("The log is not on the end");
+        }
     }
 
     private int getPositionList(int logPosition) {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/AzureTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/AzureTestUtils.java
@@ -5,11 +5,12 @@ import org.mockito.Mockito;
 
 public class AzureTestUtils {
 
+    public static final String AZURE_CLOUD_NAME = "azure";
     private static final String SUBSCRIPTION_ID_DEFAULT = "subscriptionId";
     private static final String RESOURCE_GROUP_NAME_DEFAULT = "resourceGroupName";
     private static final String REGION_NAME_DEFAULT = "regionName";
 
-    public static AzureUser createAzureCloudUser() {
+    public static AzureUser createAzureUser() {
         AzureUser azureUser = Mockito.mock(AzureUser.class);
         Mockito.when(azureUser.getSubscriptionId()).thenReturn(SUBSCRIPTION_ID_DEFAULT);
         Mockito.when(azureUser.getRegionName()).thenReturn(REGION_NAME_DEFAULT);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/AzureTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/AzureTestUtils.java
@@ -1,0 +1,20 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure;
+
+import cloud.fogbow.common.models.AzureUser;
+import org.mockito.Mockito;
+
+public class AzureTestUtils {
+
+    private static final String SUBSCRIPTION_ID_DEFAULT = "subscriptionId";
+    private static final String RESOURCE_GROUP_NAME_DEFAULT = "resourceGroupName";
+    private static final String REGION_NAME_DEFAULT = "regionName";
+
+    public static AzureUser createAzureCloudUser() {
+        AzureUser azureUser = Mockito.mock(AzureUser.class);
+        Mockito.when(azureUser.getSubscriptionId()).thenReturn(SUBSCRIPTION_ID_DEFAULT);
+        Mockito.when(azureUser.getRegionName()).thenReturn(REGION_NAME_DEFAULT);
+        Mockito.when(azureUser.getResourceGroupName()).thenReturn(RESOURCE_GROUP_NAME_DEFAULT);
+        return azureUser;
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePluginTest.java
@@ -1,0 +1,128 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
+
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.common.util.HomeDir;
+import cloud.fogbow.ras.api.http.response.ComputeInstance;
+import cloud.fogbow.ras.constants.SystemConstants;
+import cloud.fogbow.ras.core.TestUtils;
+import cloud.fogbow.ras.core.models.orders.ComputeOrder;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.AzureTestUtils;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureGetVirtualMachineRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureVirtualMachineOperation;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureIdBuilder;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureStateMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+@PrepareForTest({})
+public class AzureComputePluginTest extends TestUtils {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private AzureComputePlugin azureComputePlugin;
+    private AzureUser azureUser;
+    private AzureVirtualMachineOperation azureVirtualMachineOperation;
+
+    @Before
+    public void setUp() {
+        String azureConfFilePath = HomeDir.getPath() +
+                SystemConstants.CLOUDS_CONFIGURATION_DIRECTORY_NAME + File.separator
+                + AzureTestUtils.AZURE_CLOUD_NAME + File.separator
+                + SystemConstants.CLOUD_SPECIFICITY_CONF_FILE_NAME;
+        this.azureComputePlugin = Mockito.spy(new AzureComputePlugin(azureConfFilePath));
+        this.azureVirtualMachineOperation = Mockito.mock(AzureVirtualMachineOperationSDK.class);
+        this.azureComputePlugin.setAzureVirtualMachineOperation(this.azureVirtualMachineOperation);
+        this.azureUser = AzureTestUtils.createAzureUser();
+    }
+
+    // test case: When calling the getInstance method, it must verify if It returns the right computeInstance.
+    @Test
+    public void testGetInstanceSuccessfully() throws FogbowException {
+        // set up
+        ComputeOrder computeOrder = new ComputeOrder();
+        String instanceId = "instanceId";
+        computeOrder.setInstanceId(instanceId);
+
+        AzureGetVirtualMachineRef azureGetVirtualMachineRef = Mockito.mock(AzureGetVirtualMachineRef.class);
+        Mockito.when(this.azureVirtualMachineOperation
+                .doGetInstance(Mockito.eq(instanceId), Mockito.eq(this.azureUser)))
+                .thenReturn(azureGetVirtualMachineRef);
+
+        ComputeInstance computeInstanceExpected = Mockito.mock(ComputeInstance.class);
+        Mockito.doReturn(computeInstanceExpected).when(this.azureComputePlugin)
+                .buildComputeInstance(Mockito.eq(azureGetVirtualMachineRef), Mockito.eq(this.azureUser));
+
+        // exercise
+        ComputeInstance computeInstance = this.azureComputePlugin.getInstance(computeOrder, this.azureUser);
+
+        // verify
+        Assert.assertEquals(computeInstanceExpected, computeInstance);
+    }
+
+    // test case: When calling the getInstance method and throws a Exception,
+    // it must verify if It does not treat and rethrow the same exception.
+    @Test
+    public void testGetInstanceFail() throws FogbowException {
+        // set up
+        ComputeOrder computeOrder = new ComputeOrder();
+        String instanceId = "instanceId";
+        computeOrder.setInstanceId(instanceId);
+
+        Mockito.when(this.azureVirtualMachineOperation
+                .doGetInstance(Mockito.eq(instanceId), Mockito.eq(this.azureUser)))
+                .thenThrow(new UnexpectedException());
+
+        // verify
+        this.expectedException.expect(UnexpectedException.class);
+
+        // exercise
+        this.azureComputePlugin.getInstance(computeOrder, this.azureUser);
+    }
+
+    // test case: When calling the buildComputeInstance method,
+    // it must verify if it returns the right ComputeInstance.
+    @Test
+    public void testBuildComputeInstanceSuccessfully() {
+        // set up
+        int diskExpected = 1;
+        String nameExpected = "name";
+        int memoryExpected = 2;
+        int vcpuExpected = 3;
+        String cloudStateExpected = AzureStateMapper.SUCCEEDED_STATE;
+        List<String> ipAddressExpected = Arrays.asList("id");
+        String idExpected = AzureIdBuilder.configure(this.azureUser).buildVirtualMachineId(nameExpected);
+        AzureGetVirtualMachineRef azureGetVirtualMachineRef = AzureGetVirtualMachineRef.builder()
+                .disk(diskExpected)
+                .vCPU(vcpuExpected)
+                .memory(memoryExpected)
+                .cloudState(cloudStateExpected)
+                .name(nameExpected)
+                .ipAddresses(ipAddressExpected)
+                .build();
+
+        // exercise
+        ComputeInstance computeInstance = this.azureComputePlugin
+                .buildComputeInstance(azureGetVirtualMachineRef, this.azureUser);
+
+        // verify
+        Assert.assertEquals(diskExpected, computeInstance.getDisk());
+        Assert.assertEquals(memoryExpected, computeInstance.getMemory());
+        Assert.assertEquals(vcpuExpected, computeInstance.getvCPU());
+        Assert.assertEquals(idExpected, computeInstance.getId());
+        Assert.assertEquals(cloudStateExpected, computeInstance.getCloudState());
+        Assert.assertEquals(ipAddressExpected, computeInstance.getIpAddresses());
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureComputePluginTest.java
@@ -4,28 +4,37 @@ import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.AzureUser;
 import cloud.fogbow.common.util.HomeDir;
+import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.ras.api.http.response.ComputeInstance;
+import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.constants.SystemConstants;
 import cloud.fogbow.ras.core.TestUtils;
 import cloud.fogbow.ras.core.models.orders.ComputeOrder;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.AzureTestUtils;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureGetVirtualMachineRef;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureVirtualMachineOperation;
-import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureIdBuilder;
-import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureStateMapper;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureCreateVirtualMachineRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureGetImageRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.util.*;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 
-@PrepareForTest({})
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AzureImageOperationUtil.class, AzureInstancePolicy.class, AzureGeneralPolicy.class})
 public class AzureComputePluginTest extends TestUtils {
 
     @Rule
@@ -34,6 +43,7 @@ public class AzureComputePluginTest extends TestUtils {
     private AzureComputePlugin azureComputePlugin;
     private AzureUser azureUser;
     private AzureVirtualMachineOperation azureVirtualMachineOperation;
+    private String defaultNetworkInterfaceName;
 
     @Before
     public void setUp() {
@@ -41,11 +51,221 @@ public class AzureComputePluginTest extends TestUtils {
                 SystemConstants.CLOUDS_CONFIGURATION_DIRECTORY_NAME + File.separator
                 + AzureTestUtils.AZURE_CLOUD_NAME + File.separator
                 + SystemConstants.CLOUD_SPECIFICITY_CONF_FILE_NAME;
+        Properties properties = PropertiesUtil.readProperties(azureConfFilePath);
+        this.defaultNetworkInterfaceName = properties.getProperty(AzureConstants.DEFAULT_NETWORK_INTERFACE_NAME_KEY);
         this.azureComputePlugin = Mockito.spy(new AzureComputePlugin(azureConfFilePath));
         this.azureVirtualMachineOperation = Mockito.mock(AzureVirtualMachineOperationSDK.class);
         this.azureComputePlugin.setAzureVirtualMachineOperation(this.azureVirtualMachineOperation);
         this.azureUser = AzureTestUtils.createAzureUser();
     }
+
+    // test case: When calling the isReady method and the instance state is ready,
+    // it must verify if It returns true value
+    @Test
+    public void testIsReadySuccessfullyWhenIsReady() {
+        // set up
+        String instanceState = AzureStateMapper.SUCCEEDED_STATE;
+
+        // exercise and verify
+        Assert.assertTrue(this.azureComputePlugin.isReady(instanceState));
+    }
+
+    // test case: When calling the isReady method and the instance state is not ready,
+    // it must verify if It returns false value
+    @Test
+    public void testIsReadySuccessfullyWhenNotReady() {
+        // set up
+        String instanceState = AzureStateMapper.CREATING_STATE;
+
+        // exercise and verify
+        Assert.assertFalse(this.azureComputePlugin.isReady(instanceState));
+    }
+
+    // test case: When calling the hasFailed method and the instance state is failed,
+    // it must verify if It returns true value
+    @Test
+    public void testHasFailedSuccessfullyWhenIsFailed() {
+        // set up
+        String instanceState = AzureStateMapper.FAILED_STATE;
+
+        // exercise and verify
+        Assert.assertTrue(this.azureComputePlugin.hasFailed(instanceState));
+    }
+
+    // test case: When calling the hasFailed method and the instance state is not failed,
+    // it must verify if It returns false value
+    @Test
+    public void testHasFailedSuccessfullyWhenIsNotFailed() {
+        // set up
+        String instanceState = AzureStateMapper.SUCCEEDED_STATE;
+
+        // exercise and verify
+        Assert.assertFalse(this.azureComputePlugin.hasFailed(instanceState));
+    }
+
+    // test case: When calling the getNetworkInterfaceId method without network in the order,
+    // it must verify if It returns the default networkInterfaceId.
+    @Test
+    public void testGetNetworkInterfaceIdSuccessfullyWhenEmptyNetworkInOrder() throws FogbowException {
+        // set up
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+        List<String> networds = new ArrayList<>();
+        Mockito.when(computeOrder.getNetworkIds()).thenReturn(networds);
+
+        String networkInsterfaceIdExpected = AzureIdBuilder
+                .configure(this.azureUser)
+                .buildNetworkInterfaceId(this.defaultNetworkInterfaceName);
+
+        // exercise
+        String networkInterfaceId = this.azureComputePlugin.getNetworkInterfaceId(computeOrder, this.azureUser);
+
+        // verify
+        Assert.assertEquals(networkInsterfaceIdExpected, networkInterfaceId);
+    }
+
+    // test case: When calling the getNetworkInterfaceId method with one network in the order,
+    // it must verify if It returns the network in the order.
+    @Test
+    public void testGetNetworkInterfaceIdSuccessfullyWhenOneNetworkInOrder() throws FogbowException {
+        // set up
+        String nertworkIdExpeceted = "networkId";
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+        List<String> networds = new ArrayList<>();
+        networds.add(nertworkIdExpeceted);
+        Mockito.when(computeOrder.getNetworkIds()).thenReturn(networds);
+
+        // exercise
+        String networkInterfaceId = this.azureComputePlugin
+                .getNetworkInterfaceId(computeOrder, this.azureUser);
+
+        // verify
+        Assert.assertEquals(nertworkIdExpeceted, networkInterfaceId);
+    }
+
+    // test case: When calling the getNetworkInterfaceId method with more than one network in the order,
+    // it must verify if It throws a FogbowException.
+    @Test
+    public void testGetNetworkInterfaceIdFailWhenMoreThanOneNetworkInOrder() throws FogbowException {
+        // set up
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+        List<String> networds = Arrays.asList("one", "two");
+        Mockito.when(computeOrder.getNetworkIds()).thenReturn(networds);
+
+        // verify
+        this.expectedException.expect(FogbowException.class);
+        this.expectedException.expectMessage(Messages.Error.ERROR_MULTIPLE_NETWORKS_NOT_ALLOWED);
+
+        // exercise
+        this.azureComputePlugin.getNetworkInterfaceId(computeOrder, this.azureUser);
+
+    }
+
+    // test case: When calling the requestInstance method with mocked methods,
+    // it must verify if it creates all variable correct.
+    @Test
+    public void testRequestInstanceSuccessfully() throws FogbowException {
+        // set up
+        PowerMockito.mockStatic(AzureGeneralPolicy.class);
+        String imageId = "imageId";
+        String orderId = "orderId";
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+        Mockito.when(computeOrder.getImageId()).thenReturn(imageId);
+        Mockito.when(computeOrder.getId()).thenReturn(orderId);
+
+        String networkInterfaceId = "networkInterfaceId";
+        Mockito.doReturn(networkInterfaceId).when(this.azureComputePlugin)
+                .getNetworkInterfaceId(Mockito.eq(computeOrder), Mockito.eq(this.azureUser));
+
+        String virtualMachineSizeName = "virtualMachineSizeName";
+        Mockito.doReturn(virtualMachineSizeName).when(this.azureComputePlugin)
+                .getVirtualMachineSizeName(Mockito.eq(computeOrder), Mockito.eq(this.azureUser));
+
+        int disk = 1;
+        Mockito.when(AzureGeneralPolicy.getDisk(Mockito.eq(computeOrder))).thenReturn(disk);
+
+        AzureGetImageRef azureGetImageRef = new AzureGetImageRef("", "", "");
+        PowerMockito.mockStatic(AzureImageOperationUtil.class);
+        Mockito.when(AzureImageOperationUtil.buildAzureVirtualMachineImageBy(Mockito.eq(imageId)))
+                .thenReturn(azureGetImageRef);
+
+        String virtualMachineName = "virtualMachineName";
+        PowerMockito.mockStatic(AzureInstancePolicy.class);
+        PowerMockito.when(AzureInstancePolicy.
+                generateAzureResourceNameBy(Mockito.eq(computeOrder), Mockito.eq(this.azureUser)))
+                .thenReturn(virtualMachineName);
+
+        String userData = "userData";
+        Mockito.doReturn(userData).when(this.azureComputePlugin).getUserData(Mockito.eq(computeOrder));
+
+        String password = "password";
+        PowerMockito.when(AzureGeneralPolicy.generatePassword()).thenReturn(password);
+
+        String regionName = this.azureUser.getRegionName();
+        String resourceGroupName = this.azureUser.getResourceGroupName();
+
+        AzureCreateVirtualMachineRef azureCreateVirtualMachineRef = AzureCreateVirtualMachineRef.builder()
+                .virtualMachineName(virtualMachineName)
+                .azureGetImageRef(azureGetImageRef)
+                .networkInterfaceId(networkInterfaceId)
+                .diskSize(disk)
+                .size(virtualMachineSizeName)
+                .osComputeName(orderId)
+                .osUserName(orderId)
+                .osUserPassword(password)
+                .regionName(regionName)
+                .resourceGroupName(resourceGroupName)
+                .userData(userData)
+                .checkAndBuild();
+
+
+        // exercise
+        this.azureComputePlugin.requestInstance(computeOrder, this.azureUser);
+
+        // verify
+        Mockito.verify(this.azureComputePlugin, Mockito.times(TestUtils.RUN_ONCE)).doRequestInstance(
+                Mockito.eq(computeOrder), Mockito.eq(this.azureUser), Mockito.eq(azureCreateVirtualMachineRef)
+        );
+    }
+
+    // test case: When calling the requestInstance method any throws any exception,
+    // it must verify if it re-throws the exception.
+    @Test
+    public void testRequestInstanceFail() throws FogbowException {
+        // set up
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+
+        Mockito.doThrow(FogbowException.class).when(this.azureComputePlugin)
+                .getNetworkInterfaceId(Mockito.eq(computeOrder), Mockito.eq(this.azureUser));
+
+        // verify
+        this.expectedException.expect(FogbowException.class);
+
+        // exercise
+        this.azureComputePlugin.requestInstance(computeOrder, this.azureUser);
+    }
+
+    // test case: When calling the getVirtualMachineSizeName method,
+    // it must verify if it calls the method with right parameters.
+    @Test
+    public void testGetVirtualMachineSizeName() throws FogbowException {
+        // set up
+        int memory = 1;
+        int vcpu = 1;
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+        Mockito.when(computeOrder.getMemory()).thenReturn(memory);
+        Mockito.when(computeOrder.getvCPU()).thenReturn(vcpu);
+
+        String regionName = this.azureUser.getRegionName();
+
+        // exercise
+        this.azureComputePlugin.getVirtualMachineSizeName(computeOrder, this.azureUser);
+
+        // verify
+        Mockito.verify(this.azureVirtualMachineOperation, Mockito.times(TestUtils.RUN_ONCE)).findVirtualMachineSizeName(
+                Mockito.eq(memory), Mockito.eq(vcpu), Mockito.eq(regionName), Mockito.eq(this.azureUser)
+        );
+    }
+
 
     // test case: When calling the getInstance method, it must verify if It returns the right computeInstance.
     @Test
@@ -124,5 +344,27 @@ public class AzureComputePluginTest extends TestUtils {
         Assert.assertEquals(cloudStateExpected, computeInstance.getCloudState());
         Assert.assertEquals(ipAddressExpected, computeInstance.getIpAddresses());
     }
+
+    // test case: When calling the deleteInstance method,
+    // it must verify if it calls the method with right parameters.
+    @Test
+    public void testDeleteInstanceSuccessfully() throws FogbowException {
+        // set up
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+        String instanceId = "instanceId";
+        Mockito.when(computeOrder.getInstanceId()).thenReturn(instanceId);
+
+        Mockito.doNothing()
+                .when(this.azureVirtualMachineOperation)
+                .doDeleteInstance(Mockito.eq(instanceId), Mockito.eq(this.azureUser));
+
+        // exercise
+        this.azureComputePlugin.deleteInstance(computeOrder, this.azureUser);
+
+        // verify
+        Mockito.verify(this.azureVirtualMachineOperation, Mockito.times(TestUtils.RUN_ONCE))
+                .doDeleteInstance(Mockito.eq(instanceId), Mockito.eq(this.azureUser));
+    }
+
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineOperationSDKTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineOperationSDKTest.java
@@ -1,12 +1,16 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
 
-import cloud.fogbow.common.exceptions.InstanceNotFoundException;
-import cloud.fogbow.common.exceptions.NoAvailableResourcesException;
-import cloud.fogbow.common.exceptions.UnauthenticatedUserException;
-import cloud.fogbow.common.exceptions.UnexpectedException;
+import ch.qos.logback.classic.Level;
+import cloud.fogbow.common.exceptions.*;
 import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.constants.Messages;
+import cloud.fogbow.ras.core.LoggerAssert;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureGetVirtualMachineRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureCreateVirtualMachineRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureGetImageRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.network.sdk.AzureNetworkSDK;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureClientCacheManager;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.volume.sdk.AzureVolumeSDK;
 import com.microsoft.azure.Page;
 import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.Azure;
@@ -15,7 +19,10 @@ import com.microsoft.azure.management.compute.VirtualMachineSize;
 import com.microsoft.azure.management.compute.VirtualMachineSizeTypes;
 import com.microsoft.azure.management.network.NetworkInterface;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import com.microsoft.azure.management.resources.fluentcore.model.Indexable;
 import com.microsoft.rest.RestException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -23,34 +30,44 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.mockito.internal.verification.VerificationModeFactory;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import rx.Completable;
+import rx.Observable;
+import rx.schedulers.Schedulers;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({AzureClientCacheManager.class, AzureVirtualMachineSDK.class,})
+@PrepareForTest({AzureClientCacheManager.class, AzureVirtualMachineSDK.class,
+        AzureNetworkSDK.class, AzureVolumeSDK.class})
 public class AzureVirtualMachineOperationSDKTest {
+
+    private static final Logger LOGGER_CLASS_MOCK = Logger.getLogger(AzureVirtualMachineOperationSDK.class);
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    private LoggerAssert loggerAssert = new LoggerAssert(AzureVirtualMachineOperationSDK.class);
     private AzureVirtualMachineOperationSDK azureVirtualMachineOperationSDK;
-    private AzureUser azureUser;
+    private AzureUser azureCloudUser;
     private Azure azure;
 
     @Before
     public void setUp() {
         this.azureVirtualMachineOperationSDK =
                 Mockito.spy(new AzureVirtualMachineOperationSDK());
-        this.azureUser = Mockito.mock(AzureUser.class);
+        this.azureCloudUser = Mockito.mock(AzureUser.class);
         this.azure = null;
+        makeTheObservablesSynchronous();
 
         PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
     }
+
 
     // test case: When calling the doGetInstance method with methods mocked,
     // it must verify if It returns the right AzureGetVirtualMachineRef.
@@ -78,7 +95,7 @@ public class AzureVirtualMachineOperationSDKTest {
         int diskSize = 3;
         Mockito.when(virtualMachine.osDiskSize()).thenReturn(diskSize);
 
-        String regionName = this.azureUser.getRegionName();
+        String regionName = this.azureCloudUser.getRegionName();
 
         VirtualMachineSize virtualMachineSize = Mockito.mock(VirtualMachineSize.class);
         int memory = 1;
@@ -91,7 +108,7 @@ public class AzureVirtualMachineOperationSDKTest {
 
         PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
         Optional<VirtualMachine> virtualMachineOptional = Optional.ofNullable(virtualMachine);
-        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachineById(
+        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachine(
                 Mockito.eq(this.azure), Mockito.eq(instanceId)))
                 .thenReturn(virtualMachineOptional);
 
@@ -106,7 +123,7 @@ public class AzureVirtualMachineOperationSDKTest {
 
         // exercise
         AzureGetVirtualMachineRef azureGetVirtualMachineRef =
-                this.azureVirtualMachineOperationSDK.doGetInstance(instanceId, this.azureUser);
+                this.azureVirtualMachineOperationSDK.doGetInstance(instanceId, this.azureCloudUser);
 
         // verify
         Assert.assertEquals(azureGetVirtualMachineRefExpected, azureGetVirtualMachineRef);
@@ -124,7 +141,7 @@ public class AzureVirtualMachineOperationSDKTest {
         String instanceId = "instanceId";
 
         PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
-        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachineById(
+        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachine(
                 Mockito.eq(this.azure), Mockito.eq(instanceId)))
                 .thenThrow(new UnexpectedException());
 
@@ -132,7 +149,7 @@ public class AzureVirtualMachineOperationSDKTest {
         this.expectedException.expect(UnexpectedException.class);
 
         // exercise
-        this.azureVirtualMachineOperationSDK.doGetInstance(instanceId, this.azureUser);
+        this.azureVirtualMachineOperationSDK.doGetInstance(instanceId, this.azureCloudUser);
     }
 
     // test case: When calling the findVirtualMachineSizeByName method and find one the virtual machine size,
@@ -199,11 +216,410 @@ public class AzureVirtualMachineOperationSDKTest {
                 .findVirtualMachineSizeByName(virtualMachineSizeNameExpected, regionName, this.azure);
     }
 
-    private void mockGetAzureClient() throws UnauthenticatedUserException {
-        PowerMockito.mockStatic(AzureClientCacheManager.class);
-        PowerMockito.when(AzureClientCacheManager.getAzure(Mockito.eq(this.azureUser)))
-                .thenReturn(azure);
+
+    // test case: When calling the findVirtualMachineSizeName method with two virtual machine size name that
+    // fits in the requirements, it must verify if It returns the smaller virtual machine size.
+    @Test
+    public void testFindVirtualMachineSizeNameSuccessfully()
+            throws NoAvailableResourcesException, UnauthenticatedUserException, UnexpectedException {
+
+        // set up
+        mockGetAzureClient();
+
+        int memory = 1;
+        int vcpu = 2;
+        Region region = Region.US_EAST;
+        String regionName = region.name();
+
+        PagedList<VirtualMachineSize> virtualMachines = getVirtualMachineSizesMock();
+
+        int lessThanMemoryRequired = memory - 1;
+        int lessThanCpuRequired = vcpu - 1;
+        VirtualMachineSize virtualMachineSizeNotFits = buildVirtualMachineSizeMock(lessThanMemoryRequired, lessThanCpuRequired);
+        VirtualMachineSize virtualMachineSizeFitsSmaller = buildVirtualMachineSizeMock(memory, vcpu);
+        VirtualMachineSize virtualMachineSizeFitsBigger = buildVirtualMachineSizeMock(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+        virtualMachines.add(virtualMachineSizeNotFits);
+        virtualMachines.add(virtualMachineSizeFitsSmaller);
+        virtualMachines.add(virtualMachineSizeFitsBigger);
+
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachineSizes(Mockito.eq(this.azure), Mockito.eq(region)))
+                .thenReturn(virtualMachines);
+
+        // exercise
+        String virtualMachineSize = this.azureVirtualMachineOperationSDK
+                .findVirtualMachineSizeName(memory, vcpu, regionName, this.azureCloudUser);
+
+        // verify
+        Assert.assertNotEquals(virtualMachineSizeFitsBigger.name(), virtualMachineSize);
+        Assert.assertEquals(virtualMachineSizeFitsSmaller.name(), virtualMachineSize);
     }
+
+    // test case: When calling the findVirtualMachineSizeName method with any virtual machine size name that
+    // fits in the requirements, it must verify if It throws a NoAvailableResourcesException.
+    @Test
+    public void testFindVirtualMachineSizeNameFail()
+            throws NoAvailableResourcesException, UnauthenticatedUserException, UnexpectedException {
+
+        // set up
+        mockGetAzureClient();
+
+        int memory = 1;
+        int vcpu = 2;
+        Region region = Region.US_EAST;
+        String regionName = region.name();
+
+        PagedList<VirtualMachineSize> virtualMachines = getVirtualMachineSizesMock();
+
+        int lessThanMemoryRequired = memory - 1;
+        int lessThanCpuRequired = vcpu - 1;
+        VirtualMachineSize virtualMachineSizeNotFits = buildVirtualMachineSizeMock(lessThanMemoryRequired, lessThanCpuRequired);
+        virtualMachines.add(virtualMachineSizeNotFits);
+
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachineSizes(Mockito.eq(this.azure), Mockito.eq(region)))
+                .thenReturn(virtualMachines);
+
+        // verify
+        this.expectedException.expect(NoAvailableResourcesException.class);
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.findVirtualMachineSizeName(memory, vcpu, regionName, this.azureCloudUser);
+    }
+
+    // test case: When calling the findVirtualMachineSizeName method with throws an Unauthorized
+    // exception, it must verify if It throws an Unauthorized exception.
+    @Test
+    public void testFindVirtualMachineSizeFailWhenThrowUnauthorized()
+            throws NoAvailableResourcesException, UnauthenticatedUserException, UnexpectedException {
+
+        // set up
+        mockGetAzureClientUnauthorized();
+        int memory = 1;
+        int vcpu = 2;
+        String regionName = Region.US_EAST.name();
+
+        // verify
+        this.expectedException.expect(UnauthenticatedUserException.class);
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.findVirtualMachineSizeName(
+                memory, vcpu, regionName, this.azureCloudUser);
+    }
+
+    // test case: When calling the subscribeCreateVirtualMachine method and the observable executes
+    // without any error, it must verify if It returns the right logs.
+    @Test
+    public void testSubscribeCreateVirtualMachineSuccessfully() {
+        // set up
+        Observable<Indexable> virtualMachineObservable = createSimpleObservableSuccess();
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.subscribeCreateVirtualMachine(virtualMachineObservable);
+
+        // verify
+        this.loggerAssert
+                .assertEqualsInOrder(Level.INFO, Messages.Info.END_CREATE_VM_ASYNC_BEHAVIOUR);
+    }
+
+    // test case: When calling the subscribeCreateVirtualMachine method and the observable executes
+    // with an error, it must verify if It returns the right logs.
+    @Test
+    public void testSubscribeCreateVirtualMachineFail() {
+        // set up
+        Observable<Indexable> virtualMachineObservable = createSimpleObservableFail();
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.subscribeCreateVirtualMachine(virtualMachineObservable);
+
+        // verify
+        this.loggerAssert
+                .assertEqualsInOrder(Level.ERROR, Messages.Error.ERROR_CREATE_VM_ASYNC_BEHAVIOUR);
+    }
+
+    // test case: When calling the doCreateInstance method, it must verify if It finishes without error.
+    @Test
+    public void testDoCreateInstanceSuccessfully()
+            throws UnauthenticatedUserException, InstanceNotFoundException, UnexpectedException {
+
+        // set up
+        mockGetAzureClient();
+        AzureCreateVirtualMachineRef azureCreateVirtualMachineRef = AzureCreateVirtualMachineRef.builder()
+                .build();
+
+        Observable<Indexable> observableMocked = Mockito.mock(Observable.class);
+        Mockito.doReturn(observableMocked).when(this.azureVirtualMachineOperationSDK).buildAzureVirtualMachineObservable(
+                Mockito.eq(azureCreateVirtualMachineRef), Mockito.eq(this.azure));
+
+        Mockito.doNothing().when(this.azureVirtualMachineOperationSDK)
+                .subscribeCreateVirtualMachine(Mockito.any());
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.doCreateInstance(azureCreateVirtualMachineRef, this.azureCloudUser);
+
+        // verify
+        Mockito.verify(this.azureVirtualMachineOperationSDK, Mockito.times(1))
+                .subscribeCreateVirtualMachine(Mockito.eq(observableMocked));
+    }
+
+    // test case: When calling the buildAzureVirtualMachineObservable method, it must verify if
+    // It calls the method with the right parameters.
+    @Test
+    public void testBuildAzureVirtualMachineObservable() throws InvalidParameterException, InstanceNotFoundException, UnexpectedException {
+        // set up
+        String imagePublishedExpected = "publisher";
+        String imageSkuExpected = "sku";
+        String imageOfferExpected = "offer";
+        AzureGetImageRef azureVirtualMachineImageExpected =
+                new AzureGetImageRef(imagePublishedExpected, imageOfferExpected, imageSkuExpected);
+        String virtualMachineNameExpected = "virtualMachineNameExpected";
+        String networkInterfaceIdExpected = "networkInterfaceIdExpected";
+        int diskSize = 1;
+        String virtualMachineSizeNameExpected = "virtualMachineSizeNameExpected";
+        String osComputeNameExpected = "osComputeNameExpected";
+        String osUserNameExpected = "osUserNameExpected";
+        String osUserPasswordExpected = "osUserPasswordExpected";
+        String regionNameExpected = "regionNameExpected";
+        String resourceGroupNameExpected = "resourceGroupNameExpected";
+        String userDataExpected = "userDataExpected";
+
+        AzureCreateVirtualMachineRef azureCreateVirtualMachineRef = AzureCreateVirtualMachineRef.builder()
+                .virtualMachineName(virtualMachineNameExpected)
+                .azureGetImageRef(azureVirtualMachineImageExpected)
+                .networkInterfaceId(networkInterfaceIdExpected)
+                .diskSize(diskSize)
+                .size(virtualMachineSizeNameExpected)
+                .osComputeName(osComputeNameExpected)
+                .osUserName(osUserNameExpected)
+                .osUserPassword(osUserPasswordExpected)
+                .regionName(regionNameExpected)
+                .resourceGroupName(resourceGroupNameExpected)
+                .userData(userDataExpected)
+                .checkAndBuild();
+
+        PowerMockito.mockStatic(AzureNetworkSDK.class);
+        NetworkInterface networkInterfaceExcepted = Mockito.mock(NetworkInterface.class);
+        Optional<NetworkInterface> networkInterfaceExpectedOptional = Optional.ofNullable(networkInterfaceExcepted);
+        PowerMockito.when(AzureNetworkSDK
+                .getNetworkInterface(Mockito.eq(this.azure), Mockito.eq(networkInterfaceIdExpected)))
+                .thenReturn(networkInterfaceExpectedOptional);
+
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+        Region regionExpected = Region.fromName(regionNameExpected);
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.buildAzureVirtualMachineObservable(
+                azureCreateVirtualMachineRef, this.azure);
+
+        // verify
+        PowerMockito.verifyStatic(AzureVirtualMachineSDK.class, VerificationModeFactory.times(1));
+        AzureVirtualMachineSDK.buildVirtualMachineObservable(
+                Mockito.eq(this.azure), Mockito.eq(virtualMachineNameExpected), Mockito.eq(regionExpected),
+                Mockito.eq(resourceGroupNameExpected), Mockito.eq(networkInterfaceExcepted),
+                Mockito.eq(imagePublishedExpected), Mockito.eq(imageOfferExpected), Mockito.eq(imageSkuExpected),
+                Mockito.eq(osUserNameExpected), Mockito.eq(osUserPasswordExpected), Mockito.eq(osComputeNameExpected),
+                Mockito.eq(userDataExpected), Mockito.eq(diskSize), Mockito.eq(virtualMachineSizeNameExpected));
+    }
+
+    // test case: When calling the doDeleteInstance method and the completable executes
+    // without any error, it must verify if It returns the right logs.
+    @Test
+    public void testDoDeleteInstanceSuccessfully() throws UnexpectedException,
+            InstanceNotFoundException, UnauthenticatedUserException {
+
+        // set up
+        mockGetAzureClient();
+        String instanceId = "instanceId";
+
+        String completableMessageOne = "completableMessageOne";
+        Completable completableOne = createSimpleCompletableSuccess(completableMessageOne);
+        mockDeleteVirtualMachineCompletable(instanceId, completableOne);
+
+        String completableMessageTwo = "completableMessageOne";
+        Completable completableTwo = createSimpleCompletableSuccess(completableMessageTwo);
+        mockDeleteVirtualMachineDiskCompletable(instanceId, completableTwo);
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.doDeleteInstance(instanceId, this.azureCloudUser);
+
+        // verify
+        this.loggerAssert
+                .assertEqualsInOrder(Level.DEBUG, completableMessageOne)
+                .assertEqualsInOrder(Level.INFO, Messages.Info.END_DELETE_VM_ASYNC_BEHAVIOUR)
+                .assertEqualsInOrder(Level.DEBUG, completableMessageTwo)
+                .assertEqualsInOrder(Level.INFO, Messages.Info.END_DELETE_DISK_ASYNC_BEHAVIOUR);
+    }
+
+    // test case: When calling the doDeleteInstance method and the completable executes
+    // with error in the delete virtual machine, it must verify if It returns the right logs and
+    // does not execute the delete virtual machine disk.
+    @Test
+    public void testDoDeleteInstanceFailOnVirtualMachineDeletion() throws UnexpectedException,
+            InstanceNotFoundException, UnauthenticatedUserException {
+
+        // set up
+        mockGetAzureClient();
+        String instanceId = "instanceId";
+
+        String completableMessageOne = "completableMessageOne";
+        Completable completableOne = createSimpleCompletableFail(completableMessageOne);
+        mockDeleteVirtualMachineCompletable(instanceId, completableOne);
+
+        String completableMessageTwo = "completableMessageOne";
+        Completable completableTwo = createSimpleCompletableSuccess(completableMessageTwo);
+        mockDeleteVirtualMachineDiskCompletable(instanceId, completableTwo);
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.doDeleteInstance(instanceId, this.azureCloudUser);
+
+        // verify
+        this.loggerAssert
+                .assertEqualsInOrder(Level.DEBUG, completableMessageOne)
+                .assertEqualsInOrder(Level.ERROR, Messages.Error.ERROR_DELETE_VM_ASYNC_BEHAVIOUR)
+                .verifyLogEnd();
+    }
+
+    // test case: When calling the doDeleteInstance method and the completable executes
+    // with error in the delete virtual machine disk, it must verify if It returns the right logs.
+    @Test
+    public void testDoDeleteInstanceFailOnVirtualMachineDiskDeletion() throws UnexpectedException,
+            InstanceNotFoundException, UnauthenticatedUserException {
+
+        // set up
+        mockGetAzureClient();
+        String instanceId = "instanceId";
+
+        String completableMessageOne = "completableMessageOne";
+        Completable completableOne = createSimpleCompletableSuccess(completableMessageOne);
+        mockDeleteVirtualMachineCompletable(instanceId, completableOne);
+
+        String completableMessageTwo = "completableMessageOne";
+        Completable completableTwo = createSimpleCompletableFail(completableMessageTwo);
+        mockDeleteVirtualMachineDiskCompletable(instanceId, completableTwo);
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.doDeleteInstance(instanceId, this.azureCloudUser);
+
+        // verify
+        this.loggerAssert
+                .assertEqualsInOrder(Level.DEBUG, completableMessageOne)
+                .assertEqualsInOrder(Level.INFO, Messages.Info.END_DELETE_VM_ASYNC_BEHAVIOUR)
+                .assertEqualsInOrder(Level.DEBUG, completableMessageTwo)
+                .assertEqualsInOrder(Level.ERROR, Messages.Error.ERROR_DELETE_DISK_ASYNC_BEHAVIOUR)
+                .verifyLogEnd();
+    }
+
+
+    // test case: When calling the buildDeleteVirtualMachineDiskCompletable method and the completable executes
+    // without any error, it must verify if It returns the right logs.
+    @Test
+    public void testBuildDeleteVirtualMachineDiskCompletableSuccessfully()
+            throws UnexpectedException, InstanceNotFoundException {
+
+        // set up
+        String instanceId = "instanceId";
+        String compĺetableMessage = "compĺetableMessage";
+        Completable simpleCompletableSuccess = createSimpleCompletableSuccess(compĺetableMessage);
+        mockDeleteVirtualMachineDiskCompletable(instanceId, simpleCompletableSuccess);
+
+        // exercise
+        Completable completable = this.azureVirtualMachineOperationSDK.buildDeleteVirtualMachineDiskCompletable(this.azure, instanceId);
+        completable.subscribe();
+
+        // verify
+        this.loggerAssert
+                .assertEqualsInOrder(Level.DEBUG, compĺetableMessage)
+                .assertEqualsInOrder(Level.INFO, Messages.Info.END_DELETE_DISK_ASYNC_BEHAVIOUR);
+    }
+
+    // test case: When calling the buildDeleteVirtualMachineDiskCompletable method and the completable executes
+    // with error, it must verify if It returns the right logs.
+    @Test
+    public void testBuildDeleteVirtualMachineDiskCompletableFail()
+            throws UnexpectedException, InstanceNotFoundException {
+
+        // set up
+        String instanceId = "instanceId";
+        Completable simpleCompletableFail = createSimpleCompletableFail();
+        mockDeleteVirtualMachineDiskCompletable(instanceId, simpleCompletableFail);
+
+        // exercise
+        Completable completable = this.azureVirtualMachineOperationSDK.buildDeleteVirtualMachineDiskCompletable(this.azure, instanceId);
+        completable.subscribe();
+
+        // verify
+        this.loggerAssert
+                .assertEqualsInOrder(Level.ERROR, Messages.Error.ERROR_DELETE_DISK_ASYNC_BEHAVIOUR);
+    }
+
+    // test case: When calling the buildDeleteVirtualMachineDiskCompletable method and throws a exception because
+    // it does not found the disk, it must verify if It throws a InstanceNotFoundException.
+    @Test
+    public void testBuildDeleteVirtualMachineDiskCompletableFailWhenNotFindDisk()
+            throws UnexpectedException, InstanceNotFoundException {
+
+        // set up
+        String instanceId = "instanceId";
+
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+        Optional<VirtualMachine> virtualMachineOptional = Optional.ofNullable(null);
+        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachine(Mockito.eq(this.azure), Mockito.eq(instanceId)))
+                .thenReturn(virtualMachineOptional);
+
+        // verify
+        this.expectedException.expect(InstanceNotFoundException.class);
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.buildDeleteVirtualMachineDiskCompletable(this.azure, instanceId);
+    }
+
+    // test case: When calling the buildDeleteVirtualMachineCompletable method and the completable executes
+    // without any error, it must verify if It returns the right logs.
+    @Test
+    public void testBuildDeleteVirtualMachineCompletableSuccessfully() {
+        // set up
+        String instanceId = "instanceId";
+        Completable virtualMachineCompletableSuccess = createSimpleCompletableSuccess();
+
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+        PowerMockito.when(AzureVirtualMachineSDK
+                .buildDeleteVirtualMachineCompletable(Mockito.eq(this.azure), Mockito.eq(instanceId)))
+                .thenReturn(virtualMachineCompletableSuccess);
+
+        // exercise
+        Completable completable = this.azureVirtualMachineOperationSDK
+                .buildDeleteVirtualMachineCompletable(this.azure, instanceId);
+        completable.subscribe();
+
+        // verify
+        this.loggerAssert
+                .assertEqualsInOrder(Level.INFO, Messages.Info.END_DELETE_VM_ASYNC_BEHAVIOUR);
+    }
+
+    // test case: When calling the buildDeleteVirtualMachineCompletable method and the completable executes
+    // without any error, it must verify if It returns the right logs.
+    @Test
+    public void testBuildDeleteVirtualMachineCompletableFail() {
+        // set up
+        String instanceId = "instanceId";
+
+        Completable virtualMachineCompletableFail = createSimpleCompletableFail();
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+        PowerMockito.when(AzureVirtualMachineSDK
+                .buildDeleteVirtualMachineCompletable(Mockito.eq(this.azure), Mockito.eq(instanceId)))
+                .thenReturn(virtualMachineCompletableFail);
+
+        // exercise
+        Completable completable = this.azureVirtualMachineOperationSDK
+                .buildDeleteVirtualMachineCompletable(this.azure, instanceId);
+        completable.subscribe();
+
+        // verify
+        this.loggerAssert
+                .assertEqualsInOrder(Level.ERROR, Messages.Error.ERROR_DELETE_VM_ASYNC_BEHAVIOUR);
+    }
+
 
     private PagedList<VirtualMachineSize> getVirtualMachineSizesMock() {
         return new PagedList<VirtualMachineSize>() {
@@ -212,6 +628,63 @@ public class AzureVirtualMachineOperationSDKTest {
                 return null;
             }
         };
+    }
+
+    private void mockGetAzureClient() throws UnauthenticatedUserException {
+        PowerMockito.mockStatic(AzureClientCacheManager.class);
+        PowerMockito.when(AzureClientCacheManager.getAzure(Mockito.eq(this.azureCloudUser)))
+                .thenReturn(azure);
+    }
+
+    private void mockGetAzureClientUnauthorized() throws UnauthenticatedUserException {
+        PowerMockito.mockStatic(AzureClientCacheManager.class);
+        PowerMockito.when(AzureClientCacheManager.getAzure(Mockito.eq(this.azureCloudUser)))
+                .thenThrow(new UnauthenticatedUserException());
+    }
+
+    private void makeTheObservablesSynchronous() {
+        // The scheduler trampolime makes the subscriptions execute in the current thread
+        this.azureVirtualMachineOperationSDK.setScheduler(Schedulers.trampoline());
+    }
+
+    private Completable createSimpleCompletableSuccess() {
+        return Completable.complete();
+    }
+
+    private Completable createSimpleCompletableSuccess(String message) {
+        return Completable.create((completableSubscriber) -> {
+            LOGGER_CLASS_MOCK.debug(message);
+            completableSubscriber.onCompleted();
+        });
+    }
+
+    private Completable createSimpleCompletableFail() {
+        return Completable.error(new RuntimeException());
+    }
+
+    private Completable createSimpleCompletableFail(String message) {
+        return Completable.create((completableSubscriber) -> {
+            LOGGER_CLASS_MOCK.debug(message);
+            completableSubscriber.onError(new RuntimeException());
+        });
+    }
+
+    private Observable<Indexable> createSimpleObservableSuccess() {
+        return Observable.defer(() -> {
+            Indexable indexable = Mockito.mock(Indexable.class);
+            return Observable.just(indexable);
+        });
+    }
+
+    private Observable<Indexable> createSimpleObservableFail() {
+        return Observable.defer(() -> {
+            throw new RuntimeException();
+        });
+    }
+
+    private VirtualMachineSize buildVirtualMachineSizeMock(int memory, int vcpu) {
+        String name = RandomStringUtils.randomAlphabetic(10);
+        return buildVirtualMachineSizeMock(memory, vcpu, name);
     }
 
     private VirtualMachineSize buildVirtualMachineSizeMock(String name) {
@@ -224,6 +697,29 @@ public class AzureVirtualMachineOperationSDKTest {
         Mockito.when(virtualMachineSize.numberOfCores()).thenReturn(vcpu);
         Mockito.when(virtualMachineSize.name()).thenReturn(name);
         return virtualMachineSize;
+    }
+
+    private void mockDeleteVirtualMachineDiskCompletable(String instanceId, Completable deleteDiskCompletable)
+            throws UnexpectedException {
+
+        VirtualMachine virtalMachine = Mockito.mock(VirtualMachine.class);
+        String osDiskId = "osDiskId";
+        Mockito.when(virtalMachine.osDiskId()).thenReturn(osDiskId);
+        Optional<VirtualMachine> virtualMachineOptional = Optional.ofNullable(virtalMachine);
+        PowerMockito.when(AzureVirtualMachineSDK
+                .getVirtualMachine(Mockito.eq(this.azure), Mockito.eq(instanceId)))
+                .thenReturn(virtualMachineOptional);
+
+        PowerMockito.mockStatic(AzureVolumeSDK.class);
+        PowerMockito.when(AzureVolumeSDK
+                .buildDeleteDiskCompletable(Mockito.eq(this.azure), Mockito.eq(osDiskId)))
+                .thenReturn(deleteDiskCompletable);
+    }
+
+    private void mockDeleteVirtualMachineCompletable(String instanceId, Completable deleteVMCompletable) {
+        PowerMockito.when(AzureVirtualMachineSDK.buildDeleteVirtualMachineCompletable(
+                Mockito.eq(this.azure), Mockito.eq(instanceId)))
+                .thenReturn(deleteVMCompletable);
     }
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineOperationSDKTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineOperationSDKTest.java
@@ -1,0 +1,229 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
+
+import cloud.fogbow.common.exceptions.InstanceNotFoundException;
+import cloud.fogbow.common.exceptions.NoAvailableResourcesException;
+import cloud.fogbow.common.exceptions.UnauthenticatedUserException;
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.AzureGetVirtualMachineRef;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureClientCacheManager;
+import com.microsoft.azure.Page;
+import com.microsoft.azure.PagedList;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.compute.VirtualMachine;
+import com.microsoft.azure.management.compute.VirtualMachineSize;
+import com.microsoft.azure.management.compute.VirtualMachineSizeTypes;
+import com.microsoft.azure.management.network.NetworkInterface;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import com.microsoft.rest.RestException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AzureClientCacheManager.class, AzureVirtualMachineSDK.class,})
+public class AzureVirtualMachineOperationSDKTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private AzureVirtualMachineOperationSDK azureVirtualMachineOperationSDK;
+    private AzureUser azureUser;
+    private Azure azure;
+
+    @Before
+    public void setUp() {
+        this.azureVirtualMachineOperationSDK =
+                Mockito.spy(new AzureVirtualMachineOperationSDK());
+        this.azureUser = Mockito.mock(AzureUser.class);
+        this.azure = null;
+
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+    }
+
+    // test case: When calling the doGetInstance method with methods mocked,
+    // it must verify if It returns the right AzureGetVirtualMachineRef.
+    @Test
+    public void testDoGetInstanceSuccessfully() throws NoAvailableResourcesException, UnexpectedException,
+            UnauthenticatedUserException, InstanceNotFoundException {
+
+        // set up
+        mockGetAzureClient();
+        String instanceId = "instanceId";
+
+        VirtualMachine virtualMachine = Mockito.mock(VirtualMachine.class);
+        VirtualMachineSizeTypes virtualMachineSizeTypes = VirtualMachineSizeTypes.BASIC_A0;
+        String virtualMachineSizeName = virtualMachineSizeTypes.toString();
+        Mockito.when(virtualMachine.size()).thenReturn(virtualMachineSizeTypes);
+        String cloudState = "cloudState";
+        Mockito.when(virtualMachine.provisioningState()).thenReturn(cloudState);
+        String name = "name";
+        Mockito.when(virtualMachine.name()).thenReturn(name);
+        NetworkInterface networkInterface = Mockito.mock(NetworkInterface.class);
+        String privateIp = "privateIp";
+        List<String> ipAddresses = Arrays.asList(privateIp);
+        Mockito.when(networkInterface.primaryPrivateIP()).thenReturn(privateIp);
+        Mockito.when(virtualMachine.getPrimaryNetworkInterface()).thenReturn(networkInterface);
+        int diskSize = 3;
+        Mockito.when(virtualMachine.osDiskSize()).thenReturn(diskSize);
+
+        String regionName = this.azureUser.getRegionName();
+
+        VirtualMachineSize virtualMachineSize = Mockito.mock(VirtualMachineSize.class);
+        int memory = 1;
+        Mockito.when(virtualMachineSize.memoryInMB()).thenReturn(memory);
+        Integer vCPU = 2;
+        Mockito.when(virtualMachineSize.numberOfCores()).thenReturn(vCPU);
+        Mockito.doReturn(virtualMachineSize).when(this.azureVirtualMachineOperationSDK)
+                .findVirtualMachineSizeByName(Mockito.eq(virtualMachineSizeName),
+                        Mockito.eq(regionName), Mockito.eq(this.azure));
+
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+        Optional<VirtualMachine> virtualMachineOptional = Optional.ofNullable(virtualMachine);
+        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachineById(
+                Mockito.eq(this.azure), Mockito.eq(instanceId)))
+                .thenReturn(virtualMachineOptional);
+
+        AzureGetVirtualMachineRef azureGetVirtualMachineRefExpected = AzureGetVirtualMachineRef.builder()
+                .cloudState(cloudState)
+                .ipAddresses(ipAddresses)
+                .disk(diskSize)
+                .memory(memory)
+                .name(name)
+                .vCPU(vCPU)
+                .build();
+
+        // exercise
+        AzureGetVirtualMachineRef azureGetVirtualMachineRef =
+                this.azureVirtualMachineOperationSDK.doGetInstance(instanceId, this.azureUser);
+
+        // verify
+        Assert.assertEquals(azureGetVirtualMachineRefExpected, azureGetVirtualMachineRef);
+    }
+
+    // test case: When calling the doGetInstance method with methods mocked and throw any exception,
+    // it must verify if It retrows the same exception.
+    @Test
+    public void testDoGetInstanceFailWhenThrowException()
+            throws UnauthenticatedUserException, UnexpectedException,
+            InstanceNotFoundException, NoAvailableResourcesException {
+
+        // set up
+        mockGetAzureClient();
+        String instanceId = "instanceId";
+
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachineById(
+                Mockito.eq(this.azure), Mockito.eq(instanceId)))
+                .thenThrow(new UnexpectedException());
+
+        // verify
+        this.expectedException.expect(UnexpectedException.class);
+
+        // exercise
+        this.azureVirtualMachineOperationSDK.doGetInstance(instanceId, this.azureUser);
+    }
+
+    // test case: When calling the findVirtualMachineSizeByName method and find one the virtual machine size,
+    // it must verify if It returns the right virtual machine size.
+    @Test
+    public void testFindVirtualMachineSizeByNameSuccessfully()
+            throws UnauthenticatedUserException, NoAvailableResourcesException, UnexpectedException {
+        // set up
+        mockGetAzureClient();
+        String virtualMachineSizeNameExpected = "nameExpected";
+
+        Region region = Region.US_EAST;
+        String regionName = region.name();
+        PagedList<VirtualMachineSize> virtualMachines = getVirtualMachineSizesMock();
+
+        VirtualMachineSize virtualMachineSizeNotMactchOne = buildVirtualMachineSizeMock("notmatch");
+        VirtualMachineSize virtualMachineSizeMatch = buildVirtualMachineSizeMock(virtualMachineSizeNameExpected);
+        VirtualMachineSize virtualMachineSizeNotMactchTwo = buildVirtualMachineSizeMock("notmatch");
+
+        virtualMachines.add(virtualMachineSizeNotMactchOne);
+        virtualMachines.add(virtualMachineSizeMatch);
+        virtualMachines.add(virtualMachineSizeNotMactchTwo);
+
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachineSizes(Mockito.eq(this.azure), Mockito.eq(region)))
+                .thenReturn(virtualMachines);
+
+        // exercise
+        VirtualMachineSize virtualMachineSize = this.azureVirtualMachineOperationSDK
+                .findVirtualMachineSizeByName(virtualMachineSizeNameExpected, regionName, this.azure);
+
+        // verify
+        Assert.assertEquals(virtualMachineSizeMatch.name(), virtualMachineSize.name());
+    }
+
+    // test case: When calling the findVirtualMachineSizeByName method and does not find the virtual machine size,
+    // it must verify if It throws a NoAvailableResourcesException exception.
+    @Test
+    public void testFindVirtualMachineSizeByNameFail()
+            throws UnauthenticatedUserException, NoAvailableResourcesException, UnexpectedException {
+        // set up
+        mockGetAzureClient();
+        String virtualMachineSizeNameExpected = "nameExpected";
+
+        Region region = Region.US_EAST;
+        String regionName = region.name();
+        PagedList<VirtualMachineSize> virtualMachines = getVirtualMachineSizesMock();
+
+        VirtualMachineSize virtualMachineSizeNotMactchOne = buildVirtualMachineSizeMock("notmatch");
+        VirtualMachineSize virtualMachineSizeNotMactchTwo = buildVirtualMachineSizeMock("notmatch");
+
+        virtualMachines.add(virtualMachineSizeNotMactchOne);
+        virtualMachines.add(virtualMachineSizeNotMactchTwo);
+
+        PowerMockito.mockStatic(AzureVirtualMachineSDK.class);
+        PowerMockito.when(AzureVirtualMachineSDK.getVirtualMachineSizes(Mockito.eq(this.azure), Mockito.eq(region)))
+                .thenReturn(virtualMachines);
+
+        // verify
+        this.expectedException.expect(NoAvailableResourcesException.class);
+
+        // exercise
+        this.azureVirtualMachineOperationSDK
+                .findVirtualMachineSizeByName(virtualMachineSizeNameExpected, regionName, this.azure);
+    }
+
+    private void mockGetAzureClient() throws UnauthenticatedUserException {
+        PowerMockito.mockStatic(AzureClientCacheManager.class);
+        PowerMockito.when(AzureClientCacheManager.getAzure(Mockito.eq(this.azureUser)))
+                .thenReturn(azure);
+    }
+
+    private PagedList<VirtualMachineSize> getVirtualMachineSizesMock() {
+        return new PagedList<VirtualMachineSize>() {
+            @Override
+            public Page<VirtualMachineSize> nextPage(String s) throws RestException {
+                return null;
+            }
+        };
+    }
+
+    private VirtualMachineSize buildVirtualMachineSizeMock(String name) {
+        return buildVirtualMachineSizeMock(0, 0, name);
+    }
+
+    private VirtualMachineSize buildVirtualMachineSizeMock(int memory, int vcpu, String name) {
+        VirtualMachineSize virtualMachineSize = Mockito.mock(VirtualMachineSize.class);
+        Mockito.when(virtualMachineSize.memoryInMB()).thenReturn(memory);
+        Mockito.when(virtualMachineSize.numberOfCores()).thenReturn(vcpu);
+        Mockito.when(virtualMachineSize.name()).thenReturn(name);
+        return virtualMachineSize;
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDKTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDKTest.java
@@ -7,7 +7,9 @@ import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.compute.VirtualMachineSize;
 import com.microsoft.azure.management.compute.VirtualMachineSizes;
 import com.microsoft.azure.management.compute.VirtualMachines;
+import com.microsoft.azure.management.network.NetworkInterface;
 import com.microsoft.azure.management.resources.fluentcore.arm.Region;
+import com.microsoft.azure.management.resources.fluentcore.model.Indexable;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,8 +19,10 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import rx.Observable;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({AzureVirtualMachineSDK.class})
@@ -27,10 +31,186 @@ public class AzureVirtualMachineSDKTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    // test case: When calling the getVirtualMachineById method and finds a virtual machine,
+    // test case: When calling the buildVirtualMachineObservable method with an image linux,
+    // it must verify if It returns the right observable.
+    @Test
+    public void testBuildVirtualMachineObservableSuccessfullyWhenLinx() throws Exception {
+        String imageReference = "linux";
+        String osUserName = "osUserName";
+        String osUserPassword = "osUserPassword";
+        String osComputeName = "osComputeName";
+        Function<VirtualMachine.DefinitionStages.WithOS, VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged>
+                linuxMock = (withExistingPrimaryNetworkInterface) -> {
+
+            VirtualMachine.DefinitionStages.WithLinuxRootUsernameManagedOrUnmanaged withLatestLinuxImage =
+                    Mockito.mock(VirtualMachine.DefinitionStages.WithLinuxRootUsernameManagedOrUnmanaged.class);
+            Mockito.when(withExistingPrimaryNetworkInterface.withLatestLinuxImage(
+                    Mockito.eq(imageReference), Mockito.eq(imageReference), Mockito.eq(imageReference)))
+                    .thenReturn(withLatestLinuxImage);
+
+            VirtualMachine.DefinitionStages.WithLinuxRootPasswordOrPublicKeyManagedOrUnmanaged withRootUsername =
+                    Mockito.mock(VirtualMachine.DefinitionStages.WithLinuxRootPasswordOrPublicKeyManagedOrUnmanaged.class);
+            Mockito.when(withLatestLinuxImage.withRootUsername(Mockito.eq(osUserName)))
+                    .thenReturn(withRootUsername);
+
+            VirtualMachine.DefinitionStages.WithLinuxCreateManagedOrUnmanaged withRootPassword =
+                    Mockito.mock(VirtualMachine.DefinitionStages.WithLinuxCreateManagedOrUnmanaged.class);
+            Mockito.when(withRootUsername.withRootPassword(Mockito.eq(osUserPassword)))
+                    .thenReturn(withRootPassword);
+
+            VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged withComputerName =
+                    Mockito.mock(VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged.class);
+            Mockito.when(withRootPassword.withComputerName(osComputeName)).thenReturn(withComputerName);
+
+            return withComputerName;
+        };
+
+        checkBuildVirtualMachineObservable(imageReference , osUserName, osUserPassword, osComputeName, linuxMock);
+    }
+
+
+    // test case: When calling the buildVirtualMachineObservable method with an image windows,
+    // it must verify if It returns the right observable.
+    @Test
+    public void testBuildVirtualMachineObservableSuccessfullyWhenWindows() throws Exception {
+        String imageReference = "windows";
+        String osUserName = "osUserName";
+        String osUserPassword = "osUserPassword";
+        String osComputeName = "osComputeName";
+        Function<VirtualMachine.DefinitionStages.WithOS, VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged>
+                windowsMock = (withExistingPrimaryNetworkInterface) -> {
+
+            VirtualMachine.DefinitionStages.WithWindowsAdminUsernameManagedOrUnmanaged withLatestWindowsImage =
+                    Mockito.mock(VirtualMachine.DefinitionStages.WithWindowsAdminUsernameManagedOrUnmanaged.class);
+            Mockito.when(withExistingPrimaryNetworkInterface.withLatestWindowsImage(
+                    Mockito.eq(imageReference), Mockito.eq(imageReference), Mockito.eq(imageReference)))
+                    .thenReturn(withLatestWindowsImage);
+
+            VirtualMachine.DefinitionStages.WithWindowsAdminPasswordManagedOrUnmanaged withAdminUsername =
+                    Mockito.mock(VirtualMachine.DefinitionStages.WithWindowsAdminPasswordManagedOrUnmanaged.class);
+            Mockito.when(withLatestWindowsImage.withAdminUsername(Mockito.eq(osUserName)))
+                    .thenReturn(withAdminUsername);
+
+            VirtualMachine.DefinitionStages.WithWindowsCreateManagedOrUnmanaged withAdminPassword =
+                    Mockito.mock(VirtualMachine.DefinitionStages.WithWindowsCreateManagedOrUnmanaged.class);
+            Mockito.when(withAdminUsername.withAdminPassword(Mockito.eq(osUserPassword)))
+                    .thenReturn(withAdminPassword);
+
+            VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged withComputerName =
+                    Mockito.mock(VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged.class);
+            Mockito.when(withAdminPassword.withComputerName(osComputeName)).thenReturn(withComputerName);
+            return withComputerName;
+        };
+
+        checkBuildVirtualMachineObservable(imageReference , osUserName, osUserPassword, osComputeName, windowsMock);
+    }
+
+    // test case: When calling the constainsWindownsOn method and imagesku has the windows in the text,
+    // it must verify if It returns true.
+    @Test
+    public void testTsWindowsImageSuccessfullyWhenImageSkuHasWindows() {
+        // set up
+        String imageSku = "windows";
+        String imageOffer = "System";
+
+        // exercise
+        boolean isWindows = AzureVirtualMachineSDK.isWindowsImage(imageOffer, imageSku);
+        // verify
+        Assert.assertTrue(isWindows);
+    }
+
+    // test case: When calling the constainsWindownsOn method and imageoffer has the windows in the text,
+    // it must verify if It returns true.
+    @Test
+    public void testIsWindowsImageSuccessfullyWhenImageOfferHasWindows() {
+        // set up
+        String imageSku = "10.20";
+        String imageOffer = "windows";
+
+        // exercise
+        boolean isWindows = AzureVirtualMachineSDK.isWindowsImage(imageOffer, imageSku);
+        // verify
+        Assert.assertTrue(isWindows);
+    }
+
+    // test case: When calling the constainsWindownsOn method and neither sku or offer has the
+    // windows in the text, it must verify if It returns false.
+    @Test
+    public void testIsWindowsImageSuccessfullyWhenItIsNotWindows() {
+        // set up
+        String imageSku = "linux";
+        String imageOffer = "system";
+
+        // exercise
+        boolean isWindows = AzureVirtualMachineSDK.isWindowsImage(imageOffer, imageSku);
+        // verify
+        Assert.assertFalse(isWindows);
+    }
+
+    // test case: When calling the constainsWindownsOn method and it contains windows lower case,
+    // it must verify if It returns true.
+    @Test
+    public void testConstainsWindownsOnSuccessfullyWhenContainsLowerCase() {
+        // set up
+        String text = "windows";
+        // exercise
+        boolean containsWindows = AzureVirtualMachineSDK.constainsWindownsOn(text);
+        // verify
+        Assert.assertTrue(containsWindows);
+    }
+
+    // test case: When calling the constainsWindownsOn method and it contains windows upper case,
+    // it must verify if It returns true.
+    @Test
+    public void testConstainsWindownsOnSuccessfullyWhenContainsUpperCase() {
+        // set up
+        String text = "WINDOWS";
+        // exercise
+        boolean containsWindows = AzureVirtualMachineSDK.constainsWindownsOn(text);
+        // verify
+        Assert.assertTrue(containsWindows);
+    }
+
+    // test case: When calling the constainsWindownsOn method and it contains windows in a long text,
+    // it must verify if It returns true.
+    @Test
+    public void testConstainsWindownsOnSuccessfullyWhenContainsLongText() {
+        // set up
+        String text = "abc - windows WINDOWS  1204.65.78.9.8.7.86 _()}Ç:,vm";
+        // exercise
+        boolean containsWindows = AzureVirtualMachineSDK.constainsWindownsOn(text);
+        // verify
+        Assert.assertTrue(containsWindows);
+    }
+
+    // test case: When calling the constainsWindownsOn method and it does not contains windows,
+    // it must verify if It returns false.
+    @Test
+    public void testConstainsWindownsOnSuccessfullyWhenNotContains() {
+        // set up
+        String text = "linux-v2";
+        // exercise
+        boolean containsWindows = AzureVirtualMachineSDK.constainsWindownsOn(text);
+        // verify
+        Assert.assertFalse(containsWindows);
+    }
+
+    // test case: When calling the constainsWindownsOn method and it does not contains windows but
+    // the text is similar, it must verify if It returns false.
+    @Test
+    public void testConstainsWindownsOnSuccessfullyWhenNotContainsWitSimilarText() {
+        // set up
+        String text = "linux-wind.wos-WINDOW-S";
+        // exercise
+        boolean containsWindows = AzureVirtualMachineSDK.constainsWindownsOn(text);
+        // verify
+        Assert.assertFalse(containsWindows);
+    }
+
+    // test case: When calling the getVirtualMachine method and finds a virtual machine,
     // it must verify if It returns a Optional with a virtual machine.
     @Test
-    public void testGetVirtualMachineByIdSuccessfullyWhenFindVirtualMachine() throws Exception {
+    public void testGetVirtualMachineSuccessfullyWhenFindVirtualMachine() throws Exception {
         // set up
         Azure azure = null;
         String virtualMachineId = "virtualMachineId";
@@ -40,21 +220,21 @@ public class AzureVirtualMachineSDKTest {
                 .thenReturn(virtualMachine);
         PowerMockito.spy(AzureVirtualMachineSDK.class);
         PowerMockito.doReturn(virtualMachineObject)
-                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesObject", Mockito.eq(azure));
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesSDK", Mockito.eq(azure));
 
         // exercise
         Optional<VirtualMachine> virtualMachineOptional =
-                AzureVirtualMachineSDK.getVirtualMachineById(azure, virtualMachineId);
+                AzureVirtualMachineSDK.getVirtualMachine(azure, virtualMachineId);
 
         // verify
         Assert.assertTrue(virtualMachineOptional.isPresent());
         Assert.assertEquals(virtualMachine, virtualMachineOptional.get());
     }
 
-    // test case: When calling the getVirtualMachineById method and do not find a virtual machine,
+    // test case: When calling the getVirtualMachine method and do not find a virtual machine,
     // it must verify if It returns a Optional with a virtual machine.
     @Test
-    public void testGetVirtualMachineByIdSuccessfullyWhenNotFindVirtualMachine() throws Exception {
+    public void testGetVirtualMachineSuccessfullyWhenNotFindVirtualMachine() throws Exception {
         // set up
         Azure azure = null;
         String virtualMachineId = "virtualMachineId";
@@ -64,34 +244,34 @@ public class AzureVirtualMachineSDKTest {
                 .thenReturn(virtualMachineNull);
         PowerMockito.spy(AzureVirtualMachineSDK.class);
         PowerMockito.doReturn(virtualMachineObject)
-                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesObject", Mockito.eq(azure));
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesSDK", Mockito.eq(azure));
 
         // exercise
         Optional<VirtualMachine> virtualMachineOptional =
-                AzureVirtualMachineSDK.getVirtualMachineById(azure, virtualMachineId);
+                AzureVirtualMachineSDK.getVirtualMachine(azure, virtualMachineId);
 
         // verify
         Assert.assertFalse(virtualMachineOptional.isPresent());
     }
 
-    // test case: When calling the getVirtualMachineById method and throws any exception,
+    // test case: When calling the getVirtualMachine method and throws any exception,
     // it must verify if It throws an UnexpectedException.
     @Test
-    public void testGetVirtualMachineByIdFail() throws Exception {
+    public void testGetVirtualMachineFail() throws Exception {
         // set up
         Azure azure = null;
         String virtualMachineId = "virtualMachineId";
         String errorMessage = "error";
         PowerMockito.spy(AzureVirtualMachineSDK.class);
         PowerMockito.doThrow(new RuntimeException(errorMessage))
-                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesObject", Mockito.eq(azure));
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesSDK", Mockito.eq(azure));
 
         // verify
         this.expectedException.expect(UnexpectedException.class);
         this.expectedException.expectMessage(errorMessage);
 
         // exercise
-        AzureVirtualMachineSDK.getVirtualMachineById(azure, virtualMachineId);
+        AzureVirtualMachineSDK.getVirtualMachine(azure, virtualMachineId);
     }
 
     // test case: When calling the getVirtualMachineSizes method,
@@ -109,7 +289,7 @@ public class AzureVirtualMachineSDKTest {
         Mockito.when(sizes.listByRegion(Mockito.eq(region))).thenReturn(virtualMachineSizeExpected);
         Mockito.when(virtualMachineObject.sizes()).thenReturn(sizes);
         PowerMockito.doReturn(virtualMachineObject)
-                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesObject", Mockito.eq(azure));
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesSDK", Mockito.eq(azure));
 
         // exercise
         PagedList<VirtualMachineSize> virtualMachineSizes =
@@ -130,7 +310,7 @@ public class AzureVirtualMachineSDKTest {
         String errorMessage = "error";
         PowerMockito.spy(AzureVirtualMachineSDK.class);
         PowerMockito.doThrow(new RuntimeException(errorMessage))
-                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesObject", Mockito.eq(azure));
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesSDK", Mockito.eq(azure));
 
         // verify
         this.expectedException.expect(UnexpectedException.class);
@@ -138,7 +318,75 @@ public class AzureVirtualMachineSDKTest {
 
         // exercise
         AzureVirtualMachineSDK.getVirtualMachineSizes(azure, region);
-
     }
+
+    private void checkBuildVirtualMachineObservable(String imageReference, String osUserName, String osUserPassword, String osComputeName,
+                                                    Function<VirtualMachine.DefinitionStages.WithOS, VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged> function)
+            throws Exception {
+
+        // verify
+        Azure azure = null;
+        String virtualMachineName = "virtualMachineName";
+        Region region = Region.US_EAST;
+        String resourceGroupName = "resourceGroupName";
+        NetworkInterface networkInterface = Mockito.mock(NetworkInterface.class);
+        String imagePublished = imageReference;
+        String imageSku = imageReference;
+        String imageOffer = imageReference;
+        String userData = "userData";
+        int diskSize = 1;
+        String size = "size";
+
+        PowerMockito.spy(AzureVirtualMachineSDK.class);
+
+        VirtualMachines virtualMachine = Mockito.mock(VirtualMachines.class);
+
+        VirtualMachine.DefinitionStages.Blank define = Mockito.mock(VirtualMachine.DefinitionStages.Blank.class);
+        Mockito.when(virtualMachine.define(Mockito.eq(virtualMachineName))).thenReturn(define);
+
+        VirtualMachine.DefinitionStages.WithGroup withRegion = Mockito.mock(VirtualMachine.DefinitionStages.WithGroup.class);
+        Mockito.when(define.withRegion(Mockito.eq(region))).thenReturn(withRegion);
+
+        VirtualMachine.DefinitionStages.WithNetwork withExistingResourceGroup
+                = Mockito.mock(VirtualMachine.DefinitionStages.WithNetwork.class);
+        Mockito.when(withRegion.withExistingResourceGroup(Mockito.eq(resourceGroupName))).thenReturn(withExistingResourceGroup);
+
+        VirtualMachine.DefinitionStages.WithOS withExistingPrimaryNetworkInterface
+                = Mockito.mock(VirtualMachine.DefinitionStages.WithOS.class);
+        Mockito.when(withExistingResourceGroup.withExistingPrimaryNetworkInterface(Mockito.eq(networkInterface)))
+                .thenReturn(withExistingPrimaryNetworkInterface);
+
+        VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged withComputerName
+                = function.apply(withExistingPrimaryNetworkInterface);
+
+        VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged withCustomData
+                = Mockito.mock(VirtualMachine.DefinitionStages.WithFromImageCreateOptionsManaged.class);
+        Mockito.when(withComputerName.withCustomData(Mockito.eq(userData)))
+                .thenReturn(withCustomData);
+
+        VirtualMachine.DefinitionStages.WithCreate withOSDiskSizeInGB
+                = Mockito.mock(VirtualMachine.DefinitionStages.WithCreate.class);
+        Mockito.when(withCustomData.withOSDiskSizeInGB(diskSize)).thenReturn(withOSDiskSizeInGB);
+
+        VirtualMachine.DefinitionStages.WithCreate withSize
+                = Mockito.mock(VirtualMachine.DefinitionStages.WithCreate.class);
+        Mockito.when(withOSDiskSizeInGB.withSize(size)).thenReturn(withSize);
+
+        Observable<Indexable> observableExpected = Mockito.mock(Observable.class);
+        Mockito.when(withSize.createAsync()).thenReturn(observableExpected);
+
+        PowerMockito.doReturn(virtualMachine)
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesSDK", Mockito.eq(azure));
+
+        // exercise
+        Observable<Indexable> observable = AzureVirtualMachineSDK.buildVirtualMachineObservable(
+                azure, virtualMachineName, region, resourceGroupName, networkInterface,
+                imagePublished, imageOffer, imageSku, osUserName, osUserPassword,
+                osComputeName, userData, diskSize, size);
+
+        // verify
+        Assert.assertEquals(observableExpected, observable);
+    }
+
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDKTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDKTest.java
@@ -1,9 +1,13 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
 
 import cloud.fogbow.common.exceptions.UnexpectedException;
+import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.VirtualMachine;
+import com.microsoft.azure.management.compute.VirtualMachineSize;
+import com.microsoft.azure.management.compute.VirtualMachineSizes;
 import com.microsoft.azure.management.compute.VirtualMachines;
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -88,6 +92,53 @@ public class AzureVirtualMachineSDKTest {
 
         // exercise
         AzureVirtualMachineSDK.getVirtualMachineById(azure, virtualMachineId);
+    }
+
+    // test case: When calling the getVirtualMachineSizes method,
+    // it must verify if It returns a list of virtual machine sizes.
+    @Test
+    public void testGetVirtualMachineSizesSuccessfully() throws Exception {
+        // set up
+        Azure azure = null;
+        Region region = Region.US_EAST;
+
+        VirtualMachines virtualMachineObject = Mockito.mock(VirtualMachines.class);
+        PowerMockito.spy(AzureVirtualMachineSDK.class);
+        VirtualMachineSizes sizes = Mockito.mock(VirtualMachineSizes.class);
+        PagedList<VirtualMachineSize> virtualMachineSizeExpected = Mockito.mock(PagedList.class);
+        Mockito.when(sizes.listByRegion(Mockito.eq(region))).thenReturn(virtualMachineSizeExpected);
+        Mockito.when(virtualMachineObject.sizes()).thenReturn(sizes);
+        PowerMockito.doReturn(virtualMachineObject)
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesObject", Mockito.eq(azure));
+
+        // exercise
+        PagedList<VirtualMachineSize> virtualMachineSizes =
+                AzureVirtualMachineSDK.getVirtualMachineSizes(azure, region);
+
+        // verify
+        Assert.assertEquals(virtualMachineSizeExpected, virtualMachineSizes);
+    }
+
+    // test case: When calling the getVirtualMachineSizes method ant throws an exception,
+    // it must verify if It throws a UnexpectedException.
+    @Test
+    public void testGetVirtualMachineSizesFail() throws Exception {
+        // set up
+        Azure azure = null;
+        Region region = Region.US_EAST;
+
+        String errorMessage = "error";
+        PowerMockito.spy(AzureVirtualMachineSDK.class);
+        PowerMockito.doThrow(new RuntimeException(errorMessage))
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesObject", Mockito.eq(azure));
+
+        // verify
+        this.expectedException.expect(UnexpectedException.class);
+        this.expectedException.expectMessage(errorMessage);
+
+        // exercise
+        AzureVirtualMachineSDK.getVirtualMachineSizes(azure, region);
+
     }
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDKTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDKTest.java
@@ -1,0 +1,93 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk;
+
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.compute.VirtualMachine;
+import com.microsoft.azure.management.compute.VirtualMachines;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Optional;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AzureVirtualMachineSDK.class})
+public class AzureVirtualMachineSDKTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the getVirtualMachineById method and finds a virtual machine,
+    // it must verify if It returns a Optional with a virtual machine.
+    @Test
+    public void testGetVirtualMachineByIdSuccessfullyWhenFindVirtualMachine() throws Exception {
+        // set up
+        Azure azure = null;
+        String virtualMachineId = "virtualMachineId";
+        VirtualMachines virtualMachineObject = Mockito.mock(VirtualMachines.class);
+        VirtualMachine virtualMachine = Mockito.mock(VirtualMachine.class);
+        Mockito.when(virtualMachineObject.getById(Mockito.eq(virtualMachineId)))
+                .thenReturn(virtualMachine);
+        PowerMockito.spy(AzureVirtualMachineSDK.class);
+        PowerMockito.doReturn(virtualMachineObject)
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesObject", Mockito.eq(azure));
+
+        // exercise
+        Optional<VirtualMachine> virtualMachineOptional =
+                AzureVirtualMachineSDK.getVirtualMachineById(azure, virtualMachineId);
+
+        // verify
+        Assert.assertTrue(virtualMachineOptional.isPresent());
+        Assert.assertEquals(virtualMachine, virtualMachineOptional.get());
+    }
+
+    // test case: When calling the getVirtualMachineById method and do not find a virtual machine,
+    // it must verify if It returns a Optional with a virtual machine.
+    @Test
+    public void testGetVirtualMachineByIdSuccessfullyWhenNotFindVirtualMachine() throws Exception {
+        // set up
+        Azure azure = null;
+        String virtualMachineId = "virtualMachineId";
+        VirtualMachines virtualMachineObject = Mockito.mock(VirtualMachines.class);
+        VirtualMachine virtualMachineNull = null;
+        Mockito.when(virtualMachineObject.getById(Mockito.eq(virtualMachineId)))
+                .thenReturn(virtualMachineNull);
+        PowerMockito.spy(AzureVirtualMachineSDK.class);
+        PowerMockito.doReturn(virtualMachineObject)
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesObject", Mockito.eq(azure));
+
+        // exercise
+        Optional<VirtualMachine> virtualMachineOptional =
+                AzureVirtualMachineSDK.getVirtualMachineById(azure, virtualMachineId);
+
+        // verify
+        Assert.assertFalse(virtualMachineOptional.isPresent());
+    }
+
+    // test case: When calling the getVirtualMachineById method and throws any exception,
+    // it must verify if It throws an UnexpectedException.
+    @Test
+    public void testGetVirtualMachineByIdFail() throws Exception {
+        // set up
+        Azure azure = null;
+        String virtualMachineId = "virtualMachineId";
+        String errorMessage = "error";
+        PowerMockito.spy(AzureVirtualMachineSDK.class);
+        PowerMockito.doThrow(new RuntimeException(errorMessage))
+                .when(AzureVirtualMachineSDK.class, "getVirtualMachinesObject", Mockito.eq(azure));
+
+        // verify
+        this.expectedException.expect(UnexpectedException.class);
+        this.expectedException.expectMessage(errorMessage);
+
+        // exercise
+        AzureVirtualMachineSDK.getVirtualMachineById(azure, virtualMachineId);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/network/sdk/AzureNetworkSDKTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/network/sdk/AzureNetworkSDKTest.java
@@ -1,0 +1,92 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.network.sdk;
+
+import cloud.fogbow.common.exceptions.UnexpectedException;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.network.NetworkInterface;
+import com.microsoft.azure.management.network.NetworkInterfaces;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Optional;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AzureNetworkSDK.class})
+public class AzureNetworkSDKTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the getNetworkInterface method and finds a network interface,
+    // it must verify if It returns a Optional with a network interface.
+    @Test
+    public void testGetNetworkInterfaceSuccessfullyWhenFindNetworkInterface() throws Exception {
+        // set up
+        Azure azure = null;
+        String networkInterfaceId = "networkInterfaceId";
+        NetworkInterfaces networkInterfacesObject = Mockito.mock(NetworkInterfaces.class);
+        NetworkInterface networkInterfaceExpected = Mockito.mock(NetworkInterface.class);
+        Mockito.when(networkInterfacesObject.getById(Mockito.eq(networkInterfaceId)))
+                .thenReturn(networkInterfaceExpected);
+        PowerMockito.spy(AzureNetworkSDK.class);
+        PowerMockito.doReturn(networkInterfacesObject)
+                .when(AzureNetworkSDK.class, "getNetworkInterfacesSDK", Mockito.eq(azure));
+
+        // exercise
+        Optional<NetworkInterface> networkInterface =
+                AzureNetworkSDK.getNetworkInterface(azure, networkInterfaceId);
+
+        // verify
+        Assert.assertTrue(networkInterface.isPresent());
+        Assert.assertEquals(networkInterfaceExpected, networkInterface.get());
+    }
+
+    // test case: When calling the getNetworkInterface method and do not find a network interface,
+    // it must verify if It returns a Optional without a network interface.
+    @Test
+    public void testGetNetworkInterfaceSuccessfullyWhenNotFindNetworkInterface() throws Exception {
+        // set up
+        Azure azure = null;
+        String networkInterfaceId = "networkInterfaceId";
+        NetworkInterfaces networkInterfacesObject = Mockito.mock(NetworkInterfaces.class);
+        NetworkInterface networkInterfaceExpected = null;
+        Mockito.when(networkInterfacesObject.getById(Mockito.eq(networkInterfaceId)))
+                .thenReturn(networkInterfaceExpected);
+        PowerMockito.spy(AzureNetworkSDK.class);
+        PowerMockito.doReturn(networkInterfacesObject)
+                .when(AzureNetworkSDK.class, "getNetworkInterfacesSDK", Mockito.eq(azure));
+
+        // exercise
+        Optional<NetworkInterface> networkInterface = AzureNetworkSDK.getNetworkInterface(azure, networkInterfaceId);
+
+        // verify
+        Assert.assertFalse(networkInterface.isPresent());
+    }
+
+    // test case: When calling the getNetworkInterface method and throws any exception,
+    // it must verify if It throws an UnexpectedException.
+    @Test
+    public void testGetNetworkInterfacesFail() throws Exception {
+        // set up
+        Azure azure = null;
+        String networkInterfaceId = "networkInterfaceId";
+        PowerMockito.spy(AzureNetworkSDK.class);
+        String errorMessage = "error";
+        PowerMockito.doThrow(new RuntimeException(errorMessage))
+                .when(AzureNetworkSDK.class, "getNetworkInterfacesSDK", Mockito.eq(azure));
+
+        // verify
+        this.expectedException.expect(UnexpectedException.class);
+        this.expectedException.expectMessage(errorMessage);
+
+        // exercise
+        AzureNetworkSDK.getNetworkInterface(azure, networkInterfaceId);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureClientCacheManagerTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureClientCacheManagerTest.java
@@ -29,7 +29,7 @@ public class AzureClientCacheManagerTest {
 
     @Before
     public void setUp() {
-        this.azureUser = AzureTestUtils.createAzureCloudUser();
+        this.azureUser = AzureTestUtils.createAzureUser();
     }
 
     // test case: When calling the getAzure method and throws an exception,

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureClientCacheManagerTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureClientCacheManagerTest.java
@@ -1,0 +1,102 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.exceptions.UnauthenticatedUserException;
+import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.core.TestUtils;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.AzureTestUtils;
+import com.microsoft.azure.AzureEnvironment;
+import com.microsoft.azure.credentials.AzureTokenCredentials;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AzureClientCacheManager.class})
+public class AzureClientCacheManagerTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    private AzureUser azureUser;
+
+    @Before
+    public void setUp() {
+        this.azureUser = AzureTestUtils.createAzureCloudUser();
+    }
+
+    // test case: When calling the getAzure method and throws an exception,
+    // it must verify if It throws an UnauthenticatedUserException.
+    @Test
+    public void testGetAzureFail() throws Exception {
+        // set up
+        PowerMockito.spy(AzureClientCacheManager.class);
+
+        PowerMockito.doThrow(new FogbowException())
+                .when(AzureClientCacheManager.class, "createAzure", Mockito.eq(this.azureUser));
+
+        // verify
+        this.expectedException.expect(UnauthenticatedUserException.class);
+
+        // exercise
+        AzureClientCacheManager.getAzure(this.azureUser);
+    }
+
+    // test case: When calling the createAzure method and occurs any error,
+    // it must verify if It throws a FogbowException.
+    @Test
+    public void testCreateAzure() throws FogbowException {
+
+        AzureUser azureUserUnauthorized = new AzureUser(null, null, null,
+                null, null, null, null, null);
+
+        // verify
+        this.expectedException.expect(FogbowException.class);
+
+        // exercise
+        AzureClientCacheManager.createAzure(azureUserUnauthorized);
+    }
+
+    // test case: When calling the buildAzureTokenCredentials method,
+    // it must verify if It creates a right AzureTokenCredentials.
+    @Test
+    public void testBuildAzureTokenCredentialsSuccessfully() {
+        // set up
+        PowerMockito.spy(AzureClientCacheManager.class);
+
+        String clientId = this.azureUser.getClientId();
+        String tenantId = this.azureUser.getTenantId();
+        String clientKey = this.azureUser.getClientKey();
+        String subscriptionId = this.azureUser.getSubscriptionId();
+
+        final String managementEndpoint = AzureEnvironment.AZURE.managementEndpoint();
+        final String activeDirectoryEndpoint = AzureEnvironment.AZURE.activeDirectoryEndpoint();
+        final String resourceManagerEndpoint = AzureEnvironment.AZURE.resourceManagerEndpoint();
+        final String graphEndpoint = AzureEnvironment.AZURE.graphEndpoint();
+        final String keyVaultDnsSuffix = AzureEnvironment.AZURE.keyVaultDnsSuffix();
+
+        // exercise
+        AzureTokenCredentials azureTokenCredentials =
+                AzureClientCacheManager.buildAzureTokenCredentials(this.azureUser);
+
+        // verify
+        AzureEnvironment environment = azureTokenCredentials.environment();
+        Assert.assertEquals(subscriptionId, azureTokenCredentials.defaultSubscriptionId());
+        Assert.assertEquals(graphEndpoint, environment.graphEndpoint());
+        Assert.assertEquals(managementEndpoint, environment.managementEndpoint());
+        Assert.assertEquals(activeDirectoryEndpoint, environment.activeDirectoryEndpoint());
+        Assert.assertEquals(resourceManagerEndpoint, environment.resourceManagerEndpoint());
+        Assert.assertEquals(keyVaultDnsSuffix, environment.keyVaultDnsSuffix());
+        PowerMockito.verifyStatic(AzureClientCacheManager.class, VerificationModeFactory.times(TestUtils.RUN_ONCE));
+        AzureClientCacheManager.getApplicationTokenCredentials(Mockito.eq(clientId),
+                Mockito.eq(tenantId), Mockito.eq(clientKey), Mockito.any());
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureGeneralPolicyTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureGeneralPolicyTest.java
@@ -1,0 +1,70 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.ras.constants.Messages;
+import cloud.fogbow.ras.core.models.orders.ComputeOrder;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import java.util.regex.Pattern;
+
+public class AzureGeneralPolicyTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the getDisk method with disk value valid in the compute order,
+    // it must verify if it returns the disk value.
+    @Test
+    public void testGetDiskSuccessfully() throws InvalidParameterException {
+        // set up
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+        int diskExpected = AzureGeneralPolicy.MINIMUM_DISK;
+        Mockito.when(computeOrder.getDisk()).thenReturn(diskExpected);
+
+        // exercise
+        int disk = AzureGeneralPolicy.getDisk(computeOrder);
+
+        // verify
+        Assert.assertEquals(diskExpected, disk);
+    }
+
+    // test case: When calling the getDisk method with disk value invalid in the compute order,
+    // it must verify if it throws an InvalidParameterException.
+    @Test
+    public void testGetDiskFail() throws InvalidParameterException {
+        // set up
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+        int diskInvalid = AzureGeneralPolicy.MINIMUM_DISK - 1;
+        Mockito.when(computeOrder.getDisk()).thenReturn(diskInvalid);
+
+        // verify
+        this.expectedException.expect(InvalidParameterException.class);
+        this.expectedException.expectMessage(String.format(
+                Messages.Error.ERROR_DISK_PARAMETER_AZURE_POLICY, AzureGeneralPolicy.MINIMUM_DISK));
+
+        // exercise
+        AzureGeneralPolicy.getDisk(computeOrder);
+    }
+
+    // test case: When calling the generatePassword method , it must verify if it
+    // returns a value as specified.
+    @Test
+    public void testGeneratePasswordSuccessfully() {
+        // set up
+        String regex = "(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{1,})%s([a-z]|[A-Z]|[0-9])*";
+        regex = String.format(regex, AzureGeneralPolicy.PASSWORD_PREFIX);
+        Pattern pattern = Pattern.compile(regex);
+
+        // exercise
+        String password = AzureGeneralPolicy.generatePassword();
+
+        // verify
+        Assert.assertTrue(pattern.matcher(password).matches());
+    }
+
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureIdBuilderTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureIdBuilderTest.java
@@ -1,18 +1,46 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
 
+import cloud.fogbow.common.exceptions.InvalidParameterException;
 import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.constants.Messages;
+import cloud.fogbow.ras.core.models.orders.Order;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.AzureTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class AzureIdBuilderTest {
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
     private AzureUser azureUser;
 
     @Before
     public void setUp() {
         this.azureUser = AzureTestUtils.createAzureUser();
+    }
+
+    // test case: When calling the buildNetworkInterfaceId method,
+    // it must verify if It return the right network interface id.
+    @Test
+    public void testBuildNetworkInterfaceIdSuccessfully() {
+        // set up
+        String networkInterfaceName = "networkInterfaceName";
+
+        String networkInterfaceIdExpected = String.format(AzureIdBuilder.NETWORK_INTERFACE_STRUCTURE,
+                this.azureUser.getSubscriptionId(),
+                this.azureUser.getResourceGroupName(),
+                networkInterfaceName);
+
+        // exercise
+        String networkInterfaceId = AzureIdBuilder
+                .configure(this.azureUser)
+                .buildNetworkInterfaceId(networkInterfaceName);
+
+        // verify
+        Assert.assertEquals(networkInterfaceIdExpected, networkInterfaceId);
     }
 
     // test case: When calling the buildVirtualMachineId method, it must verify if
@@ -35,5 +63,59 @@ public class AzureIdBuilderTest {
         // verify
         Assert.assertEquals(virtualMachineIdExpected, networkInterfaceId);
     }
+
+    // test case: When calling the checkIdSizePolicy method with resourceName within the limit,
+    // it must verify if It does not throw an InvalidParameterException.
+    @Test
+    public void testCheckIdSizePolicySuccessfully() throws InvalidParameterException {
+        // set up
+        int whatLeftToTotalLimit = getWhatLeftToTotalLimit();
+        String resourceNameInTheLimit = String.valueOf(new char[whatLeftToTotalLimit]);
+
+        String idInTheLimitSize = AzureIdBuilder
+                .configure(this.azureUser)
+                .buildNetworkInterfaceId(resourceNameInTheLimit);
+
+        // exercise
+        AzureIdBuilder
+                .configure(this.azureUser)
+                .checkIdSizePolicy(resourceNameInTheLimit);
+
+        // verify
+        Assert.assertEquals(Order.FIELDS_MAX_SIZE, idInTheLimitSize.length());
+    }
+
+    // test case: When calling the checkIdSizePolicy method with resourceName out of the limit,
+    // it must verify if It throws an InvalidParameterException.
+    @Test
+    public void testCheckIdSizePolicyFail() throws InvalidParameterException {
+        // set up
+        int whatLeftToTotalLimit = getWhatLeftToTotalLimit();
+        int outOfLimit = 1;
+        String resourceNameInTheLimit = String.valueOf(new char[whatLeftToTotalLimit + outOfLimit]);
+
+        String idInTheLimitSize = AzureIdBuilder
+                .configure(this.azureUser)
+                .buildNetworkInterfaceId(resourceNameInTheLimit);
+
+        // verify
+        Assert.assertEquals(Order.FIELDS_MAX_SIZE + outOfLimit, idInTheLimitSize.length());
+        this.expectedException.expect(InvalidParameterException.class);
+        this.expectedException.expectMessage(String.format(Messages.Error.ERROR_ID_LIMIT_SIZE_EXCEEDED, outOfLimit));
+
+        // exercise
+        AzureIdBuilder
+                .configure(this.azureUser)
+                .checkIdSizePolicy(resourceNameInTheLimit);
+
+    }
+
+    private int getWhatLeftToTotalLimit() {
+        String anyIdEmpty = AzureIdBuilder
+                .configure(this.azureUser)
+                .buildId(AzureIdBuilder.BIGGER_STRUCTURE, "");
+        return Order.FIELDS_MAX_SIZE - anyIdEmpty.length();
+    }
+
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureIdBuilderTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureIdBuilderTest.java
@@ -1,0 +1,39 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.AzureTestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AzureIdBuilderTest {
+
+    private AzureUser azureUser;
+
+    @Before
+    public void setUp() {
+        this.azureUser = AzureTestUtils.createAzureCloudUser();
+    }
+
+    // test case: When calling the buildVirtualMachineId method, it must verify if
+    // It returns the right virtual machine id.
+    @Test
+    public void testBuildVirtualMachineIdSuccessfully() {
+        // set up
+        String virtualMachineName = "virtualMachineName";
+
+        String virtualMachineIdExpected = String.format(AzureIdBuilder.VIRTUAL_MACHINE_STRUCTURE,
+                this.azureUser.getSubscriptionId(),
+                this.azureUser.getResourceGroupName(),
+                virtualMachineName);
+
+        // exercise
+        String networkInterfaceId = AzureIdBuilder
+                .configure(this.azureUser)
+                .buildVirtualMachineId(virtualMachineName);
+
+        // verify
+        Assert.assertEquals(virtualMachineIdExpected, networkInterfaceId);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureIdBuilderTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureIdBuilderTest.java
@@ -12,7 +12,7 @@ public class AzureIdBuilderTest {
 
     @Before
     public void setUp() {
-        this.azureUser = AzureTestUtils.createAzureCloudUser();
+        this.azureUser = AzureTestUtils.createAzureUser();
     }
 
     // test case: When calling the buildVirtualMachineId method, it must verify if

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtilTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtilTest.java
@@ -1,0 +1,74 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.ras.api.http.response.ImageSummary;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureGetImageRef;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class AzureImageOperationUtilTest {
+
+    // test case: When calling the buildImageSummaryBy method,
+    // it must verify if It return the right ImageSummary.
+    @Test
+    public void testBuildImageSummaryBySuccessfully() {
+        // set up
+        String publisherExpected = "publisherExpected";
+        String offerExpected = "offerExpected";
+        String skuExpected = "skuExpected";
+        AzureGetImageRef azureVirtualMachineImage = Mockito.mock(AzureGetImageRef.class);
+        Mockito.when(azureVirtualMachineImage.getPublisher()).thenReturn(publisherExpected);
+        Mockito.when(azureVirtualMachineImage.getOffer()).thenReturn(offerExpected);
+        Mockito.when(azureVirtualMachineImage.getSku()).thenReturn(skuExpected);
+
+        String summaryIdExpected = new StringBuilder()
+                .append(publisherExpected)
+                .append(AzureImageOperationUtil.IMAGE_SUMMARY_ID_SEPARATOR)
+                .append(offerExpected)
+                .append(AzureImageOperationUtil.IMAGE_SUMMARY_ID_SEPARATOR)
+                .append(skuExpected)
+                .toString();
+
+        String summaryNameExpected = new StringBuilder()
+                .append(offerExpected)
+                .append(AzureImageOperationUtil.IMAGE_SUMMARY_NAME_SEPARATOR)
+                .append(skuExpected)
+                .toString();
+
+        // execute
+        ImageSummary imageSummary = AzureImageOperationUtil.buildImageSummaryBy(azureVirtualMachineImage);
+
+        // verify
+        Assert.assertEquals(summaryIdExpected, imageSummary.getId());
+        Assert.assertEquals(summaryNameExpected, imageSummary.getName());
+    }
+
+    // test case: When calling the buildAzureVirtualMachineImageBy method,
+    // it must verify if It return the right VirtualMachineImage.
+    @Test
+    public void testBuildAzureVirtualMachineImageBySuccessfully() {
+        // set up
+        String publisherExpected = "publisherExpected";
+        String offerExpected = "offerExpected";
+        String skuExpected = "skuExpected";
+
+        String summaryIdExpected = new StringBuilder()
+                .append(publisherExpected)
+                .append(AzureImageOperationUtil.IMAGE_SUMMARY_ID_SEPARATOR)
+                .append(offerExpected)
+                .append(AzureImageOperationUtil.IMAGE_SUMMARY_ID_SEPARATOR)
+                .append(skuExpected)
+                .toString();
+
+        // execute
+        AzureGetImageRef azureVirtualMachineImage =
+                AzureImageOperationUtil.buildAzureVirtualMachineImageBy(summaryIdExpected);
+
+        // verify
+        Assert.assertEquals(publisherExpected, azureVirtualMachineImage.getPublisher());
+        Assert.assertEquals(offerExpected, azureVirtualMachineImage.getOffer());
+        Assert.assertEquals(skuExpected, azureVirtualMachineImage.getSku());
+    }
+
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureInstancePolicyTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureInstancePolicyTest.java
@@ -1,0 +1,113 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.ras.constants.SystemConstants;
+import cloud.fogbow.ras.core.models.orders.ComputeOrder;
+import cloud.fogbow.ras.core.models.orders.Order;
+import cloud.fogbow.ras.core.plugins.interoperability.azure.AzureTestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.function.BiFunction;
+
+public class AzureInstancePolicyTest {
+
+    private AzureUser azureUser;
+
+    @Before
+    public void setUp() {
+        this.azureUser = AzureTestUtils.createAzureUser();
+    }
+
+    // test case: When calling the generateAzureResourceNameBy method with general order,
+    // it must verify if it returns a resourceGroupName using the order id.
+    @Test
+    public void testGenerateAzureResourceNameSuccessfullyByWhenOrder() throws InvalidParameterException {
+        // set up
+        Order order = Mockito.mock(Order.class);
+        String orderId = "orderId";
+        Mockito.when(order.getId()).thenReturn(orderId);
+
+        String resourceNameExpected = SystemConstants.FOGBOW_INSTANCE_NAME_PREFIX + orderId;
+
+        // exercise
+        String resourceName = AzureInstancePolicy.generateAzureResourceNameBy(order.getId(),
+                this.azureUser);
+
+        // verify
+        Assert.assertEquals(resourceNameExpected, resourceName);
+    }
+
+    // test case: When calling the generateAzureResourceNameBy method with Compute order,
+    // it must verify if it returns a resourceGroupName using the order name.
+    @Test
+    public void testGenerateAzureResourceNameSuccessfullyByWhenComputeOrder() throws InvalidParameterException {
+        // set up
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+        String orderId = "orderId";
+        Mockito.when(computeOrder.getId()).thenReturn(orderId);
+        String resourceNameExpected = "resourceName";
+        Mockito.when(computeOrder.getName()).thenReturn(resourceNameExpected);
+
+        // exercise
+        String resourceName = AzureInstancePolicy.generateAzureResourceNameBy(
+                computeOrder, this.azureUser);
+
+        // verify
+        Assert.assertEquals(resourceNameExpected, resourceName);
+    }
+
+    // test case: When calling the generateFogbowInstanceIdBy method with Compute order,
+    // it must verify if it returns an instance using the order name.
+    @Test
+    public void testGenerateFogbowInstanceIdBySuccessfullyWhenComputeOrder()
+            throws InvalidParameterException {
+
+        // set up
+        String resourceName = "resourceName";
+        ComputeOrder computeOrder = Mockito.mock(ComputeOrder.class);
+        String orderId = "orderId";
+        Mockito.when(computeOrder.getId()).thenReturn(orderId);
+        Mockito.when(computeOrder.getName()).thenReturn(resourceName);
+
+        String instanceIdExpected = AzureIdBuilder.configure(this.azureUser)
+                .buildVirtualMachineId(resourceName);
+
+        // exercise
+        String instanceId = AzureInstancePolicy
+                .generateFogbowInstanceIdBy(computeOrder, this.azureUser);
+
+        // verify
+        Assert.assertEquals(instanceIdExpected, instanceId);
+    }
+
+    // test case: When calling the generateFogbowInstanceIdBy method with general order,
+    // it must verify if it returns an instance using the order name.
+    @Test
+    public void testGenerateFogbowInstanceIdBySuccessfullyWhenOrder()
+            throws InvalidParameterException {
+
+        // set up
+        Order order = Mockito.mock(Order.class);
+        String orderId = "orderId";
+        Mockito.when(order.getId()).thenReturn(orderId);
+        BiFunction<String, AzureUser, String> builder = (name, cloudUser) ->
+                AzureIdBuilder.configure(cloudUser).buildVirtualMachineId(name);
+
+        String resourceNameExpected = SystemConstants.FOGBOW_INSTANCE_NAME_PREFIX + orderId;
+
+        String instanceIdExpected = AzureIdBuilder.configure(this.azureUser)
+                .buildVirtualMachineId(resourceNameExpected);
+
+        // exercise
+        String instanceId = AzureInstancePolicy
+                .generateFogbowInstanceIdBy(order.getId(), this.azureUser, builder);
+
+        // verify
+        Assert.assertEquals(instanceIdExpected, instanceId);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureStateMapperTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureStateMapperTest.java
@@ -1,0 +1,52 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.ras.api.http.response.InstanceState;
+import cloud.fogbow.ras.core.models.ResourceType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AzureStateMapperTest {
+
+    // test case: When calling the map method with compute type and creating state,
+    // it must verify if It returns the instance creating state.
+    @Test
+    public void testMapSuccessfullyWhenCreatingState() {
+        // set up
+        ResourceType resourceType = ResourceType.COMPUTE;
+
+        // exercise
+        InstanceState instanceState = AzureStateMapper.map(resourceType, AzureStateMapper.CREATING_STATE);
+
+        // verify
+        Assert.assertEquals(InstanceState.CREATING, instanceState);
+    }
+
+    // test case: When calling the map method with compute type and creating state,
+    // it must verify if It returns the instance creating state.
+    @Test
+    public void testMapSuccessfullyWhenSuccededState() {
+        // set up
+        ResourceType resourceType = ResourceType.COMPUTE;
+
+        // exercise
+        InstanceState instanceState = AzureStateMapper.map(resourceType, AzureStateMapper.SUCCEEDED_STATE);
+
+        // verify
+        Assert.assertEquals(InstanceState.READY, instanceState);
+    }
+
+    // test case: When calling the map method with compute type and creating state,
+    // it must verify if It returns the instance creating state.
+    @Test
+    public void testMapSuccessfullyWhenUndefinedState() {
+        // set up
+        ResourceType resourceType = ResourceType.COMPUTE;
+
+        // exercise
+        InstanceState instanceState = AzureStateMapper.map(resourceType, "undefined");
+
+        // verify
+        Assert.assertEquals(InstanceState.INCONSISTENT, instanceState);
+    }
+
+}

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureStateMapperTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureStateMapperTest.java
@@ -22,9 +22,9 @@ public class AzureStateMapperTest {
     }
 
     // test case: When calling the map method with compute type and creating state,
-    // it must verify if It returns the instance creating state.
+    // it must verify if It returns the instance ready state.
     @Test
-    public void testMapSuccessfullyWhenSuccededState() {
+    public void testMapSuccessfullyWhenSucceededState() {
         // set up
         ResourceType resourceType = ResourceType.COMPUTE;
 
@@ -35,8 +35,22 @@ public class AzureStateMapperTest {
         Assert.assertEquals(InstanceState.READY, instanceState);
     }
 
+    // test case: When calling the map method with compute type and failed state,
+    // it must verify if It returns the instance failed state.
+    @Test
+    public void testMapSuccessfullyWhenFailedState() {
+        // set up
+        ResourceType resourceType = ResourceType.COMPUTE;
+
+        // exercise
+        InstanceState instanceState = AzureStateMapper.map(resourceType, AzureStateMapper.FAILED_STATE);
+
+        // verify
+        Assert.assertEquals(InstanceState.FAILED, instanceState);
+    }
+
     // test case: When calling the map method with compute type and creating state,
-    // it must verify if It returns the instance creating state.
+    // it must verify if It returns the instance inconsistent state.
     @Test
     public void testMapSuccessfullyWhenUndefinedState() {
         // set up

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/GenericBuilderTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/GenericBuilderTest.java
@@ -1,0 +1,164 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
+
+import cloud.fogbow.common.exceptions.InvalidParameterException;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.function.Supplier;
+
+public class GenericBuilderTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    // test case: When calling the build method with all attributes filled and it does not call
+    // check parameters method, it must verify if the Object was filled with the right values.
+    @Test
+    public void testBuildSuccessfullyWhenAllAttributesAreFilledAndWithoutChecking() {
+        // set up
+        String attributeRequired = "attributeRequired";
+        String attributeOptional = "attributeOptional";
+
+        // exercise
+        GenericObject genericObject = GenericObject.builder()
+                .atributeRequired(attributeRequired)
+                .atributeOptional(attributeOptional)
+                .build();
+
+        // verify
+        Assert.assertEquals(attributeOptional, genericObject.getAtributeOptional());
+        Assert.assertEquals(attributeRequired, genericObject.getAtributeRequired());
+    }
+
+    // test case: When calling the build method with all "set" methods filled and it calls
+    // check parameters method, it must verify if the Object was filled with the right values and
+    // does not throw the exception.
+    @Test
+    public void testBuildSuccessfullyWhenAllAttributesAreFilledAndWithChecking()
+            throws InvalidParameterException {
+        // set up
+        String attributeRequired = "attributeRequired";
+        String attributeOptional = "attributeOptional";
+
+        // exercise
+        GenericObject genericObject = GenericObject.builder()
+                .atributeRequired(attributeRequired)
+                .atributeOptional(attributeOptional)
+                .checkAndBuild();
+
+        // verify
+        Assert.assertEquals(attributeOptional, genericObject.getAtributeOptional());
+        Assert.assertEquals(attributeRequired, genericObject.getAtributeRequired());
+    }
+
+    // test case: When calling the build method with a required attribute not filled and it does not call
+    // check parameters method, it must verify if the Object was filled with the right values.
+    @Test
+    public void testBuildSuccessfullyWhenARequiredAttributeIsNotFieldAndWithoutChecking() {
+        // set up
+        String attributeOptional = "attributeOptional";
+
+        // exercise
+        GenericObject genericObject = GenericObject.builder()
+                .atributeOptional(attributeOptional)
+                .build();
+
+        // verify
+        Assert.assertEquals(attributeOptional, genericObject.getAtributeOptional());
+        Assert.assertNull(genericObject.getAtributeRequired());
+    }
+
+    // test case: When calling the build method with a required attribute not filled and it does not call
+    // check parameters method, it must verify if it throws an exception.
+    @Test
+    public void testBuildFailWhenARequiredAttributeIsNotFieldAndWithChecking() {
+
+        // set up
+        String attributeOptional = "attributeOptional";
+
+        // exercise
+        try {
+            GenericObject.builder()
+                    .atributeOptional(attributeOptional)
+                    .checkAndBuild();
+        } catch (InvalidParameterException e) {
+            // verify
+            String exceptionMessageExpected = generateExceptionMessage();
+            Assert.assertEquals(exceptionMessageExpected, e.getMessage());
+        }
+    }
+
+    // test case: When calling the build method with a required attribute not filled and it does not call
+    // check parameters method, it must verify if it the Object was filled with the right values.
+    @Test
+    public void testBuildSuccessfullyWhenAnOpitionalAttributeIsNotFieldAndWithChecking()
+            throws InvalidParameterException {
+
+        // set up
+        String attributeRequired = "attributeRequired";
+
+        // exercise
+        GenericObject genericObject = GenericObject.builder()
+                .atributeRequired(attributeRequired)
+                .checkAndBuild();
+
+        // verify
+        Assert.assertEquals(attributeRequired, genericObject.getAtributeRequired());
+        Assert.assertNull(attributeRequired, genericObject.getAtributeOptional());
+    }
+
+    private String generateExceptionMessage() {
+        String requiredAttribute = GenericObject.class.getDeclaredFields()[0].getName();
+        return String.format(GenericBuilder.FIELD_REQUIRED_MESSAGE,
+                requiredAttribute, GenericObject.class.getSimpleName());
+    }
+
+    private static class GenericObject {
+
+        @GenericBuilder.Required
+        private String atributeRequired;
+        private String atributeOptional;
+
+        private static Builder builder() {
+            return new Builder(GenericObject::new);
+        }
+
+        private String getAtributeRequired() {
+            return atributeRequired;
+        }
+
+        private void setAtributeRequired(String atributeRequired) {
+            this.atributeRequired = atributeRequired;
+        }
+
+        private String getAtributeOptional() {
+            return atributeOptional;
+        }
+
+        private void setAtributeOptional(String atributeOptional) {
+            this.atributeOptional = atributeOptional;
+        }
+
+        private static class Builder extends GenericBuilder<GenericObject> {
+
+            private Builder(Supplier<GenericObject> instantiator) {
+                super(instantiator);
+            }
+
+            private Builder atributeRequired(String atributeRequired) {
+                with(GenericObject::setAtributeRequired, atributeRequired);
+                return this;
+            }
+
+            private Builder atributeOptional(String atributeOptional) {
+                with(GenericObject::setAtributeOptional, atributeOptional);
+                return this;
+            }
+
+        }
+
+    }
+}
+

--- a/src/test/resources/private/clouds/azure/cloud.conf
+++ b/src/test/resources/private/clouds/azure/cloud.conf
@@ -1,0 +1,2 @@
+# Required
+default_network_interface_name=fogbow-network-interface-name


### PR DESCRIPTION
## Description
Implementing Azure Compute Plugin

## Note
- It's not the final version. I didn't do the integration tests. Because of this, the PR will be merged in the azure-compute-plugin branch instead of develop branch.
- The Azure SDK uses RXJava(reactive programming).

## Proposed changes
- Implement get instance method in the Azure Compute plugin
- Create some utility classes to the Azure context

## Additional information
This branch depends on a branch in the Fogbow Common (azure-compute-plugin-one)

## PR Slices
[x] One: Get instance context
[] Two: Request instance context
[] Three: Delete instance context

## Reminding
PRs order:
*azure-compute-plugin < PR1* < PR2 < PR3