### PR TITLE
Fixes cloud name being ignored when getting user allocation

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/ApplicationFacade.java
+++ b/src/main/java/cloud/fogbow/ras/core/ApplicationFacade.java
@@ -369,7 +369,7 @@ public class ApplicationFacade {
             cloudName = this.cloudListController.getDefaultCloudName();
         RasOperation rasOperation = new RasOperation(Operation.GET_USER_ALLOCATION, resourceType, cloudName);
         this.authorizationPlugin.isAuthorized(requester, rasOperation);
-        return this.orderController.getUserAllocation(providerId, requester, resourceType);
+        return this.orderController.getUserAllocation(providerId, cloudName, requester, resourceType);
     }
 
     protected Quota getUserQuota(String providerId, String cloudName, String userToken, ResourceType resourceType)

--- a/src/main/java/cloud/fogbow/ras/core/OrderController.java
+++ b/src/main/java/cloud/fogbow/ras/core/OrderController.java
@@ -164,7 +164,7 @@ public class OrderController {
         }
     }
 
-    public Allocation getUserAllocation(String providerId, SystemUser systemUser, ResourceType resourceType)
+    public Allocation getUserAllocation(String providerId, String cloudName, SystemUser systemUser, ResourceType resourceType)
             throws UnexpectedException {
         Collection<Order> orders = this.orderHolders.getActiveOrdersMap().values();
 
@@ -173,6 +173,7 @@ public class OrderController {
                 .filter(order -> order.getOrderState().equals(OrderState.FULFILLED))
                 .filter(order -> order.isProviderLocal(providerId))
                 .filter(order -> order.getSystemUser().equals(systemUser))
+                .filter(order -> order.getCloudName().equals(cloudName))
                 .collect(Collectors.toList());
 
         switch (resourceType) {

--- a/src/test/java/cloud/fogbow/ras/core/ApplicationFacadeTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/ApplicationFacadeTest.java
@@ -1441,7 +1441,7 @@ public class ApplicationFacadeTest extends BaseUnitTests {
         Mockito.verify(this.authorizationPlugin, Mockito.times(TestUtils.RUN_ONCE)).isAuthorized(Mockito.eq(systemUser),
                 Mockito.eq(expectedOperation));
         Mockito.verify(this.orderController, Mockito.times(TestUtils.RUN_ONCE))
-                .getUserAllocation(Mockito.eq(providerId), Mockito.eq(systemUser), Mockito.eq(resourceType));
+                .getUserAllocation(Mockito.eq(providerId), Mockito.eq(TestUtils.DEFAULT_CLOUD_NAME), Mockito.eq(systemUser), Mockito.eq(resourceType));
     }
     
     // test case: When calling the getUserQuota method with null or empty cloud

--- a/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
@@ -478,7 +478,7 @@ public class OrderControllerTest extends BaseUnitTests {
 
         // exercise
         ComputeAllocation allocation = (ComputeAllocation) this.ordersController
-                .getUserAllocation(TestUtils.LOCAL_MEMBER_ID, systemUser, ResourceType.COMPUTE);
+                .getUserAllocation(TestUtils.LOCAL_MEMBER_ID, TestUtils.DEFAULT_CLOUD_NAME, systemUser, ResourceType.COMPUTE);
 
         // verify
         Assert.assertEquals(expectedValue, allocation.getInstances());
@@ -509,7 +509,7 @@ public class OrderControllerTest extends BaseUnitTests {
 
         // exercise
         VolumeAllocation allocation = (VolumeAllocation) this.ordersController
-                .getUserAllocation(TestUtils.LOCAL_MEMBER_ID, systemUser, ResourceType.VOLUME);
+                .getUserAllocation(TestUtils.LOCAL_MEMBER_ID, TestUtils.DEFAULT_CLOUD_NAME, systemUser, ResourceType.VOLUME);
 
         // verify
         Assert.assertEquals(expectedValue, allocation.getDisk());
@@ -538,7 +538,7 @@ public class OrderControllerTest extends BaseUnitTests {
 
         // exercise
         NetworkAllocation allocation = (NetworkAllocation) this.ordersController
-                .getUserAllocation(TestUtils.LOCAL_MEMBER_ID, systemUser, ResourceType.NETWORK);
+                .getUserAllocation(TestUtils.LOCAL_MEMBER_ID, TestUtils.DEFAULT_CLOUD_NAME, systemUser, ResourceType.NETWORK);
 
         // verify
         Assert.assertEquals(expectedValue, allocation.getNetworks());
@@ -567,7 +567,7 @@ public class OrderControllerTest extends BaseUnitTests {
 
         // exercise
         PublicIpAllocation allocation = (PublicIpAllocation) this.ordersController
-                .getUserAllocation(TestUtils.LOCAL_MEMBER_ID, systemUser, ResourceType.PUBLIC_IP);
+                .getUserAllocation(TestUtils.LOCAL_MEMBER_ID, TestUtils.DEFAULT_CLOUD_NAME, systemUser, ResourceType.PUBLIC_IP);
 
         // verify
         Assert.assertEquals(expectedValue, allocation.getPublicIps());
@@ -585,7 +585,7 @@ public class OrderControllerTest extends BaseUnitTests {
         this.activeOrdersMap.put(networkOrder.getId(), networkOrder);
 
         // exercise
-        this.ordersController.getUserAllocation(TestUtils.LOCAL_MEMBER_ID, systemUser, ResourceType.GENERIC_RESOURCE);
+        this.ordersController.getUserAllocation(TestUtils.LOCAL_MEMBER_ID, TestUtils.DEFAULT_CLOUD_NAME, systemUser, ResourceType.GENERIC_RESOURCE);
     }
 
     // test case: Checks if deleting a failed order, this one will be moved to the closed orders

--- a/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/OrderControllerTest.java
@@ -734,6 +734,7 @@ public class OrderControllerTest extends BaseUnitTests {
         publicIpOrder.setRequester(TestUtils.LOCAL_MEMBER_ID);
         publicIpOrder.setProvider(TestUtils.LOCAL_MEMBER_ID);
         publicIpOrder.setOrderState(OrderState.FULFILLED);
+        publicIpOrder.setCloudName(TestUtils.DEFAULT_CLOUD_NAME);
         return publicIpOrder;
     }
 
@@ -743,6 +744,7 @@ public class OrderControllerTest extends BaseUnitTests {
         volumeOrder.setRequester(TestUtils.LOCAL_MEMBER_ID);
         volumeOrder.setProvider(TestUtils.LOCAL_MEMBER_ID);
         volumeOrder.setOrderState(OrderState.FULFILLED);
+        volumeOrder.setCloudName(TestUtils.DEFAULT_CLOUD_NAME);
         return volumeOrder;
     }
     
@@ -752,6 +754,7 @@ public class OrderControllerTest extends BaseUnitTests {
         networkOrder.setRequester(TestUtils.LOCAL_MEMBER_ID);
         networkOrder.setProvider(TestUtils.LOCAL_MEMBER_ID);
         networkOrder.setOrderState(OrderState.FULFILLED);
+        networkOrder.setCloudName(TestUtils.DEFAULT_CLOUD_NAME);
         return networkOrder;
     }
     
@@ -761,6 +764,7 @@ public class OrderControllerTest extends BaseUnitTests {
         computeOrder.setRequester(TestUtils.LOCAL_MEMBER_ID);
         computeOrder.setProvider(TestUtils.LOCAL_MEMBER_ID);
         computeOrder.setOrderState(OrderState.FULFILLED);
+        computeOrder.setCloudName(TestUtils.DEFAULT_CLOUD_NAME);
         return computeOrder;
     }
     


### PR DESCRIPTION
This pull request fixes a bug where the cloud name is not considered when filtering orders to get the user allocation. 

The main change was made into `OrderController.getUserAllocation()` and the changes in the others files was only to keep the other classes, which use this method, working properly.