### PR TITLE
Fix azure test utils

### DIFF
--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/AzureTestUtils.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/AzureTestUtils.java
@@ -1,18 +1,9 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure;
 
-import cloud.fogbow.common.models.AzureUser;
-import org.junit.Ignore;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-/*
- * This class is intended to reuse code components to assist other unit test classes
- * but does not contemplate performing any tests. The @Ignore annotation is being used
- * in this context to prevent it from being initialized as a test class.
- */
-@Ignore
-@RunWith(PowerMockRunner.class)
+import cloud.fogbow.common.models.AzureUser;
+
 public class AzureTestUtils {
 
     public static final String AZURE_CLOUD_NAME = "azure";

--- a/src/test/resources/private/clouds/azure/cloud.conf
+++ b/src/test/resources/private/clouds/azure/cloud.conf
@@ -1,4 +1,4 @@
 # Required
-default_network_interface_name=fogbow-network-interface-name
-default_resource_group_name=fogbow-default-resource-group_name
+default_network_interface_name=default-network-interface-name
+default_resource_group_name=default-resource-group-name
 default_region_name=eastus


### PR DESCRIPTION
## Description
This branch fixes some tests that are currently failing in the develop branch, due to incompatibilities with values ​​obtained from the configuration file and tries to revert the misuse of the AzureTestUtils class to prevent it from being extended.