### PR TITLE
Fix aws deletion logic

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/AwsV2CloudUtil.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/AwsV2CloudUtil.java
@@ -46,11 +46,11 @@ public class AwsV2CloudUtil {
     }
     
     public static DescribeImagesResponse doDescribeImagesRequest(DescribeImagesRequest request, Ec2Client client)
-            throws InternalServerErrorException {
+            throws FogbowException {
         try {
             return client.describeImages(request);
         } catch (Exception e) {
-            throw new InternalServerErrorException(e.getMessage());
+            throw new InstanceNotFoundException(e.getMessage());
         }
     }
     
@@ -66,7 +66,7 @@ public class AwsV2CloudUtil {
         try {
             return client.describeVolumes(request);
         } catch (SdkException e) {
-            throw new InternalServerErrorException(e.getMessage());
+            throw new InstanceNotFoundException(e.getMessage());
         }
     }
     
@@ -135,7 +135,7 @@ public class AwsV2CloudUtil {
         try {
             return client.describeInstances(describeInstancesRequest);
         } catch (SdkException e) {
-            throw new InternalServerErrorException(e.getMessage());
+            throw new InstanceNotFoundException(e.getMessage());
         }
     }
 
@@ -200,7 +200,7 @@ public class AwsV2CloudUtil {
         try {
             return client.describeAddresses(request);
         } catch (SdkException e) {
-            throw new InternalServerErrorException(e.getMessage());
+            throw new InstanceNotFoundException(e.getMessage());
         }
     }
     
@@ -225,7 +225,7 @@ public class AwsV2CloudUtil {
         try {
             return client.describeSubnets(request);
         } catch (SdkException e) {
-            throw new InternalServerErrorException(e.getMessage());
+            throw new InstanceNotFoundException(e.getMessage());
         }
     }
     

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/AwsV2StateMapper.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/AwsV2StateMapper.java
@@ -32,6 +32,7 @@ public class AwsV2StateMapper {
 	public static final String RUNNING_STATE = "running";
 	public static final String SHUTTING_DOWN_STATE = "deleting";
 	public static final String STOPPING_STATE = "stopping";
+	public static final String TERMINATED_STATE = "terminated";
 	public static final String TRANSIENT_STATE = "transient";
 	public static final String UNKNOWN_TO_SDK_VERSION_STATE = "unknown_to_sdk_version";
 

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/AwsV2CloudUtilTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/AwsV2CloudUtilTest.java
@@ -482,7 +482,7 @@ public class AwsV2CloudUtilTest extends BaseUnitTests {
             // exercise
             AwsV2CloudUtil.doDescribeAddressesRequests(request, this.client);
             Assert.fail();
-        } catch (InternalServerErrorException e) {
+        } catch (InstanceNotFoundException e) {
             // verify
             Assert.assertEquals(expected, e.getMessage());
         }
@@ -622,7 +622,7 @@ public class AwsV2CloudUtilTest extends BaseUnitTests {
             // exercise
             AwsV2CloudUtil.doDescribeSubnetsRequest(request, this.client);
             Assert.fail();
-        } catch (InternalServerErrorException e) {
+        } catch (InstanceNotFoundException e) {
             // verify
             Assert.assertEquals(expected, e.getMessage());
         }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePluginTest.java
@@ -357,7 +357,7 @@ public class AwsComputePluginTest extends BaseUnitTests {
         Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).getAllDisksSize(Mockito.eq(volumes));
         Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).getIpAddresses(Mockito.eq(instance));
     }
-	
+
     // test case: When calling the getIpAddresses method, it must verify
     // that is call was successful.
     @Test
@@ -446,7 +446,31 @@ public class AwsComputePluginTest extends BaseUnitTests {
         // verify
         Assert.assertEquals(expected, memory);
     }
-    
+
+    // test case: When calling the checkTerminatedStateFrom method with an
+    // instance terminated, it must verify if an InstanceNotFoundException has
+    // been thrown.
+    @Test
+    public void testCheckTerminatedStateFromInstance() {
+        // set up
+        Instance instance = Instance.builder()
+                .state(InstanceState.builder()
+                        .name(AwsV2StateMapper.TERMINATED_STATE)
+                        .build())
+                .build();
+
+        String expected = Messages.Exception.INSTANCE_NOT_FOUND;
+
+        try {
+            // exercise
+            this.plugin.checkTerminatedStateFrom(instance );
+            Assert.fail();
+        } catch (InstanceNotFoundException e) {
+            // verify
+            Assert.assertEquals(expected, e.getMessage());
+        }
+    }
+
     // test case: When calling the doRequestInstance method, it must verify
     // that is call was successful.
     @Test


### PR DESCRIPTION
## Description
Fix from the Issue #544

## Proposed changes
- Resources description methods throw InstanceNotFoundException when your plugins fail to get your instances.