### PR TITLE
AWS Intra plugin refactor

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/AwsV2StateMapper.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/AwsV2StateMapper.java
@@ -1,5 +1,11 @@
 package cloud.fogbow.ras.core.plugins.interoperability.aws;
 
+import cloud.fogbow.ras.core.plugins.interoperability.aws.attachment.v2.AwsAttachmentPlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.aws.compute.v2.AwsComputePlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.aws.image.v2.AwsImagePlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.aws.network.v2.AwsNetworkPlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.aws.publicip.v2.AwsPublicIpPlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.aws.volume.v2.AwsVolumePlugin;
 import org.apache.log4j.Logger;
 
 import cloud.fogbow.ras.api.http.response.InstanceState;
@@ -9,12 +15,12 @@ import cloud.fogbow.ras.core.models.ResourceType;
 public class AwsV2StateMapper {
 
 	private static final Logger LOGGER = Logger.getLogger(AwsV2StateMapper.class);
-	private static final String ATTACHMENT_PLUGIN = "AwsV2AttachmentPlugin";
-	private static final String COMPUTE_PLUGIN = "AwsV2ComputePlugin";
-	private static final String IMAGE_PLUGIN = "AwsV2ImagePlugin";
-	private static final String NETWORK_PLUGIN = "AwsV2NetworkPlugin";
-	private static final String PUBLIC_IP_PLUGIN = "AwsV2PublicIpPlugin";
-	private static final String VOLUME_PLUGIN = "AwsV2VolumePlugin";
+	private static final String ATTACHMENT_PLUGIN = AwsAttachmentPlugin.class.getSimpleName();
+	private static final String COMPUTE_PLUGIN = AwsComputePlugin.class.getSimpleName();
+	private static final String IMAGE_PLUGIN = AwsImagePlugin.class.getSimpleName();
+	private static final String NETWORK_PLUGIN = AwsNetworkPlugin.class.getSimpleName();
+	private static final String PUBLIC_IP_PLUGIN = AwsPublicIpPlugin.class.getSimpleName();
+	private static final String VOLUME_PLUGIN = AwsVolumePlugin.class.getSimpleName();
 
 	public static final String ATTACHED_STATE = "attached";
 	public static final String ATTACHING_STATE = "attaching";

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/attachment/v2/AwsAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/attachment/v2/AwsAttachmentPlugin.java
@@ -3,6 +3,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.aws.attachment.v2;
 import java.util.Properties;
 
 import cloud.fogbow.common.exceptions.InternalServerErrorException;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
 import cloud.fogbow.common.exceptions.FogbowException;
@@ -32,8 +33,10 @@ public class AwsAttachmentPlugin implements AttachmentPlugin<AwsV2User> {
 
 	private static final Logger LOGGER = Logger.getLogger(AwsVolumePlugin.class);
 	
-	protected static final String DEFAULT_DEVICE_NAME = "/dev/sdb";
-	protected static final String RESOURCE_NAME = "Attachment";
+	@VisibleForTesting
+	static final String DEFAULT_DEVICE_NAME = "/dev/sdb";
+	@VisibleForTesting
+	static final String RESOURCE_NAME = "Attachment";
 
 	private String region;
 
@@ -86,18 +89,20 @@ public class AwsAttachmentPlugin implements AttachmentPlugin<AwsV2User> {
         return doGetInstance(attachmentId, client);
     }
 
-    protected AttachmentInstance doGetInstance(String attachmentId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    AttachmentInstance doGetInstance(String attachmentId, Ec2Client client) throws FogbowException {
         DescribeVolumesRequest request = DescribeVolumesRequest.builder()
                 .volumeIds(attachmentId)
                 .build();
-        
+
         DescribeVolumesResponse response = AwsV2CloudUtil.doDescribeVolumesRequest(request, client);
         return buildAttachmentInstance(response);
     }
 
-    protected void doDeleteInstance(String volumeId, Ec2Client client)
+    @VisibleForTesting
+    void doDeleteInstance(String volumeId, Ec2Client client)
             throws InternalServerErrorException {
-        
+
         DetachVolumeRequest request = DetachVolumeRequest.builder()
                 .volumeId(volumeId)
                 .build();
@@ -110,7 +115,8 @@ public class AwsAttachmentPlugin implements AttachmentPlugin<AwsV2User> {
         }
     }
 
-	protected AttachmentInstance buildAttachmentInstance(DescribeVolumesResponse response)
+	@VisibleForTesting
+    AttachmentInstance buildAttachmentInstance(DescribeVolumesResponse response)
 			throws FogbowException {
 
 	    Volume volume = AwsV2CloudUtil.getVolumeFrom(response);
@@ -122,14 +128,16 @@ public class AwsAttachmentPlugin implements AttachmentPlugin<AwsV2User> {
 		return new AttachmentInstance(volumeId, cloudState, computeId, volumeId, device);
 	}
 
-	protected VolumeAttachment getAttachmentBy(Volume volume) throws FogbowException {
+	@VisibleForTesting
+    VolumeAttachment getAttachmentBy(Volume volume) throws FogbowException {
 		if (!volume.attachments().isEmpty()) {
 			return volume.attachments().listIterator().next();
 		}
 		throw new InstanceNotFoundException(Messages.Exception.INSTANCE_NOT_FOUND);
 	}
-	
-	protected String doRequestInstance(AttachVolumeRequest request, Ec2Client client)
+
+	@VisibleForTesting
+    String doRequestInstance(AttachVolumeRequest request, Ec2Client client)
             throws FogbowException {
 
         String attachmentId;
@@ -148,7 +156,8 @@ public class AwsAttachmentPlugin implements AttachmentPlugin<AwsV2User> {
      * change it depending on circumstances, as with other operating systems that
      * behave differently.
      */
-    protected String getAttachedDeviceName(String deviceName) {
+    @VisibleForTesting
+    String getAttachedDeviceName(String deviceName) {
         /*
          * By default, "/dev/sd[a-z]" is provided as an example for Debian based linux
          * distributions, and "/dev/xvd[a-z]" for Red Hat based distributions and their

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePlugin.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import cloud.fogbow.common.exceptions.*;
+import cloud.fogbow.common.util.StorageUnit;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
@@ -82,8 +83,6 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
     static final int INSTANCES_LAUNCH_NUMBER = 1;
     @VisibleForTesting
     static final int MAXIMUM_SIZE_ALLOWED = 1;
-    @VisibleForTesting
-    static final int ONE_GIGABYTE = 1024;
 
     private String defaultSubnetId;
     private String flavorsFilePath;
@@ -471,11 +470,15 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         String name = requirements[INSTANCE_TYPE_COLUMN];
         String flavorId = generateFlavorId();
         int cpu = Integer.parseInt(requirements[VCPU_COLUMN]);
-        Double memory = Double.parseDouble(requirements[MEMORY_COLUMN]) * ONE_GIGABYTE;
+
+        double memoryInGB = Double.parseDouble(requirements[MEMORY_COLUMN]);
+        double memoryInMB = StorageUnit.gigabyte(memoryInGB).asMegabyte();
+        int memory = Double.valueOf(memoryInMB).intValue();
+
         int disk = imageEntry.getValue();
         String imageId = imageEntry.getKey();
         Map<String, String> requirementsMap = loadRequirementsMap(requirements);
-        return new AwsHardwareRequirements(name, flavorId, cpu, memory.intValue(), disk, imageId, requirementsMap);
+        return new AwsHardwareRequirements(name, flavorId, cpu, memory, disk, imageId, requirementsMap);
     }
 
     @VisibleForTesting

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePlugin.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import cloud.fogbow.common.exceptions.*;
-import cloud.fogbow.common.util.StorageUnit;
+import cloud.fogbow.common.util.BinaryUnit;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
@@ -472,7 +472,7 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         int cpu = Integer.parseInt(requirements[VCPU_COLUMN]);
 
         double memoryInGB = Double.parseDouble(requirements[MEMORY_COLUMN]);
-        double memoryInMB = StorageUnit.gigabyte(memoryInGB).asMegabyte();
+        double memoryInMB = BinaryUnit.gigabytes(memoryInGB).asMegabytes();
         int memory = Double.valueOf(memoryInMB).intValue();
 
         int disk = imageEntry.getValue();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePlugin.java
@@ -57,20 +57,33 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
     private static final int STORAGE_COLUMN = 3;
     private static final int VCPU_COLUMN = 1;
 
-    protected static final String BANDWIDTH_REQUIREMENT = "bandwidth";
-    protected static final String GRAPHIC_EMULATION_REQUIREMENT = "FPGAs";
-    protected static final String GRAPHIC_MEMORY_REQUIREMENT = "memory-GPU";
-    protected static final String GRAPHIC_PROCESSOR_REQUIREMENT = "GPUs";
-    protected static final String GRAPHIC_SHARING_REQUIREMENT = "p2p-between-GPUs";
-    protected static final String PERFORMANCE_REQUIREMENT = "performance";
-    protected static final String PROCESSOR_REQUIREMENT = "processor";
-    protected static final String RESOURCE_NAME = "Compute";
-    protected static final String STORAGE_REQUIREMENT = "storage";
+    @VisibleForTesting
+    static final String BANDWIDTH_REQUIREMENT = "bandwidth";
+    @VisibleForTesting
+    static final String GRAPHIC_EMULATION_REQUIREMENT = "FPGAs";
+    @VisibleForTesting
+    static final String GRAPHIC_MEMORY_REQUIREMENT = "memory-GPU";
+    @VisibleForTesting
+    static final String GRAPHIC_PROCESSOR_REQUIREMENT = "GPUs";
+    @VisibleForTesting
+    static final String GRAPHIC_SHARING_REQUIREMENT = "p2p-between-GPUs";
+    @VisibleForTesting
+    static final String PERFORMANCE_REQUIREMENT = "performance";
+    @VisibleForTesting
+    static final String PROCESSOR_REQUIREMENT = "processor";
+    @VisibleForTesting
+    static final String RESOURCE_NAME = "Compute";
+    @VisibleForTesting
+    static final String STORAGE_REQUIREMENT = "storage";
 	
-    protected static final int DEFAULT_DEVICE_INDEX = 0;
-    protected static final int INSTANCES_LAUNCH_NUMBER = 1;
-    protected static final int MAXIMUM_SIZE_ALLOWED = 1;
-    protected static final int ONE_GIGABYTE = 1024;
+    @VisibleForTesting
+    static final int DEFAULT_DEVICE_INDEX = 0;
+    @VisibleForTesting
+    static final int INSTANCES_LAUNCH_NUMBER = 1;
+    @VisibleForTesting
+    static final int MAXIMUM_SIZE_ALLOWED = 1;
+    @VisibleForTesting
+    static final int ONE_GIGABYTE = 1024;
 
     private String defaultSubnetId;
     private String flavorsFilePath;
@@ -124,7 +137,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return false;
     }
 
-    protected void doDeleteInstance(String instanceId, Ec2Client client) throws InternalServerErrorException {
+    @VisibleForTesting
+    void doDeleteInstance(String instanceId, Ec2Client client) throws InternalServerErrorException {
         TerminateInstancesRequest request = TerminateInstancesRequest.builder()
                 .instanceIds(instanceId)
                 .build();
@@ -136,7 +150,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         }
     }
 	
-    protected ComputeInstance doGetInstance(String instanceId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    ComputeInstance doGetInstance(String instanceId, Ec2Client client) throws FogbowException {
         DescribeInstancesResponse response = AwsV2CloudUtil.doDescribeInstanceById(instanceId, client);
         Instance instance = AwsV2CloudUtil.getInstanceFrom(response);
         checkTerminatedStateFrom(instance);
@@ -144,7 +159,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return buildComputeInstance(instance, volumes);
     }
 	
-    protected ComputeInstance buildComputeInstance(Instance instance, List<Volume> volumes) {
+    @VisibleForTesting
+    ComputeInstance buildComputeInstance(Instance instance, List<Volume> volumes) {
         String id = instance.instanceId();
         String cloudState = instance.state().nameAsString();
         String name = instance.tags().listIterator().next().value();
@@ -157,7 +173,7 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
     }
 
     @VisibleForTesting
-    protected String getFaultMessage(Instance instance) {
+    String getFaultMessage(Instance instance) {
         String faultMessage = null;
         String stateTransitionReason = instance.stateTransitionReason();
         if (!stateTransitionReason.isEmpty()) {
@@ -166,7 +182,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return faultMessage;
     }
 
-    protected List<String> getIpAddresses(Instance instance) {
+    @VisibleForTesting
+    List<String> getIpAddresses(Instance instance) {
         List<String> ipAddresses = new ArrayList<>();
         List<String> privateIpaddresses;
         String publicIpAddress;
@@ -183,7 +200,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return ipAddresses;
     }
 
-    protected String getPublicIpAddresses(Instance awsInstance, int index) {
+    @VisibleForTesting
+    String getPublicIpAddresses(Instance awsInstance, int index) {
         String ipAddress = null;
         InstanceNetworkInterfaceAssociation association;
         association = awsInstance.networkInterfaces().get(index).association();
@@ -193,7 +211,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return ipAddress;
     }
 
-    protected List<String> getPrivateIpAddresses(Instance awsInstance, int index) {
+    @VisibleForTesting
+    List<String> getPrivateIpAddresses(Instance awsInstance, int index) {
         List<String> ipAddresses = new ArrayList<String>();
         List<InstancePrivateIpAddress> instancePrivateIpAddresses;
         instancePrivateIpAddresses = awsInstance.networkInterfaces().get(index).privateIpAddresses();
@@ -205,7 +224,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return ipAddresses;
     }
 
-    protected int getAllDisksSize(List<Volume> volumes) {
+    @VisibleForTesting
+    int getAllDisksSize(List<Volume> volumes) {
         int size = 0;
         for (Volume volume : volumes) {
             size += volume.size();
@@ -213,7 +233,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return size;
     }
 
-    protected int getMemoryValueFrom(InstanceType instanceType) {
+    @VisibleForTesting
+    int getMemoryValueFrom(InstanceType instanceType) {
         for (AwsHardwareRequirements flavor : getFlavors()) {
             if (flavor.getName().equals(instanceType.toString())) {
                 return flavor.getRam();
@@ -222,14 +243,16 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return 0;
     }
 
-    protected void checkTerminatedStateFrom(Instance instance) throws InstanceNotFoundException {
+    @VisibleForTesting
+    void checkTerminatedStateFrom(Instance instance) throws InstanceNotFoundException {
         String state = instance.state().nameAsString();
         if (state.equals(AwsV2StateMapper.TERMINATED_STATE)) {
             throw new InstanceNotFoundException(Messages.Exception.INSTANCE_NOT_FOUND);
         }
     }
 
-    protected String doRequestInstance(ComputeOrder computeOrder, AwsHardwareRequirements flavor,
+    @VisibleForTesting
+    String doRequestInstance(ComputeOrder computeOrder, AwsHardwareRequirements flavor,
             RunInstancesRequest request, Ec2Client client) throws InternalServerErrorException {
         
         try {
@@ -249,7 +272,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         }
     }
 
-    protected void updateInstanceAllocation(ComputeOrder computeOrder, AwsHardwareRequirements flavor, Instance instance,
+    @VisibleForTesting
+    void updateInstanceAllocation(ComputeOrder computeOrder, AwsHardwareRequirements flavor, Instance instance,
             Ec2Client client) throws FogbowException {
 
         synchronized (computeOrder) {
@@ -264,7 +288,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         }
     }
     
-    protected Image getImageById(String imageId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    Image getImageById(String imageId, Ec2Client client) throws FogbowException {
         DescribeImagesRequest request = DescribeImagesRequest.builder()
                 .imageIds(imageId)
                 .build();
@@ -276,7 +301,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         throw new InstanceNotFoundException(Messages.Exception.IMAGE_NOT_FOUND);
     }
 
-    protected RunInstancesRequest buildRequestInstance(ComputeOrder order, AwsHardwareRequirements flavor, Subnet subnet)
+    @VisibleForTesting
+    RunInstancesRequest buildRequestInstance(ComputeOrder order, AwsHardwareRequirements flavor, Subnet subnet)
             throws FogbowException {
 
         String imageId = flavor.getImageId();
@@ -296,7 +322,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return request;
     }
 	
-    protected InstanceNetworkInterfaceSpecification buildNetworkInterface(Subnet subnet) throws FogbowException {
+    @VisibleForTesting
+    InstanceNetworkInterfaceSpecification buildNetworkInterface(Subnet subnet) throws FogbowException {
         List<Tag> subnetTags = subnet.tags();
         String groupId = AwsV2CloudUtil.getGroupIdFrom(subnetTags);
         String subnetId = subnet.subnetId();
@@ -310,13 +337,15 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return networkInterface;
     }
 
-    protected Subnet getNetworkSelected(ComputeOrder order, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    Subnet getNetworkSelected(ComputeOrder order, Ec2Client client) throws FogbowException {
         List<String> networkIds = order.getNetworkIds();
         String subnetId = selectNetworkId(networkIds);
         return AwsV2CloudUtil.getSubnetById(subnetId, client);
     }
 
-    protected String selectNetworkId(List<String> networkIdList) throws FogbowException {
+    @VisibleForTesting
+    String selectNetworkId(List<String> networkIdList) throws FogbowException {
         String networkId = this.defaultSubnetId;
         if (!networkIdList.isEmpty()) {
             checkNetworkIdListIntegrity(networkIdList);
@@ -325,13 +354,15 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return networkId;
     }
 
-    protected void checkNetworkIdListIntegrity(List<String> networkIdList) throws FogbowException {
+    @VisibleForTesting
+    void checkNetworkIdListIntegrity(List<String> networkIdList) throws FogbowException {
         if (networkIdList.size() > MAXIMUM_SIZE_ALLOWED) {
             throw new InvalidParameterException(Messages.Exception.MANY_NETWORKS_NOT_ALLOWED);
         }
     }
 
-    protected AwsHardwareRequirements findSmallestFlavor(ComputeOrder computeOrder, AwsV2User cloudUser)
+    @VisibleForTesting
+    AwsHardwareRequirements findSmallestFlavor(ComputeOrder computeOrder, AwsV2User cloudUser)
             throws FogbowException {
 
         updateHardwareRequirements(cloudUser);
@@ -355,7 +386,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
      * @param orderRequirements: a map of requirements in the compute order request.
      * @return a set of requirements-filtered flavors or the current set of flavors.
      */
-    protected TreeSet<AwsHardwareRequirements> getFlavorsByRequirements(Map<String, String> orderRequirements) {
+    @VisibleForTesting
+    TreeSet<AwsHardwareRequirements> getFlavorsByRequirements(Map<String, String> orderRequirements) {
         TreeSet<AwsHardwareRequirements> resultSet = getFlavors();
         List<AwsHardwareRequirements> resultList = null;
         if (orderRequirements != null && !orderRequirements.isEmpty()) {
@@ -369,13 +401,15 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return resultSet;
     }
 
-    protected TreeSet<AwsHardwareRequirements> parseToTreeSet(List<AwsHardwareRequirements> list) {
+    @VisibleForTesting
+    TreeSet<AwsHardwareRequirements> parseToTreeSet(List<AwsHardwareRequirements> list) {
         TreeSet<AwsHardwareRequirements> resultSet = new TreeSet<AwsHardwareRequirements>();
         resultSet.addAll(list);
         return resultSet;
     }
 
-    protected List<AwsHardwareRequirements> filterFlavors(TreeSet<AwsHardwareRequirements> flavors,
+    @VisibleForTesting
+    List<AwsHardwareRequirements> filterFlavors(TreeSet<AwsHardwareRequirements> flavors,
             Entry<String, String> requirements) {
 
         String key = requirements.getKey().trim();
@@ -385,7 +419,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
                 .collect(Collectors.toList());
     }
 
-    protected TreeSet<AwsHardwareRequirements> getFlavors() {
+    @VisibleForTesting
+    TreeSet<AwsHardwareRequirements> getFlavors() {
         synchronized (this.flavors) {
             return this.flavors;
         }
@@ -399,7 +434,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
      * @param cloudUser: the user of the AWS cloud.
      * @throws FogbowException: if any error occurs.
      */
-    protected void updateHardwareRequirements(AwsV2User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    void updateHardwareRequirements(AwsV2User cloudUser) throws FogbowException {
         List<String> lines = loadLinesFromFlavorFile();
         String[] requirements = null;
         AwsHardwareRequirements flavor = null;
@@ -416,7 +452,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         }
     }
 
-    protected List<String> loadLinesFromFlavorFile() throws ConfigurationErrorException {
+    @VisibleForTesting
+    List<String> loadLinesFromFlavorFile() throws ConfigurationErrorException {
         String file = getFlavorsFilePath();
         Path path = Paths.get(file);
         try {
@@ -427,7 +464,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         }
     }
 	
-    protected AwsHardwareRequirements buildHardwareRequirements(Entry<String, Integer> imageEntry,
+    @VisibleForTesting
+    AwsHardwareRequirements buildHardwareRequirements(Entry<String, Integer> imageEntry,
             String[] requirements) {
 
         String name = requirements[INSTANCE_TYPE_COLUMN];
@@ -440,7 +478,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return new AwsHardwareRequirements(name, flavorId, cpu, memory.intValue(), disk, imageId, requirementsMap);
     }
 
-    protected Map<String, String> loadRequirementsMap(String[] requirements) {
+    @VisibleForTesting
+    Map<String, String> loadRequirementsMap(String[] requirements) {
         Map<String, String> requirementsMap = new HashMap<String, String>();
         requirementsMap.put(BANDWIDTH_REQUIREMENT, requirements[DEDICATED_EBS_BANDWIDTH_COLUMN]);
         requirementsMap.put(GRAPHIC_EMULATION_REQUIREMENT, requirements[GRAPHIC_EMULATION_COLUMN]);
@@ -453,7 +492,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return requirementsMap;
     }
 
-    protected Map<String, Integer> generateImagesSizeMap(AwsV2User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    Map<String, Integer> generateImagesSizeMap(AwsV2User cloudUser) throws FogbowException {
 
         Map<String, Integer> imageMap = new HashMap<String, Integer>();
         String cloudUserId = cloudUser.getId();
@@ -472,7 +512,8 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
         return imageMap;
     }
 
-    protected int getImageSize(Image image) {
+    @VisibleForTesting
+    int getImageSize(Image image) {
         int size = 0;
         for (BlockDeviceMapping device : image.blockDeviceMappings()) {
             size = device.ebs().volumeSize();
@@ -482,15 +523,18 @@ public class AwsComputePlugin implements ComputePlugin<AwsV2User> {
 
     // The following methods are used to assist in testing.
 	
-    protected String generateFlavorId() {
+    @VisibleForTesting
+    String generateFlavorId() {
         return UUID.randomUUID().toString();
     }
 	
-    protected String getFlavorsFilePath() {
+    @VisibleForTesting
+    String getFlavorsFilePath() {
         return flavorsFilePath;
     }
 	
-    protected void setLaunchCommandGenerator(LaunchCommandGenerator launchCommandGenerator) {
+    @VisibleForTesting
+    void setLaunchCommandGenerator(LaunchCommandGenerator launchCommandGenerator) {
         this.launchCommandGenerator = launchCommandGenerator;
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/image/v2/AwsImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/image/v2/AwsImagePlugin.java
@@ -13,6 +13,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.ImagePlugin;
 import cloud.fogbow.ras.core.plugins.interoperability.aws.AwsV2ClientUtil;
 import cloud.fogbow.ras.core.plugins.interoperability.aws.AwsV2CloudUtil;
 import cloud.fogbow.ras.core.plugins.interoperability.aws.AwsV2ConfigurationPropertyKeys;
+import com.google.common.annotations.VisibleForTesting;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.BlockDeviceMapping;
 import software.amazon.awssdk.services.ec2.model.DescribeImagesRequest;
@@ -23,7 +24,8 @@ public class AwsImagePlugin implements ImagePlugin<AwsV2User> {
 
 	private static final int ONE_THOUSAND_BYTES = 1024;
 	
-	protected static final Integer NO_VALUE_FLAG = -1;
+	@VisibleForTesting
+    static final Integer NO_VALUE_FLAG = -1;
 
     private String region;
 
@@ -57,7 +59,8 @@ public class AwsImagePlugin implements ImagePlugin<AwsV2User> {
         return buildImageInstance(retrievedImage);
     }
     
-	protected ImageInstance buildImageInstance(Image image) {
+	@VisibleForTesting
+    ImageInstance buildImageInstance(Image image) {
         String id = image.imageId();
         String name = image.name();
 		String status = image.stateAsString();
@@ -67,7 +70,8 @@ public class AwsImagePlugin implements ImagePlugin<AwsV2User> {
         return new ImageInstance(id, name, size, minDisk, minRam, status);
     }
 
-    protected long getImageSize(List<BlockDeviceMapping> blockDeviceMappings) {
+    @VisibleForTesting
+    long getImageSize(List<BlockDeviceMapping> blockDeviceMappings) {
     	long kilobyte = ONE_THOUSAND_BYTES;
     	long megabyte = kilobyte * ONE_THOUSAND_BYTES;
     	long gigabyte = megabyte * ONE_THOUSAND_BYTES;
@@ -78,7 +82,8 @@ public class AwsImagePlugin implements ImagePlugin<AwsV2User> {
         return size * gigabyte;
     }
     
-    protected List<ImageSummary> buildImagesSummary(DescribeImagesResponse response) {
+    @VisibleForTesting
+    List<ImageSummary> buildImagesSummary(DescribeImagesResponse response) {
         List<ImageSummary> images = new ArrayList<>();
         
         List<Image> retrievedImages = response.images();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/image/v2/AwsImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/image/v2/AwsImagePlugin.java
@@ -71,11 +71,11 @@ public class AwsImagePlugin implements ImagePlugin<AwsV2User> {
 
     @VisibleForTesting
     long getImageSize(List<BlockDeviceMapping> blockDeviceMappings) {
-    	long size = 0;
+    	long sizeInGB = 0;
         for (BlockDeviceMapping blockDeviceMapping : blockDeviceMappings) {
-            size += blockDeviceMapping.ebs().volumeSize();
+            sizeInGB += blockDeviceMapping.ebs().volumeSize();
         }
-        double sizeInBytes = BinaryUnit.gigabytes(size).asBytes();
+        double sizeInBytes = BinaryUnit.gigabytes(sizeInGB).asBytes();
         return (long) Math.ceil(sizeInBytes);
     }
     

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/image/v2/AwsImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/image/v2/AwsImagePlugin.java
@@ -6,6 +6,7 @@ import java.util.Properties;
 
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.models.AwsV2User;
+import cloud.fogbow.common.util.BinaryUnit;
 import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.ras.api.http.response.ImageInstance;
 import cloud.fogbow.ras.api.http.response.ImageSummary;
@@ -21,8 +22,6 @@ import software.amazon.awssdk.services.ec2.model.DescribeImagesResponse;
 import software.amazon.awssdk.services.ec2.model.Image;
 
 public class AwsImagePlugin implements ImagePlugin<AwsV2User> {
-
-	private static final int ONE_THOUSAND_BYTES = 1024;
 	
 	@VisibleForTesting
     static final Integer NO_VALUE_FLAG = -1;
@@ -72,14 +71,12 @@ public class AwsImagePlugin implements ImagePlugin<AwsV2User> {
 
     @VisibleForTesting
     long getImageSize(List<BlockDeviceMapping> blockDeviceMappings) {
-    	long kilobyte = ONE_THOUSAND_BYTES;
-    	long megabyte = kilobyte * ONE_THOUSAND_BYTES;
-    	long gigabyte = megabyte * ONE_THOUSAND_BYTES;
     	long size = 0;
         for (BlockDeviceMapping blockDeviceMapping : blockDeviceMappings) {
             size += blockDeviceMapping.ebs().volumeSize();
         }
-        return size * gigabyte;
+        double sizeInBytes = BinaryUnit.gigabytes(size).asBytes();
+        return (long) Math.ceil(sizeInBytes);
     }
     
     @VisibleForTesting

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/network/v2/AwsNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/network/v2/AwsNetworkPlugin.java
@@ -55,13 +55,20 @@ public class AwsNetworkPlugin implements NetworkPlugin<AwsV2User> {
 
     private static final Logger LOGGER = Logger.getLogger(AwsNetworkPlugin.class);
 
-    protected static final String ALL_PROTOCOLS = "-1";
-    protected static final String DEFAULT_DESTINATION_CIDR = "0.0.0.0/0";
-    protected static final String GATEWAY_RESOURCE = "Gateway";
-    protected static final String LOCAL_GATEWAY_DESTINATION = "local";
-    protected static final String SECURITY_GROUP_DESCRIPTION = "Security group associated with a fogbow network.";
-    protected static final String SUBNET_RESOURCE = "Subnet";
-    protected static final String VPC_RESOURCE = "VPC";
+    @VisibleForTesting
+    static final String ALL_PROTOCOLS = "-1";
+    @VisibleForTesting
+    static final String DEFAULT_DESTINATION_CIDR = "0.0.0.0/0";
+    @VisibleForTesting
+    static final String GATEWAY_RESOURCE = "Gateway";
+    @VisibleForTesting
+    static final String LOCAL_GATEWAY_DESTINATION = "local";
+    @VisibleForTesting
+    static final String SECURITY_GROUP_DESCRIPTION = "Security group associated with a fogbow network.";
+    @VisibleForTesting
+    static final String SUBNET_RESOURCE = "Subnet";
+    @VisibleForTesting
+    static final String VPC_RESOURCE = "VPC";
 
     private String region;
     private String zone;
@@ -229,7 +236,8 @@ public class AwsNetworkPlugin implements NetworkPlugin<AwsV2User> {
         throw new InstanceNotFoundException(Messages.Exception.INSTANCE_NOT_FOUND);
     }
 
-    protected void doDeleteSubnet(String subnetId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    void doDeleteSubnet(String subnetId, Ec2Client client) throws FogbowException {
         DeleteSubnetRequest request = DeleteSubnetRequest.builder()
                 .subnetId(subnetId)
                 .build();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/network/v2/AwsNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/network/v2/AwsNetworkPlugin.java
@@ -296,7 +296,7 @@ public class AwsNetworkPlugin implements NetworkPlugin<AwsV2User> {
             doModifyVpcAttributes(vpcId, client);
             String gatewayId = doCreateInternetGateway(vpcId, client);
             doAttachInternetGateway(gatewayId, vpcId, client);
-            doCreateRouteTables(cidr, gatewayId, vpcId, client);
+            doCreateRouteTables(gatewayId, vpcId, client);
             return vpcId;
         } catch (SdkException e) {
             throw new InternalServerErrorException(e.getMessage());
@@ -304,7 +304,7 @@ public class AwsNetworkPlugin implements NetworkPlugin<AwsV2User> {
     }
 
     @VisibleForTesting
-    void doCreateRouteTables(String cidr, String gatewayId, String vpcId, Ec2Client client)
+    void doCreateRouteTables(String gatewayId, String vpcId, Ec2Client client)
             throws FogbowException {
 
         RouteTable routeTable = getRouteTables(vpcId, client);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/publicip/v2/AwsPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/publicip/v2/AwsPublicIpPlugin.java
@@ -3,6 +3,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.aws.publicip.v2;
 import java.util.List;
 import java.util.Properties;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
 import cloud.fogbow.common.exceptions.FogbowException;
@@ -43,12 +44,18 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
 
     private static final Logger LOGGER = Logger.getLogger(AwsPublicIpPlugin.class);
 
-    protected static final String AWS_TAG_ASSOCIATION_ID = "associationId";
-    protected static final String DEFAULT_DESTINATION_CIDR = "0.0.0.0/0";
-    protected static final String SECURITY_GROUP_DESCRIPTION = "Security group associated with a fogbow public IP.";
-    protected static final String TCP_PROTOCOL = "tcp";
-    protected static final int PUBLIC_IP_ALLOCATION_NUMBER = 1;
-    protected static final int SSH_DEFAULT_PORT = 22;
+    @VisibleForTesting
+    static final String AWS_TAG_ASSOCIATION_ID = "associationId";
+    @VisibleForTesting
+    static final String DEFAULT_DESTINATION_CIDR = "0.0.0.0/0";
+    @VisibleForTesting
+    static final String SECURITY_GROUP_DESCRIPTION = "Security group associated with a fogbow public IP.";
+    @VisibleForTesting
+    static final String TCP_PROTOCOL = "tcp";
+    @VisibleForTesting
+    static final int PUBLIC_IP_ALLOCATION_NUMBER = 1;
+    @VisibleForTesting
+    static final int SSH_DEFAULT_PORT = 22;
 
     private String defaultGroupId;
     private String region;
@@ -93,7 +100,8 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         return AwsV2StateMapper.map(ResourceType.PUBLIC_IP, instanceState).equals(InstanceState.FAILED);
     }
 
-    protected void doDeleteInstance(String allocationId, String instanceId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    void doDeleteInstance(String allocationId, String instanceId, Ec2Client client) throws FogbowException {
         Address address = AwsV2CloudUtil.getAddressById(allocationId, client);
         String networkInterfaceId = address.networkInterfaceId();
         String defaultGroupId = getDefaultGroupId(instanceId, client);
@@ -124,7 +132,8 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         throw new InternalServerErrorException(Messages.Exception.UNEXPECTED_ERROR);
     }
 
-    protected void doDisassociateAddresses(String associationId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    void doDisassociateAddresses(String associationId, Ec2Client client) throws FogbowException {
         DisassociateAddressRequest request = DisassociateAddressRequest.builder()
                 .associationId(associationId)
                 .build();
@@ -135,12 +144,14 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         }
     }
 
-    protected PublicIpInstance doGetInstance(String allocationId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    PublicIpInstance doGetInstance(String allocationId, Ec2Client client) throws FogbowException {
         Address address = AwsV2CloudUtil.getAddressById(allocationId, client);
         return buildPublicIpInstance(address);
     }
 
-    protected PublicIpInstance buildPublicIpInstance(Address address) {
+    @VisibleForTesting
+    PublicIpInstance buildPublicIpInstance(Address address) {
         String id = address.allocationId();
         String cloudState = setPublicIpInstanceState(address);
         String ip = address.publicIp();
@@ -148,14 +159,16 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         return publicIpInstance;
     }
     
-    protected String setPublicIpInstanceState(Address address) {
+    @VisibleForTesting
+    String setPublicIpInstanceState(Address address) {
         if (address.instanceId() != null) {
             return AwsV2StateMapper.AVAILABLE_STATE;
         }
         return AwsV2StateMapper.ERROR_STATE;
     }
 
-    protected String doRequestInstance(PublicIpOrder order, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    String doRequestInstance(PublicIpOrder order, Ec2Client client) throws FogbowException {
         String allocationId = doAllocateAddresses(client);
         String computeId = order.getComputeId();
         Instance instance = getInstanceReservation(computeId, client);
@@ -166,7 +179,8 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         return allocationId;
     }
 
-    protected void doAssociateAddress(String allocationId, String networkInterfaceId, Ec2Client client)
+    @VisibleForTesting
+    void doAssociateAddress(String allocationId, String networkInterfaceId, Ec2Client client)
             throws FogbowException {
 
         AssociateAddressRequest request = AssociateAddressRequest.builder()
@@ -182,7 +196,8 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         }
     }
 
-    protected String getDefaultGroupId(String instanceId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    String getDefaultGroupId(String instanceId, Ec2Client client) throws FogbowException {
         Instance instance = getInstanceReservation(instanceId, client);
         String subnetId = instance.subnetId();
         Subnet subnet = AwsV2CloudUtil.getSubnetById(subnetId, client);
@@ -190,7 +205,8 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         return AwsV2CloudUtil.getGroupIdFrom(subnetTags);
     }
 
-    protected void doModifyNetworkInterfaceAttributes(String allocationId, String groupId, String networkInterfaceId,
+    @VisibleForTesting
+    void doModifyNetworkInterfaceAttributes(String allocationId, String groupId, String networkInterfaceId,
             Ec2Client client) throws FogbowException {
 
         ModifyNetworkInterfaceAttributeRequest request = ModifyNetworkInterfaceAttributeRequest.builder()
@@ -211,7 +227,8 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         }
     }
 
-    protected void doReleaseAddresses(String allocationId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    void doReleaseAddresses(String allocationId, Ec2Client client) throws FogbowException {
         ReleaseAddressRequest request = ReleaseAddressRequest.builder()
                 .allocationId(allocationId)
                 .build();
@@ -222,11 +239,13 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         }
     }
 
-    protected String getNetworkInterfaceIdFrom(Instance instance) {
+    @VisibleForTesting
+    String getNetworkInterfaceIdFrom(Instance instance) {
         return instance.networkInterfaces().listIterator().next().networkInterfaceId();
     }
 
-    protected String handleSecurityIssues(String allocationId, Instance instance, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    String handleSecurityIssues(String allocationId, Instance instance, Ec2Client client) throws FogbowException {
         String groupName = SystemConstants.PIP_SECURITY_GROUP_PREFIX + allocationId;
         String vpcId = instance.vpcId();
         try {
@@ -249,7 +268,8 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         }
     }
     
-    protected Instance getInstanceReservation(String instanceId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    Instance getInstanceReservation(String instanceId, Ec2Client client) throws FogbowException {
         DescribeInstancesResponse response = AwsV2CloudUtil.doDescribeInstanceById(instanceId, client);
         if (response != null && !response.reservations().isEmpty()) {
             Reservation reservation = response.reservations().listIterator().next();
@@ -260,7 +280,8 @@ public class AwsPublicIpPlugin implements PublicIpPlugin<AwsV2User> {
         throw new InstanceNotFoundException(Messages.Exception.INSTANCE_NOT_FOUND);
     }
 
-    protected String doAllocateAddresses(Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    String doAllocateAddresses(Ec2Client client) throws FogbowException {
         AllocateAddressRequest request = AllocateAddressRequest.builder()
                 .domain(DomainType.VPC)
                 .build();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPlugin.java
@@ -12,6 +12,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import cloud.fogbow.common.constants.FogbowConstants;
+import cloud.fogbow.common.util.BinaryUnit;
 import cloud.fogbow.ras.api.http.response.quotas.ResourceQuota;
 import cloud.fogbow.ras.api.http.response.quotas.allocation.ResourceAllocation;
 import cloud.fogbow.ras.core.plugins.interoperability.QuotaPlugin;
@@ -55,8 +56,6 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     static final int MEMORY_COLUMN = 2;
     @VisibleForTesting
     static final int LIMITS_COLUMN = 11;
-    @VisibleForTesting
-    static final int ONE_GIGABYTE = 1024;
 
     public static int maximumStorage;
     public static int maximumNetworks;
@@ -245,8 +244,9 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     ComputeAllocation buildAvailableInstance(@NotNull String[] requirements) {
         int instances = Integer.parseInt(requirements[LIMITS_COLUMN]);
         int vCPU = Integer.parseInt(requirements[VCPU_COLUMN]);
-        Double memory = Double.parseDouble(requirements[MEMORY_COLUMN]) * ONE_GIGABYTE;
-        int ram = memory.intValue();
+        Double memoryInGB = Double.parseDouble(requirements[MEMORY_COLUMN]);
+        double memoryInMB = BinaryUnit.gigabytes(memoryInGB).asMegabytes();
+        int ram = (int) Math.ceil(memoryInMB);
         return new ComputeAllocation(instances, vCPU, ram);
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPlugin.java
@@ -42,14 +42,21 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
 
     private static final Logger LOGGER = Logger.getLogger(AwsQuotaPlugin.class);
 
-    protected static final String COMMENTED_LINE_PREFIX = "#";
-    protected static final String CSV_COLUMN_SEPARATOR = ",";
+    @VisibleForTesting
+    static final String COMMENTED_LINE_PREFIX = "#";
+    @VisibleForTesting
+    static final String CSV_COLUMN_SEPARATOR = ",";
 
-    protected static final int INSTANCE_TYPE_COLUMN = 0;
-    protected static final int VCPU_COLUMN = 1;
-    protected static final int MEMORY_COLUMN = 2;
-    protected static final int LIMITS_COLUMN = 11;
-    protected static final int ONE_GIGABYTE = 1024;
+    @VisibleForTesting
+    static final int INSTANCE_TYPE_COLUMN = 0;
+    @VisibleForTesting
+    static final int VCPU_COLUMN = 1;
+    @VisibleForTesting
+    static final int MEMORY_COLUMN = 2;
+    @VisibleForTesting
+    static final int LIMITS_COLUMN = 11;
+    @VisibleForTesting
+    static final int ONE_GIGABYTE = 1024;
 
     public static int maximumStorage;
     public static int maximumNetworks;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPlugin.java
@@ -66,7 +66,7 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     private String flavorsFilePath;
     private String region;
 
-    public AwsQuotaPlugin(@NotNull String confFilePath) {
+    public AwsQuotaPlugin(String confFilePath) {
         Properties properties = PropertiesUtil.readProperties(confFilePath);
         maximumStorage = Integer.parseInt(properties.getProperty(AwsV2ConfigurationPropertyKeys.AWS_STORAGE_QUOTA_KEY));
         maximumNetworks = Integer.parseInt(properties.getProperty(AwsV2ConfigurationPropertyKeys.AWS_VPC_QUOTA_KEY));
@@ -78,7 +78,7 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     }
 
     @Override
-    public ResourceQuota getUserQuota(@NotNull AwsV2User cloudUser) throws FogbowException {
+    public ResourceQuota getUserQuota(AwsV2User cloudUser) throws FogbowException {
         Ec2Client client = AwsV2ClientUtil.createEc2Client(cloudUser.getToken(), this.region);
 
         loadAvailableAllocations();
@@ -90,7 +90,7 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     }
 
     @VisibleForTesting
-    ResourceAllocation calculateUsedQuota(@NotNull Ec2Client client) throws FogbowException {
+    ResourceAllocation calculateUsedQuota(Ec2Client client) throws FogbowException {
         ComputeAllocation computeAllocation = this.calculateComputeUsedQuota();
         int storage = this.calculateUsedStorage(client);
         int elasticIps = this.calculateUsedElasticIp(client);
@@ -117,20 +117,20 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     }
 
     @VisibleForTesting
-    int calculateUsedNetworks(@NotNull Ec2Client client) throws FogbowException {
+    int calculateUsedNetworks(Ec2Client client) throws FogbowException {
         List<Vpc> vpcs = client.describeVpcs().vpcs();
         return vpcs.size();
     }
 
     @VisibleForTesting
-    int calculateUsedElasticIp(@NotNull Ec2Client client) throws FogbowException {
+    int calculateUsedElasticIp(Ec2Client client) throws FogbowException {
         DescribeAddressesRequest request = DescribeAddressesRequest.builder().build();
         DescribeAddressesResponse response = AwsV2CloudUtil.doDescribeAddressesRequests(request, client);
         return response.addresses().size();
     }
 
     @VisibleForTesting
-    int calculateUsedStorage(@NotNull Ec2Client client) throws FogbowException {
+    int calculateUsedStorage(Ec2Client client) throws FogbowException {
         DescribeVolumesRequest request = DescribeVolumesRequest.builder().build();
         DescribeVolumesResponse response = AwsV2CloudUtil.doDescribeVolumesRequest(request, client);
         return getAllVolumesSize(response.volumes());
@@ -182,7 +182,7 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     }
 
     @VisibleForTesting
-    void loadInstancesAllocated(@NotNull Ec2Client client) throws FogbowException {
+    void loadInstancesAllocated(Ec2Client client) throws FogbowException {
         List<Instance> instances = getInstanceReservations(client);
         ComputeAllocation allocation;
         if (!instances.isEmpty()) {
@@ -195,7 +195,7 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     }
 
     @VisibleForTesting
-    ComputeAllocation buildAllocatedInstance(@NotNull Instance instance, @NotNull Ec2Client client) throws FogbowException {
+    ComputeAllocation buildAllocatedInstance(Instance instance, Ec2Client client) throws FogbowException {
         String instanceType = instance.instanceTypeAsString();
         ComputeAllocation totalAllocation = getTotalComputeAllocationMap().get(instanceType);
         ComputeAllocation allocatedInstance = getComputeAllocationMap().get(instanceType);
@@ -206,7 +206,7 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     }
 
     @VisibleForTesting
-    int getAllVolumesSize(@NotNull List<Volume> volumes) {
+    int getAllVolumesSize(List<Volume> volumes) {
         int size = 0;
         for (Volume volume : volumes) {
             size += volume.size();
@@ -215,7 +215,7 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     }
 
     @VisibleForTesting
-    List<Instance> getInstanceReservations(@NotNull Ec2Client client) throws FogbowException {
+    List<Instance> getInstanceReservations(Ec2Client client) throws FogbowException {
         DescribeInstancesResponse response = AwsV2CloudUtil.doDescribeInstances(client);
         List<Instance> instances = new ArrayList<>();
         for (Reservation reservation : response.reservations()) {
@@ -241,7 +241,7 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     }
 
     @VisibleForTesting
-    ComputeAllocation buildAvailableInstance(@NotNull String[] requirements) {
+    ComputeAllocation buildAvailableInstance(String[] requirements) {
         int instances = Integer.parseInt(requirements[LIMITS_COLUMN]);
         int vCPU = Integer.parseInt(requirements[VCPU_COLUMN]);
         Double memoryInGB = Double.parseDouble(requirements[MEMORY_COLUMN]);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPlugin.java
@@ -24,14 +24,11 @@ import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.models.AwsV2User;
 import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.ras.api.http.response.quotas.allocation.ComputeAllocation;
-import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.plugins.interoperability.aws.AwsV2ClientUtil;
 import cloud.fogbow.ras.core.plugins.interoperability.aws.AwsV2CloudUtil;
 import cloud.fogbow.ras.core.plugins.interoperability.aws.AwsV2ConfigurationPropertyKeys;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.*;
-
-import javax.validation.constraints.NotNull;
 
 /**
  * This class calculates the quota of available instances according to the
@@ -117,7 +114,7 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
     }
 
     @VisibleForTesting
-    int calculateUsedNetworks(Ec2Client client) throws FogbowException {
+    int calculateUsedNetworks(Ec2Client client) {
         List<Vpc> vpcs = client.describeVpcs().vpcs();
         return vpcs.size();
     }
@@ -188,14 +185,14 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
         if (!instances.isEmpty()) {
             for (Instance instance : instances) {
                 String instanceType = instance.instanceTypeAsString();
-                allocation = buildAllocatedInstance(instance, client);
+                allocation = buildAllocatedInstance(instance);
                 this.computeAllocationMap.put(instanceType, allocation);
             }
         }
     }
 
     @VisibleForTesting
-    ComputeAllocation buildAllocatedInstance(Instance instance, Ec2Client client) throws FogbowException {
+    ComputeAllocation buildAllocatedInstance(Instance instance) {
         String instanceType = instance.instanceTypeAsString();
         ComputeAllocation totalAllocation = getTotalComputeAllocationMap().get(instanceType);
         ComputeAllocation allocatedInstance = getComputeAllocationMap().get(instanceType);
@@ -261,8 +258,6 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
             throw new ConfigurationErrorException(e.getMessage());
         }
     }
-
-    // These methods are used to assist in testing.
 
     @VisibleForTesting
     Map<String, ComputeAllocation> getTotalComputeAllocationMap() {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPlugin.java
@@ -73,8 +73,8 @@ public class AwsQuotaPlugin implements QuotaPlugin<AwsV2User> {
         maximumPublicIpAddresses = Integer.parseInt(properties.getProperty(AwsV2ConfigurationPropertyKeys.AWS_ELASTIC_IP_ADDRESSES_QUOTA_KEY));
         this.region = properties.getProperty(AwsV2ConfigurationPropertyKeys.AWS_REGION_SELECTION_KEY);
         this.flavorsFilePath = properties.getProperty(AwsV2ConfigurationPropertyKeys.AWS_FLAVORS_TYPES_FILE_PATH_KEY);
-        this.totalComputeAllocationMap = new HashMap<String, ComputeAllocation>();
-        this.computeAllocationMap = new HashMap<String, ComputeAllocation>();
+        this.totalComputeAllocationMap = new HashMap<>();
+        this.computeAllocationMap = new HashMap<>();
     }
 
     @Override

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/securityrule/v2/AwsSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/securityrule/v2/AwsSecurityRulePlugin.java
@@ -7,6 +7,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import cloud.fogbow.common.exceptions.InternalServerErrorException;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
 import cloud.fogbow.common.constants.AwsConstants;
@@ -58,11 +59,15 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
     private static final int SECURITY_RULE_ID_FIELDS_NUMBER = 8;
     private static final int TYPE_FIELD_POSITION = 7;
     
-    protected static final String ALL_PROTOCOLS = "-1";
-    protected static final String CIDR_SEPARATOR = "/";
-    protected static final String SECURITY_RULE_IDENTIFIER_FORMAT = "%s@%s@%s@%s@%s@%s@%s@%s";
+    @VisibleForTesting
+    static final String ALL_PROTOCOLS = "-1";
+    @VisibleForTesting
+    static final String CIDR_SEPARATOR = "/";
+    @VisibleForTesting
+    static final String SECURITY_RULE_IDENTIFIER_FORMAT = "%s@%s@%s@%s@%s@%s@%s@%s";
     
-    protected static final int FIRST_POSITION = 0;
+    @VisibleForTesting
+    static final int FIRST_POSITION = 0;
     
     private String region;
 
@@ -98,7 +103,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         doDeleteSecurityRule(securityRuleId, client);
     }
 
-    protected void doDeleteSecurityRule(String securityRuleId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    void doDeleteSecurityRule(String securityRuleId, Ec2Client client) throws FogbowException {
         String instanceId = extractFieldFrom(securityRuleId, FIRST_POSITION);
         String type = extractFieldFrom(securityRuleId, TYPE_FIELD_POSITION);
         ResourceType resourceType = type.equals(PUBLIC_IP_RESOURCE_TYPE) 
@@ -117,7 +123,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         }
     }
 
-    protected void revokeEgressRule(String groupId, SecurityRule rule, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    void revokeEgressRule(String groupId, SecurityRule rule, Ec2Client client) throws FogbowException {
         IpPermission ipPermission = buildIpPermission(rule);
 
         RevokeSecurityGroupEgressRequest request = RevokeSecurityGroupEgressRequest.builder()
@@ -131,7 +138,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         }
     }
 
-    protected void revokeIngressRule(String groupId, SecurityRule rule, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    void revokeIngressRule(String groupId, SecurityRule rule, Ec2Client client) throws FogbowException {
         IpPermission ipPermission = buildIpPermission(rule);
 
         RevokeSecurityGroupIngressRequest request = RevokeSecurityGroupIngressRequest.builder()
@@ -145,7 +153,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         }
     }
 
-    protected SecurityRule doUnpackingSecurityRuleId(String securityRuleId) {
+    @VisibleForTesting
+    SecurityRule doUnpackingSecurityRuleId(String securityRuleId) {
         String[] fields = securityRuleId.split(AwsConstants.SECURITY_RULE_ID_SEPARATOR);
         if (fields.length == SECURITY_RULE_ID_FIELDS_NUMBER) {
             int portFrom = Integer.valueOf(fields[PORT_FROM_FIELD_POSITION]);
@@ -159,13 +168,15 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         throw new InvalidParameterException(String.format(Messages.Exception.INVALID_PARAMETER_S, securityRuleId));
     }
 
-    protected Direction getDirectionValueFrom(String fieldValue) {
+    @VisibleForTesting
+    Direction getDirectionValueFrom(String fieldValue) {
         return Direction.valueOf(fieldValue.equals(INGRESS_VALUE) 
                 ? INGRESS_DIRECTION 
                 : EGRESS_DIRECTION);
     }
     
-    protected String extractFieldFrom(String securityRuleId, int position) {
+    @VisibleForTesting
+    String extractFieldFrom(String securityRuleId, int position) {
         String[] fields = securityRuleId.split(AwsConstants.SECURITY_RULE_ID_SEPARATOR);
         if (fields.length == SECURITY_RULE_ID_FIELDS_NUMBER) {
             return fields[position];
@@ -173,7 +184,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         throw new InvalidParameterException(String.format(Messages.Exception.INVALID_PARAMETER_S, securityRuleId));
     }
     
-    protected List<SecurityRuleInstance> doGetSecurityRules(String instanceId, ResourceType resourceType,
+    @VisibleForTesting
+    List<SecurityRuleInstance> doGetSecurityRules(String instanceId, ResourceType resourceType,
             Ec2Client client) throws FogbowException {
 
         String securityGroupId = getSecurityGroupId(instanceId, resourceType, client);
@@ -188,7 +200,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         return resultList;
     }
     
-    protected List<SecurityRuleInstance> loadSecurityRuleInstances(String instanceId, ResourceType resourceType,
+    @VisibleForTesting
+    List<SecurityRuleInstance> loadSecurityRuleInstances(String instanceId, ResourceType resourceType,
             Direction direction, List<IpPermission> ipPermissions) {
         
         List<SecurityRuleInstance> instancesList = new ArrayList<>();
@@ -205,7 +218,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         return instancesList;
     }
     
-    protected SecurityRuleInstance buildSecurityRuleInstance(String instanceId, ResourceType resourceType,
+    @VisibleForTesting
+    SecurityRuleInstance buildSecurityRuleInstance(String instanceId, ResourceType resourceType,
             Direction direction, IpPermission ipPermission) {
         
         int portFrom = ipPermission.fromPort();
@@ -218,20 +232,23 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         return new SecurityRuleInstance(id, direction, portFrom, portTo, cidr, etherType, protocol);
     }
     
-    protected Protocol getProtocolFrom(String ipProtocol) {
+    @VisibleForTesting
+    Protocol getProtocolFrom(String ipProtocol) {
         return ipProtocol == ALL_PROTOCOLS 
                 ? Protocol.ANY 
                 : Protocol.valueOf(ipProtocol.toUpperCase());
     }
 
-    protected boolean validateIpPermission(IpPermission ipPermission) {
+    @VisibleForTesting
+    boolean validateIpPermission(IpPermission ipPermission) {
         return ipPermission.fromPort() != null 
                 && ipPermission.toPort() != null 
                 && ipPermission.ipProtocol() != null
                 && !ipPermission.ipRanges().isEmpty();
     }
     
-    protected SecurityGroup getSecurityGroupById(String groupId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    SecurityGroup getSecurityGroupById(String groupId, Ec2Client client) throws FogbowException {
         DescribeSecurityGroupsRequest request = DescribeSecurityGroupsRequest.builder()
                 .groupIds(groupId)
                 .build();
@@ -240,7 +257,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         return getSecurityGroupFrom(response);
     }
 
-    protected SecurityGroup getSecurityGroupFrom(DescribeSecurityGroupsResponse response)
+    @VisibleForTesting
+    SecurityGroup getSecurityGroupFrom(DescribeSecurityGroupsResponse response)
             throws FogbowException {
         
         if (response != null && !response.securityGroups().isEmpty()) {
@@ -249,7 +267,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         throw new InstanceNotFoundException(Messages.Exception.INSTANCE_NOT_FOUND);
     }
 
-    protected DescribeSecurityGroupsResponse doDescribeSecurityGroupsRequest(DescribeSecurityGroupsRequest request,
+    @VisibleForTesting
+    DescribeSecurityGroupsResponse doDescribeSecurityGroupsRequest(DescribeSecurityGroupsRequest request,
             Ec2Client client) throws FogbowException {
         try {
             return client.describeSecurityGroups(request);
@@ -258,7 +277,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         }
     }
     
-    protected String doPackingSecurityRuleId(String instanceId, SecurityRule securityRule, ResourceType resourceType) {
+    @VisibleForTesting
+    String doPackingSecurityRuleId(String instanceId, SecurityRule securityRule, ResourceType resourceType) {
         String[] cidrSlice = securityRule.getCidr().split(CIDR_SEPARATOR);
         String securityRuleId = String.format(SECURITY_RULE_IDENTIFIER_FORMAT, 
                 instanceId, 
@@ -273,7 +293,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         return securityRuleId;
     }
     
-    protected void addRuleToSecurityGroup(String groupId, SecurityRule securityRule, Ec2Client client)
+    @VisibleForTesting
+    void addRuleToSecurityGroup(String groupId, SecurityRule securityRule, Ec2Client client)
             throws FogbowException {
         
         IpPermission ipPermission = buildIpPermission(securityRule);
@@ -288,7 +309,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         }
     }
 
-    protected void addEgressRule(String groupId, IpPermission ipPermission, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    void addEgressRule(String groupId, IpPermission ipPermission, Ec2Client client) throws FogbowException {
         AuthorizeSecurityGroupEgressRequest request = AuthorizeSecurityGroupEgressRequest.builder()
                 .groupId(groupId)
                 .ipPermissions(ipPermission)
@@ -300,7 +322,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         }
     }
     
-    protected void addIngressRule(String groupId, IpPermission ipPermission, Ec2Client client)
+    @VisibleForTesting
+    void addIngressRule(String groupId, IpPermission ipPermission, Ec2Client client)
             throws FogbowException {
         
         AuthorizeSecurityGroupIngressRequest request = AuthorizeSecurityGroupIngressRequest.builder()
@@ -314,7 +337,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         }
     }
     
-    protected IpPermission buildIpPermission(SecurityRule securityRule) {
+    @VisibleForTesting
+    IpPermission buildIpPermission(SecurityRule securityRule) {
         int fromPort = securityRule.getPortFrom();
         int toPort = securityRule.getPortTo();
         String ipProtocol = defineIpProtocolFrom(securityRule.getProtocol());
@@ -331,13 +355,15 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         return ipPermission;
     }
 
-    protected String defineIpProtocolFrom(Protocol protocol) {
+    @VisibleForTesting
+    String defineIpProtocolFrom(Protocol protocol) {
         return protocol.equals(Protocol.ANY) 
                 ? ALL_PROTOCOLS
                 : protocol.toString();
     }
     
-    protected IpRange buildIpAddressRange(SecurityRule securityRule) {
+    @VisibleForTesting
+    IpRange buildIpAddressRange(SecurityRule securityRule) {
         String cidrIp = securityRule.getCidr();
         validateIpAddress(cidrIp);
         
@@ -348,7 +374,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         return ipRange;
     }
     
-    protected void validateIpAddress(String cidrIp) {
+    @VisibleForTesting
+    void validateIpAddress(String cidrIp) {
         Ipv4AddressValidator validator = new Ipv4AddressValidator();
         String[] cidrSlice = cidrIp.split(CIDR_SEPARATOR);
         String ipAddress = cidrSlice[0];
@@ -357,7 +384,8 @@ public class AwsSecurityRulePlugin implements SecurityRulePlugin<AwsV2User> {
         }
     }
     
-    protected String getSecurityGroupId(String instanceId, ResourceType resourceType, Ec2Client client)
+    @VisibleForTesting
+    String getSecurityGroupId(String instanceId, ResourceType resourceType, Ec2Client client)
             throws FogbowException {
 
         switch (resourceType) {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/volume/v2/AwsVolumePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/aws/volume/v2/AwsVolumePlugin.java
@@ -3,6 +3,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.aws.volume.v2;
 import java.util.Properties;
 
 import cloud.fogbow.common.exceptions.InternalServerErrorException;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
 import cloud.fogbow.common.exceptions.FogbowException;
@@ -81,7 +82,8 @@ public class AwsVolumePlugin implements VolumePlugin<AwsV2User> {
 		doDeleteInstance(volumeId, client);
 	}
 
-	protected void doDeleteInstance(String volumeId, Ec2Client client) throws InternalServerErrorException {
+	@VisibleForTesting
+    void doDeleteInstance(String volumeId, Ec2Client client) throws InternalServerErrorException {
 	    DeleteVolumeRequest request = DeleteVolumeRequest.builder()
 	            .volumeId(volumeId)
 	            .build();
@@ -93,7 +95,8 @@ public class AwsVolumePlugin implements VolumePlugin<AwsV2User> {
 		}
 	}
 	
-    protected VolumeInstance doGetInstance(String volumeId, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    VolumeInstance doGetInstance(String volumeId, Ec2Client client) throws FogbowException {
         DescribeVolumesRequest request = DescribeVolumesRequest.builder()
                 .volumeIds(volumeId)
                 .build();
@@ -102,7 +105,8 @@ public class AwsVolumePlugin implements VolumePlugin<AwsV2User> {
         return buildVolumeInstance(response);
     }
 
-    protected VolumeInstance buildVolumeInstance(DescribeVolumesResponse response) throws FogbowException {
+    @VisibleForTesting
+    VolumeInstance buildVolumeInstance(DescribeVolumesResponse response) throws FogbowException {
         Volume volume = AwsV2CloudUtil.getVolumeFrom(response);
         String id = volume.volumeId();
         String cloudState = volume.stateAsString();
@@ -111,7 +115,8 @@ public class AwsVolumePlugin implements VolumePlugin<AwsV2User> {
         return new VolumeInstance(id, cloudState, name, size);
     }
 	
-    protected String doRequestInstance(CreateVolumeRequest request, VolumeOrder order, Ec2Client client) throws FogbowException {
+    @VisibleForTesting
+    String doRequestInstance(CreateVolumeRequest request, VolumeOrder order, Ec2Client client) throws FogbowException {
         String volumeId;
         try {
             CreateVolumeResponse response = client.createVolume(request);
@@ -124,7 +129,8 @@ public class AwsVolumePlugin implements VolumePlugin<AwsV2User> {
         return volumeId;
     }
 
-    protected void updateVolumeAllocation(VolumeOrder volumeOrder, CreateVolumeResponse volumeResponse) {
+    @VisibleForTesting
+    void updateVolumeAllocation(VolumeOrder volumeOrder, CreateVolumeResponse volumeResponse) {
         synchronized (volumeOrder) {
             VolumeAllocation actualAllocation = new VolumeAllocation(volumeResponse.size());
             volumeOrder.setActualAllocation(actualAllocation);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePluginTest.java
@@ -11,8 +11,7 @@ import java.util.Map.Entry;
 import java.util.TreeSet;
 
 import cloud.fogbow.common.exceptions.*;
-import cloud.fogbow.common.util.StorageUnit;
-import com.google.common.annotations.VisibleForTesting;
+import cloud.fogbow.common.util.BinaryUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +60,7 @@ public class AwsComputePluginTest extends BaseUnitTests {
     private static final int FLAVOR_MEMORY_VALUE = 1;
     private static final int INSTANCE_TYPE_LIMIT_VALUE = 5;
     private static final int ZERO_VALUE = 0;
-    final int ONE_GIGABYTE = (int) StorageUnit.gigabyte(1).asMegabyte();
+    final int ONE_GIGABYTE = (int) BinaryUnit.gigabytes(1).asMegabytes();
     
     private AwsComputePlugin plugin;
     private Ec2Client client;

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/compute/v2/AwsComputePluginTest.java
@@ -11,6 +11,8 @@ import java.util.Map.Entry;
 import java.util.TreeSet;
 
 import cloud.fogbow.common.exceptions.*;
+import cloud.fogbow.common.util.StorageUnit;
+import com.google.common.annotations.VisibleForTesting;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,7 +61,8 @@ public class AwsComputePluginTest extends BaseUnitTests {
     private static final int FLAVOR_MEMORY_VALUE = 1;
     private static final int INSTANCE_TYPE_LIMIT_VALUE = 5;
     private static final int ZERO_VALUE = 0;
-	
+    final int ONE_GIGABYTE = (int) StorageUnit.gigabyte(1).asMegabyte();
+    
     private AwsComputePlugin plugin;
     private Ec2Client client;
     private LaunchCommandGenerator launchCommandGenerator;
@@ -320,7 +323,7 @@ public class AwsComputePluginTest extends BaseUnitTests {
         Mockito.doReturn(FLAVOR_MEMORY_VALUE).when(this.plugin).getMemoryValueFrom(Mockito.eq(instance.instanceType()));
 
         List<Volume> volumes = createVolumesCollection();
-        Mockito.doReturn(AwsComputePlugin.ONE_GIGABYTE).when(this.plugin).getAllDisksSize(Mockito.eq(volumes));
+        Mockito.doReturn(ONE_GIGABYTE).when(this.plugin).getAllDisksSize(Mockito.eq(volumes));
 
         List<String> ipAddresses = buildIpAdressesCollection();
         Mockito.doReturn(ipAddresses).when(this.plugin).getIpAddresses(Mockito.eq(instance));
@@ -441,7 +444,7 @@ public class AwsComputePluginTest extends BaseUnitTests {
     public void testGetAllDisksSize() {
         // set up
         List volumes = createVolumesCollection();
-        int expected = AwsComputePlugin.ONE_GIGABYTE;
+        int expected = ONE_GIGABYTE;
         
         // exercise
         int size = this.plugin.getAllDisksSize(volumes);
@@ -563,7 +566,7 @@ public class AwsComputePluginTest extends BaseUnitTests {
         Image image = buildImage();
 
         Mockito.doReturn(image).when(this.plugin).getImageById(Mockito.eq(imageId), Mockito.eq(client));
-        Mockito.doReturn(AwsComputePlugin.ONE_GIGABYTE).when(this.plugin).getImageSize(Mockito.eq(image));
+        Mockito.doReturn(ONE_GIGABYTE).when(this.plugin).getImageSize(Mockito.eq(image));
 
         // exercise
         this.plugin.updateInstanceAllocation(order, flavor, instance, client);
@@ -1059,7 +1062,7 @@ public class AwsComputePluginTest extends BaseUnitTests {
 
     private EbsBlockDevice buildEbsBlockDevice() {
         EbsBlockDevice ebsBlockDevice = EbsBlockDevice.builder()
-                .volumeSize(AwsComputePlugin.ONE_GIGABYTE)
+                .volumeSize(ONE_GIGABYTE)
                 .build();
         
         return ebsBlockDevice;
@@ -1096,7 +1099,7 @@ public class AwsComputePluginTest extends BaseUnitTests {
         Volume[] volumes = { 
                 Volume.builder()
                     .volumeId(TestUtils.FAKE_VOLUME_ID)
-                    .size(AwsComputePlugin.ONE_GIGABYTE)
+                    .size(ONE_GIGABYTE)
                     .build() 
                 };
         return Arrays.asList(volumes);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/network/v2/AwsNetworkPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/network/v2/AwsNetworkPluginTest.java
@@ -749,7 +749,7 @@ public class AwsNetworkPluginTest extends BaseUnitTests {
 
         Mockito.doNothing().when(this.plugin).doAttachInternetGateway(Mockito.eq(gatewayId), Mockito.eq(vpcId),
                 Mockito.eq(this.client));
-        Mockito.doNothing().when(this.plugin).doCreateRouteTables(Mockito.eq(cidr), Mockito.eq(gatewayId),
+        Mockito.doNothing().when(this.plugin).doCreateRouteTables(Mockito.eq(gatewayId),
                 Mockito.eq(vpcId), Mockito.eq(this.client));
 
         // exercise
@@ -762,8 +762,8 @@ public class AwsNetworkPluginTest extends BaseUnitTests {
                 Mockito.eq(this.client));
         Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).doAttachInternetGateway(Mockito.eq(gatewayId),
                 Mockito.eq(vpcId), Mockito.eq(this.client));
-        Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).doCreateRouteTables(Mockito.eq(cidr),
-                Mockito.eq(gatewayId), Mockito.eq(vpcId), Mockito.eq(this.client));
+        Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).doCreateRouteTables(Mockito.eq(gatewayId),
+                Mockito.eq(vpcId), Mockito.eq(this.client));
     }
 
     // test case: When calling the doCreateAndConfigureVpc method, and an
@@ -806,7 +806,7 @@ public class AwsNetworkPluginTest extends BaseUnitTests {
         Mockito.when(this.client.createRoute(Mockito.any(CreateRouteRequest.class))).thenReturn(response);
 
         // exercise
-        this.plugin.doCreateRouteTables(cidr, gatewayId, vpcId, this.client);
+        this.plugin.doCreateRouteTables(gatewayId, vpcId, this.client);
 
         // verify
         Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).getRouteTables(Mockito.eq(vpcId),
@@ -839,7 +839,7 @@ public class AwsNetworkPluginTest extends BaseUnitTests {
 
         try {
             // exercise
-            this.plugin.doCreateRouteTables(cidr, gatewayId, vpcId, this.client);
+            this.plugin.doCreateRouteTables(gatewayId, vpcId, this.client);
             Assert.fail();
         } catch (InternalServerErrorException e) {
             // verify

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/aws/quota/v2/AwsQuotaPluginTest.java
@@ -7,7 +7,6 @@ import cloud.fogbow.common.util.HomeDir;
 import cloud.fogbow.ras.api.http.response.quotas.ResourceQuota;
 import cloud.fogbow.ras.api.http.response.quotas.allocation.ComputeAllocation;
 import cloud.fogbow.ras.api.http.response.quotas.allocation.ResourceAllocation;
-import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.constants.SystemConstants;
 import cloud.fogbow.ras.core.BaseUnitTests;
 import cloud.fogbow.ras.core.TestUtils;
@@ -292,8 +291,7 @@ public class AwsQuotaPluginTest extends BaseUnitTests {
 
         Instance instance = instances.listIterator().next();
         ComputeAllocation allocation = createComputeAllocation();
-        Mockito.doReturn(allocation).when(this.plugin).buildAllocatedInstance(Mockito.eq(instance),
-                Mockito.eq(this.client));
+        Mockito.doReturn(allocation).when(this.plugin).buildAllocatedInstance(Mockito.eq(instance));
 
         String expectedMapKey = InstanceType.T1_MICRO.toString();
 
@@ -302,8 +300,7 @@ public class AwsQuotaPluginTest extends BaseUnitTests {
 
         // verify
         Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).getInstanceReservations(Mockito.eq(this.client));
-        Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).buildAllocatedInstance(Mockito.eq(instance),
-                Mockito.eq(this.client));
+        Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).buildAllocatedInstance(Mockito.eq(instance));
 
         Assert.assertTrue(this.plugin.getComputeAllocationMap().containsKey(expectedMapKey));
         Assert.assertEquals(allocation, this.plugin.getComputeAllocationMap().get(expectedMapKey));
@@ -396,7 +393,7 @@ public class AwsQuotaPluginTest extends BaseUnitTests {
         int ramExpected = TestUtils.MEMORY_VALUE;
 
         // exercise
-        ComputeAllocation allocation = this.plugin.buildAllocatedInstance(instance, this.client);
+        ComputeAllocation allocation = this.plugin.buildAllocatedInstance(instance);
 
         // verify
         Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).getTotalComputeAllocationMap();


### PR DESCRIPTION
This pull request refactors the AWS plugins

Requires https://github.com/fogbow/common/pull/166

- **[All interoperability plugins]** Change protected for default visibility and add @VisibleForTesting annotation
- **[ImagePlugin]** Change local byte conversion implementation for a common one (requires https://github.com/fogbow/common/pull/166)
- **[NetworkPlugin]** Remove unused parameters.
- **[QuotaPlugin]** Change local byte conversion implementation for a common one (requires https://github.com/fogbow/common/pull/166)
- **[QuotaPlugin]** Remove @NotNull annotations.
- **[QuotaPlugin]** Remove unused code.
- **[StateMapper]** Update hardcoded constants holding class names for a call on class.getSimpleName()