### PR TITLE
Azure image plugin fixes

### DIFF
--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -63,7 +63,7 @@ public class Messages {
         public static final String UNABLE_TO_CREATE_NETWORK_RESERVE = "Unable to create network reserve with CIDR: <%s>." +
                 " This address range is likely in use.";
         public static final String INVALID_REGION_NAME = "The region name '%s' is invalid.";
-        public static final String NO_IMAGES_PUBLISHER = "No virtual machine images publishers specified in azure cloud.conf";
+        public static final String NO_IMAGES_PUBLISHER = "No virtual machine images publishers specified in azure cloud.conf.";
     }
 
     public static class Fatal {

--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -237,5 +237,6 @@ public class Messages {
         public static final String ERROR_CREATE_VNET_ASYNC_BEHAVIOUR = "Error while creating virtual network asynchronously.";
         public static final String ERROR_DELETE_VNET_ASYNC_BEHAVIOUR = "Error while deleting virtual network asynchronously.";
         public static final String ERROR_DELETE_SECURITY_GROUP_ASYNC_BEHAVIOUR = "Error while deleting security group asynchronously.";
+        public static final String ERROR_WHILE_LOADING_IMAGE_S = "Error while loading the following image: %s";
     }
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePlugin.java
@@ -69,7 +69,8 @@ public class AzureComputePlugin implements ComputePlugin<AzureUser>, AzureAsync<
         String resourceName = generateResourceName();
         String virtualNetworkId = getVirtualNetworkId(computeOrder, azureUser);
         String imageId = computeOrder.getImageId();
-        AzureGetImageRef imageRef = AzureImageOperationUtil.buildAzureVirtualMachineImageBy(imageId);
+        String decodedImageId = AzureImageOperationUtil.decodeImageId(imageId);
+        AzureGetImageRef imageRef = AzureImageOperationUtil.buildAzureVirtualMachineImageBy(decodedImageId);
         String osUserName = DEFAULT_OS_USER_NAME;
         String osUserPassword = AzureGeneralPolicy.generatePassword();
         String osComputeName = name;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePlugin.java
@@ -69,7 +69,7 @@ public class AzureComputePlugin implements ComputePlugin<AzureUser>, AzureAsync<
         String resourceName = generateResourceName();
         String virtualNetworkId = getVirtualNetworkId(computeOrder, azureUser);
         String imageId = computeOrder.getImageId();
-        String decodedImageId = AzureImageOperationUtil.decodeImageId(imageId);
+        String decodedImageId = AzureImageOperationUtil.decode(imageId);
         AzureGetImageRef imageRef = AzureImageOperationUtil.buildAzureVirtualMachineImageBy(decodedImageId);
         String osUserName = DEFAULT_OS_USER_NAME;
         String osUserPassword = AzureGeneralPolicy.generatePassword();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/image/AzureImageOperation.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/image/AzureImageOperation.java
@@ -2,13 +2,14 @@ package cloud.fogbow.ras.core.plugins.interoperability.azure.image;
 
 import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.ras.api.http.response.ImageSummary;
+import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureImageOperationUtil;
 import com.microsoft.azure.PagedList;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.VirtualMachineOffer;
 import com.microsoft.azure.management.compute.VirtualMachinePublisher;
 import com.microsoft.azure.management.compute.VirtualMachineSku;
-import java.util.Base64;
+import org.apache.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.Map;
 
 public class AzureImageOperation {
     private final String region;
+    private static final Logger LOGGER = Logger.getLogger(AzureImageOperation.class);
 
     public AzureImageOperation(String region) {
         this.region = region;
@@ -44,7 +46,15 @@ public class AzureImageOperation {
                         String offerName = offer.name();
                         String skuName = sku.name();
                         ImageSummary imageSummary = AzureImageOperationUtil.buildImageSummaryBy(publisherName, offerName, skuName);
-                        String id = AzureImageOperationUtil.encodeImageId(imageSummary.getId());
+                        String id;
+
+                        try {
+                            id = AzureImageOperationUtil.encode(imageSummary.getId());
+                        } catch (UnexpectedException ex) {
+                            LOGGER.debug(String.format(Messages.Error.ERROR_WHILE_LOADING_IMAGE_S, imageSummary.getName()));
+                            continue;
+                        }
+
                         images.put(id, imageSummary);
                     }
                 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/image/AzureImageOperation.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/image/AzureImageOperation.java
@@ -1,5 +1,6 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure.image;
 
+import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.ras.api.http.response.ImageSummary;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureImageOperationUtil;
 import com.microsoft.azure.PagedList;
@@ -7,11 +8,11 @@ import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.VirtualMachineOffer;
 import com.microsoft.azure.management.compute.VirtualMachinePublisher;
 import com.microsoft.azure.management.compute.VirtualMachineSku;
+import java.util.Base64;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public class AzureImageOperation {
     private final String region;
@@ -32,7 +33,7 @@ public class AzureImageOperation {
         return azure.virtualMachineImages().publishers().listByRegion(this.region);
     }
 
-    public Map<String, ImageSummary> getImages(Azure azure, List<String> publishers) {
+    public Map<String, ImageSummary> getImages(Azure azure, List<String> publishers) throws UnexpectedException {
         Map<String, ImageSummary> images = new HashMap<>();
 
         for (VirtualMachinePublisher publisher : this.getPublishers(azure)) {
@@ -43,7 +44,7 @@ public class AzureImageOperation {
                         String offerName = offer.name();
                         String skuName = sku.name();
                         ImageSummary imageSummary = AzureImageOperationUtil.buildImageSummaryBy(publisherName, offerName, skuName);
-                        String id = UUID.randomUUID().toString();
+                        String id = AzureImageOperationUtil.encodeImageId(imageSummary.getId());
                         images.put(id, imageSummary);
                     }
                 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/image/AzureImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/image/AzureImagePlugin.java
@@ -4,6 +4,7 @@ import cloud.fogbow.common.constants.AzureConstants;
 import cloud.fogbow.common.exceptions.FatalErrorException;
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.InstanceNotFoundException;
+import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.AzureUser;
 import cloud.fogbow.common.util.AzureClientCacheManager;
 import cloud.fogbow.common.util.PropertiesUtil;
@@ -91,7 +92,7 @@ public class AzureImagePlugin implements ImagePlugin<AzureUser> {
     }
 
     @VisibleForTesting
-    Map<String, ImageSummary> getImageMap(Azure azure) {
+    Map<String, ImageSummary> getImageMap(Azure azure) throws UnexpectedException {
         if (images.isEmpty()) {
             images = this.operation.getImages(azure, this.publishers);
         }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtil.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtil.java
@@ -59,7 +59,7 @@ public class AzureImageOperationUtil {
         return StringUtils.join(list, IMAGE_SUMMARY_NAME_SEPARATOR);
     }
 
-    public static String encodeImageId(String id) throws UnexpectedException {
+    public static String encode(String id) throws UnexpectedException {
         String encodedId = Base64.getEncoder().encodeToString(id.getBytes());
 
         try {
@@ -69,7 +69,7 @@ public class AzureImageOperationUtil {
         }
     }
 
-    public static String decodeImageId(String encodedId) throws UnexpectedException {
+    public static String decode(String encodedId) throws UnexpectedException {
         try {
             String decodedId = URLDecoder.decode(encodedId, StandardCharsets.UTF_8.toString());
             return new String(Base64.getDecoder().decode(decodedId));

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtil.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtil.java
@@ -1,8 +1,15 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
 
+import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.ras.api.http.response.ImageSummary;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureGetImageRef;
 import org.apache.commons.lang3.StringUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 public class AzureImageOperationUtil {
 
@@ -52,4 +59,22 @@ public class AzureImageOperationUtil {
         return StringUtils.join(list, IMAGE_SUMMARY_NAME_SEPARATOR);
     }
 
+    public static String encodeImageId(String id) throws UnexpectedException {
+        String encodedId = Base64.getEncoder().encodeToString(id.getBytes());
+
+        try {
+            return URLEncoder.encode(encodedId, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException ex) {
+            throw new UnexpectedException(ex.getMessage());
+        }
+    }
+
+    public static String decodeImageId(String encodedId) throws UnexpectedException {
+        try {
+            String decodedId = URLDecoder.decode(encodedId, StandardCharsets.UTF_8.toString());
+            return new String(Base64.getDecoder().decode(decodedId));
+        } catch (UnsupportedEncodingException ex) {
+            throw new UnexpectedException(ex.getMessage());
+        }
+    }
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePluginTest.java
@@ -182,7 +182,7 @@ public class AzureComputePluginTest {
 
         PowerMockito.mockStatic(AzureImageOperationUtil.class);
         String decodedImageId = "decoded-image-id";
-        Mockito.when(AzureImageOperationUtil.decodeImageId(Mockito.eq(imageId))).thenReturn(decodedImageId);
+        Mockito.when(AzureImageOperationUtil.decode(Mockito.eq(imageId))).thenReturn(decodedImageId);
 
         AzureGetImageRef azureGetImageRef = new AzureGetImageRef("", "", "");
         Mockito.when(AzureImageOperationUtil.buildAzureVirtualMachineImageBy(Mockito.eq(decodedImageId)))

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePluginTest.java
@@ -180,9 +180,12 @@ public class AzureComputePluginTest {
         int disk = 1;
         Mockito.when(AzureGeneralPolicy.getDisk(Mockito.eq(computeOrder))).thenReturn(disk);
 
-        AzureGetImageRef azureGetImageRef = new AzureGetImageRef("", "", "");
         PowerMockito.mockStatic(AzureImageOperationUtil.class);
-        Mockito.when(AzureImageOperationUtil.buildAzureVirtualMachineImageBy(Mockito.eq(imageId)))
+        String decodedImageId = "decoded-image-id";
+        Mockito.when(AzureImageOperationUtil.decodeImageId(Mockito.eq(imageId))).thenReturn(decodedImageId);
+
+        AzureGetImageRef azureGetImageRef = new AzureGetImageRef("", "", "");
+        Mockito.when(AzureImageOperationUtil.buildAzureVirtualMachineImageBy(Mockito.eq(decodedImageId)))
                 .thenReturn(azureGetImageRef);
 
         String resourceName = AzureTestUtils.RESOURCE_NAME;

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/image/AzureImageOperationTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/image/AzureImageOperationTest.java
@@ -12,9 +12,7 @@ import com.microsoft.azure.management.compute.VirtualMachinePublisher;
 import com.microsoft.azure.management.compute.VirtualMachineSku;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
@@ -32,9 +30,6 @@ public class AzureImageOperationTest extends AzureTestUtils {
     private static final String AZURE_SELECTED_PUBLISHER = "Canonical";
     private AzureImageOperation operation;
     private Azure azure;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setUp() {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/image/AzureImageOperationTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/image/AzureImageOperationTest.java
@@ -1,5 +1,6 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure.image;
 
+import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.ras.api.http.response.ImageSummary;
 import cloud.fogbow.ras.core.TestUtils;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.AzureTestUtils;
@@ -33,7 +34,7 @@ public class AzureImageOperationTest extends AzureTestUtils {
     // test case: When calling getImages method with all secondary method
     // mocked, it must return the right map of ImageSummary
     @Test
-    public void testGetImagesSuccessfully() {
+    public void testGetImagesSuccessfully() throws UnexpectedException {
         // set up
         VirtualMachinePublisher publisher = createPublisher(AZURE_SELECTED_PUBLISHER);
         PagedList<VirtualMachinePublisher> publishers = (PagedList<VirtualMachinePublisher>) Mockito.mock(PagedList.class);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtilTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtilTest.java
@@ -100,7 +100,7 @@ public class AzureImageOperationUtilTest {
         String id = "publisher@#offer@#sku";
 
         // exercise
-        String encodedId = AzureImageOperationUtil.encodeImageId(id);
+        String encodedId = AzureImageOperationUtil.encode(id);
 
         // verify
         Assert.assertNotEquals(encodedId, id);
@@ -112,7 +112,8 @@ public class AzureImageOperationUtilTest {
     public void testEncodeImageIdFail() throws UnsupportedEncodingException, UnexpectedException {
         // set up
         PowerMockito.mockStatic(URLEncoder.class);
-        String id = "publisher@#offer@#sku";
+        String separator = AzureImageOperationUtil.IMAGE_SUMMARY_ID_SEPARATOR;
+        String id = "publisher" + separator + "offer" + separator + "sku";
 
         String encodedId = Base64.getEncoder().encodeToString(id.getBytes());
 
@@ -125,7 +126,7 @@ public class AzureImageOperationUtilTest {
         this.expectedException.expectMessage(message);
 
         // exercise
-        AzureImageOperationUtil.encodeImageId(id);
+        AzureImageOperationUtil.encode(id);
     }
 
     // test case: When calling decodeImageId method with mocked methods,
@@ -133,12 +134,14 @@ public class AzureImageOperationUtilTest {
     @Test
     public void testDecodeImageIdSuccessfully() throws UnexpectedException, UnsupportedEncodingException {
         // set up
-        String expectedId = "publisher@#offer@#sku";
+        String separator = AzureImageOperationUtil.IMAGE_SUMMARY_ID_SEPARATOR;
+        String expectedId = "publisher" + separator + "offer" + separator + "sku";
+
         String encodedId = Base64.getEncoder().encodeToString(expectedId.getBytes());
         String urlEncodedId = URLEncoder.encode(encodedId, StandardCharsets.UTF_8.toString());
 
         // exercise
-        String decoded = AzureImageOperationUtil.decodeImageId(urlEncodedId);
+        String decoded = AzureImageOperationUtil.decode(urlEncodedId);
 
         // verify
         Assert.assertEquals(expectedId, decoded);
@@ -161,7 +164,23 @@ public class AzureImageOperationUtilTest {
         this.expectedException.expectMessage(message);
 
         // exercise
-        AzureImageOperationUtil.decodeImageId(id);
+        AzureImageOperationUtil.decode(id);
     }
 
+    // test case: When encoding a value, if this value is decoded
+    // the initial value should be return
+    @Test
+    public void testEncodeDecodeSuccessfully() throws UnexpectedException {
+        // set up
+        String separator = AzureImageOperationUtil.IMAGE_SUMMARY_ID_SEPARATOR;
+        String expectedId = "publisher" + separator + "offer" + separator + "sku";
+
+        // exercise
+        String encoded = AzureImageOperationUtil.encode(expectedId);
+        String decoded = AzureImageOperationUtil.decode(encoded);
+
+        // verify
+        Assert.assertNotEquals(expectedId, encoded);
+        Assert.assertEquals(expectedId, decoded);
+    }
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtilTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtilTest.java
@@ -1,12 +1,34 @@
 package cloud.fogbow.ras.core.plugins.interoperability.azure.util;
 
+import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.ras.api.http.response.ImageSummary;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.compute.sdk.model.AzureGetImageRef;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+        AzureImageOperationUtil.class,
+        URLDecoder.class,
+        URLEncoder.class
+})
 public class AzureImageOperationUtilTest {
+
+    @Rule
+    private ExpectedException expectedException = ExpectedException.none();
 
     // test case: When calling the buildImageSummaryBy method,
     // it must verify if It return the right ImageSummary.
@@ -70,5 +92,76 @@ public class AzureImageOperationUtilTest {
         Assert.assertEquals(skuExpected, azureVirtualMachineImage.getSku());
     }
 
+    // test case: When calling encodeImageId method with mocked methods,
+    // it must verify if it returns the a new encoded id
+    @Test
+    public void testEncodeImageIdSuccessfully() throws UnexpectedException {
+        // set up
+        String id = "publisher@#offer@#sku";
+
+        // exercise
+        String encodedId = AzureImageOperationUtil.encodeImageId(id);
+
+        // verify
+        Assert.assertNotEquals(encodedId, id);
+    }
+
+    // test case: When calling encodeImageId method and a UnsupportedEncodingException
+    // occurs, it must verify if it rethrow a UnexpectedException
+    @Test
+    public void testEncodeImageIdFail() throws UnsupportedEncodingException, UnexpectedException {
+        // set up
+        PowerMockito.mockStatic(URLEncoder.class);
+        String id = "publisher@#offer@#sku";
+
+        String encodedId = Base64.getEncoder().encodeToString(id.getBytes());
+
+        String message = "error message";
+        PowerMockito.when(URLEncoder.encode(Mockito.eq(encodedId), Mockito.anyString()))
+                .thenThrow(new UnsupportedEncodingException(message));
+
+        // verify
+        this.expectedException.expect(UnexpectedException.class);
+        this.expectedException.expectMessage(message);
+
+        // exercise
+        AzureImageOperationUtil.encodeImageId(id);
+    }
+
+    // test case: When calling decodeImageId method with mocked methods,
+    // it must verify if it returns the right decoded id
+    @Test
+    public void testDecodeImageIdSuccessfully() throws UnexpectedException, UnsupportedEncodingException {
+        // set up
+        String expectedId = "publisher@#offer@#sku";
+        String encodedId = Base64.getEncoder().encodeToString(expectedId.getBytes());
+        String urlEncodedId = URLEncoder.encode(encodedId, StandardCharsets.UTF_8.toString());
+
+        // exercise
+        String decoded = AzureImageOperationUtil.decodeImageId(urlEncodedId);
+
+        // verify
+        Assert.assertEquals(expectedId, decoded);
+    }
+
+    // test case: When calling encodeImageId method and a UnsupportedEncodingException
+    // occurs, it must verify if it rethrow a UnexpectedException
+    @Test
+    public void testDecodeImageIdFail() throws UnsupportedEncodingException, UnexpectedException {
+        // set up
+        PowerMockito.mockStatic(URLDecoder.class);
+        String id = "AfsfsDFfggH==";
+
+        String message = "error message";
+        PowerMockito.when(URLDecoder.decode(Mockito.eq(id), Mockito.anyString()))
+                .thenThrow(new UnsupportedEncodingException(message));
+
+        // verify
+        this.expectedException.expect(UnexpectedException.class);
+        this.expectedException.expectMessage(message);
+
+        // exercise
+        AzureImageOperationUtil.decodeImageId(id);
+    }
 
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtilTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtilTest.java
@@ -92,7 +92,7 @@ public class AzureImageOperationUtilTest {
         Assert.assertEquals(skuExpected, azureVirtualMachineImage.getSku());
     }
 
-    // test case: When calling decodeImageId method with mocked methods,
+    // test case: When calling encodeImageId method with mocked methods,
     // it must verify if it returns the a new encoded id
     @Test
     public void testEncodeImageIdSuccessfully() throws UnexpectedException {
@@ -144,7 +144,7 @@ public class AzureImageOperationUtilTest {
         Assert.assertEquals(expectedId, decoded);
     }
 
-    // test case: When calling encodeImageId method and a UnsupportedEncodingException
+    // test case: When calling decodeImageId method and a UnsupportedEncodingException
     // occurs, it must verify if it rethrow a UnexpectedException
     @Test
     public void testDecodeImageIdFail() throws UnsupportedEncodingException, UnexpectedException {

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtilTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/util/AzureImageOperationUtilTest.java
@@ -92,7 +92,7 @@ public class AzureImageOperationUtilTest {
         Assert.assertEquals(skuExpected, azureVirtualMachineImage.getSku());
     }
 
-    // test case: When calling encodeImageId method with mocked methods,
+    // test case: When calling decodeImageId method with mocked methods,
     // it must verify if it returns the a new encoded id
     @Test
     public void testEncodeImageIdSuccessfully() throws UnexpectedException {


### PR DESCRIPTION
This pull request fixes #446 

The solution was encoding/decoding the image id, this way we can extract the information we need just decoding it.