### PR TITLE
Fix cloudstack compute plugin

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/DeployVirtualMachineRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/DeployVirtualMachineRequest.java
@@ -9,7 +9,7 @@ public class DeployVirtualMachineRequest extends CloudStackRequest {
     public static final String TEMPLATE_ID_KEY = "templateid";
     public static final String ZONE_ID_KEY = "zoneid";
     public static final String NAME_KEY = "name";
-    public static final String DISK_OFFERING_ID = "diskofferingid";
+    public static final String ROOT_DISK_SIZE = "rootdisksize";
     public static final String USER_DATA = "userdata";
     public static final String NETWORKS_ID = "networkids";
     public static final String KEYPAIR = "keypair";
@@ -21,7 +21,7 @@ public class DeployVirtualMachineRequest extends CloudStackRequest {
         addParameter(TEMPLATE_ID_KEY, builder.templateId);
         addParameter(ZONE_ID_KEY, builder.zoneId);
         addParameter(NAME_KEY, builder.name);
-        addParameter(DISK_OFFERING_ID, builder.diskOfferingId);
+        addParameter(ROOT_DISK_SIZE, builder.rootDiskSize);
         addParameter(USER_DATA, builder.userData);
         addParameter(NETWORKS_ID, builder.networksId);
         addParameter(KEYPAIR, builder.keypair);
@@ -43,7 +43,7 @@ public class DeployVirtualMachineRequest extends CloudStackRequest {
         private String templateId;
         private String zoneId;
         private String name;
-        private String diskOfferingId;
+        private String rootDiskSize;
         private String userData;
         private String networksId;
         private String keypair;
@@ -68,8 +68,8 @@ public class DeployVirtualMachineRequest extends CloudStackRequest {
             return this;
         }
 
-        public Builder diskOfferingId(String diskOfferingId) {
-            this.diskOfferingId = diskOfferingId;
+        public Builder rootDiskSize(String rootDiskSize) {
+            this.rootDiskSize = rootDiskSize;
             return this;
         }
 


### PR DESCRIPTION
## Description
Fix from the Issue #537

## Proposed changes
Fix the instance request in the CloudStack compute plugin, to avoid creating an extra data disk, directly setting the root disk size to the requested value in order.

## Additional Information
The amount requested in the order cannot be less than the template related to the selected image.