### PR TITLE
Cloudstack and OpenNebula intraplugin refactor

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackStateMapper.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/CloudStackStateMapper.java
@@ -3,6 +3,11 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack;
 import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.models.ResourceType;
 import cloud.fogbow.ras.api.http.response.InstanceState;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.attachment.v4_9.CloudStackAttachmentPlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.compute.v4_9.CloudStackComputePlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.network.v4_9.CloudStackNetworkPlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.publicip.v4_9.CloudStackPublicIpPlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.cloudstack.volume.v4_9.CloudStackVolumePlugin;
 import org.apache.log4j.Logger;
 
 /**
@@ -11,6 +16,12 @@ import org.apache.log4j.Logger;
 
 public class CloudStackStateMapper {
     private static final Logger LOGGER = Logger.getLogger(CloudStackStateMapper.class);
+
+    public static final String COMPUTE_PLUGIN = CloudStackComputePlugin.class.getSimpleName();
+    public static final String VOLUME_PLUGIN = CloudStackVolumePlugin.class.getSimpleName();
+    public static final String ATTACHMENT_PLUGIN = CloudStackAttachmentPlugin.class.getSimpleName();
+    public static final String NETWORK_PLUGIN = CloudStackNetworkPlugin.class.getSimpleName();
+    public static final String PUBLIC_IP_PLUGIN = CloudStackPublicIpPlugin.class.getSimpleName();
 
     public static final String ASSOCIATING_IP_ADDRESS_STATUS = "associating IP address";
     public static final String CREATING_FIREWALL_RULE_STATUS = "creating firewall rule";
@@ -54,7 +65,7 @@ public class CloudStackStateMapper {
                         return InstanceState.FAILED;
                     default:
                         LOGGER.error(String.format(Messages.Log.UNDEFINED_INSTANCE_STATE_MAPPING_S_S, cloudStackState,
-                                "CloudStackComputePlugin"));
+                                COMPUTE_PLUGIN));
                         return InstanceState.INCONSISTENT;
                 }
             case VOLUME:
@@ -69,7 +80,7 @@ public class CloudStackStateMapper {
                         return InstanceState.FAILED;
                     default:
                         LOGGER.error(String.format(Messages.Log.UNDEFINED_INSTANCE_STATE_MAPPING_S_S, cloudStackState,
-                                "CloudStackVolumePlugin"));
+                                VOLUME_PLUGIN));
                         return InstanceState.INCONSISTENT;
                 }
             case ATTACHMENT:
@@ -83,7 +94,7 @@ public class CloudStackStateMapper {
                         return InstanceState.FAILED;
                     default:
                         LOGGER.error(String.format(Messages.Log.UNDEFINED_INSTANCE_STATE_MAPPING_S_S, cloudStackState,
-                                "CloudStackAttachmentPlugin"));
+                                ATTACHMENT_PLUGIN));
                         return InstanceState.INCONSISTENT;
                 }
             case NETWORK:
@@ -98,7 +109,7 @@ public class CloudStackStateMapper {
                         return InstanceState.BUSY;
                     default:
                         LOGGER.error(String.format(Messages.Log.UNDEFINED_INSTANCE_STATE_MAPPING_S_S, cloudStackState,
-                                "CloudStackNetworkPlugin"));
+                                NETWORK_PLUGIN));
                         return InstanceState.INCONSISTENT;
                 }
             case PUBLIC_IP:
@@ -113,7 +124,7 @@ public class CloudStackStateMapper {
                         return InstanceState.FAILED;
                     default:
                         LOGGER.error(String.format(Messages.Log.UNDEFINED_INSTANCE_STATE_MAPPING_S_S, cloudStackState,
-                                "CloudStackPublicIpPlugin"));
+                                PUBLIC_IP_PLUGIN));
                         return InstanceState.INCONSISTENT;
                 }
             default:

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/attachment/v4_9/CloudStackAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/attachment/v4_9/CloudStackAttachmentPlugin.java
@@ -53,8 +53,8 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
     }
 
     @Override
-    public String requestInstance(@NotNull AttachmentOrder attachmentOrder,
-                                  @NotNull CloudStackUser cloudStackUser)
+    public String requestInstance(AttachmentOrder attachmentOrder,
+                                  CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
@@ -70,8 +70,8 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
     }
 
     @Override
-    public void deleteInstance(@NotNull AttachmentOrder attachmentOrder,
-                               @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+    public void deleteInstance(AttachmentOrder attachmentOrder,
+                               CloudStackUser cloudStackUser) throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, attachmentOrder.getInstanceId()));
 
@@ -84,8 +84,8 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
     }
 
     @Override
-    public AttachmentInstance getInstance(@NotNull AttachmentOrder attachmentOrder,
-                                          @NotNull CloudStackUser cloudStackUser)
+    public AttachmentInstance getInstance(AttachmentOrder attachmentOrder,
+                                          CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, attachmentOrder.getInstanceId()));
@@ -98,11 +98,10 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
         return doGetInstance(attachmentOrder, request, cloudStackUser);
     }
 
-    @NotNull
     @VisibleForTesting
-    AttachmentInstance doGetInstance(@NotNull AttachmentOrder attachmentOrder,
-                                     @NotNull AttachmentJobStatusRequest request,
-                                     @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+    AttachmentInstance doGetInstance(AttachmentOrder attachmentOrder,
+                                     AttachmentJobStatusRequest request,
+                                     CloudStackUser cloudStackUser) throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
         CloudStackUrlUtil.sign(uriRequest, cloudStackUser.getToken());
@@ -113,8 +112,8 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
     }
 
     @VisibleForTesting
-    void doDeleteInstance(@NotNull DetachVolumeRequest request ,
-                          @NotNull CloudStackUser cloudStackUser)
+    void doDeleteInstance(DetachVolumeRequest request ,
+                          CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -124,10 +123,9 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
         DetachVolumeResponse.fromJson(jsonResponse);
     }
 
-    @NotNull
     @VisibleForTesting
-    String doRequestInstance(@NotNull AttachVolumeRequest request,
-                             @NotNull CloudStackUser cloudStackUser)
+    String doRequestInstance(AttachVolumeRequest request,
+                             CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -138,12 +136,11 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
         return response.getJobId();
     }
 
-    @NotNull
     @VisibleForTesting
     AttachmentInstance createInstanceByJobStatus(
-            @NotNull AttachmentOrder attachmentOrder,
-            @NotNull AttachmentJobStatusResponse response,
-            @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+            AttachmentOrder attachmentOrder,
+            AttachmentJobStatusResponse response,
+            CloudStackUser cloudStackUser) throws FogbowException {
         
         int status = response.getJobStatus();
         switch (status) {
@@ -168,11 +165,10 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
         }
     }
 
-    @NotNull
     @VisibleForTesting
     void checkVolumeAttached(
-            @NotNull AttachmentOrder attachmentOrder,
-            @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+            AttachmentOrder attachmentOrder,
+            CloudStackUser cloudStackUser) throws FogbowException {
 
         GetVolumeRequest request = buildGetVolumeRequest(attachmentOrder);
         URIBuilder uriRequest = request.getUriBuilder();
@@ -196,15 +192,14 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
     }
 
     @VisibleForTesting
-    void logFailure(@NotNull AttachmentJobStatusResponse response) throws InternalServerErrorException {
+    void logFailure(AttachmentJobStatusResponse response) throws InternalServerErrorException {
         CloudStackErrorResponse errorResponse = response.getErrorResponse();
         String errorText = String.format(FAILED_ATTACH_ERROR_MESSAGE,
                 errorResponse.getErrorCode(), errorResponse.getErrorText());
         LOGGER.error(String.format(Messages.Log.ERROR_WHILE_ATTACHING_VOLUME_GENERAL_S, errorText));
     }
 
-    @NotNull
-    private AttachmentInstance createCompleteInstance(@NotNull AttachmentJobStatusResponse.Volume volume) {
+    private AttachmentInstance createCompleteInstance(AttachmentJobStatusResponse.Volume volume) {
         String source = volume.getVirtualMachineId();
         String target = volume.getId();
         String jobId = volume.getJobId();
@@ -214,7 +209,6 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
         return new AttachmentInstance(jobId, state, source, target, device);
     }
 
-    @NotNull
     private AttachmentInstance createInstance(String attachmentInstanceId, String state) {
         return new AttachmentInstance(attachmentInstanceId, state,null, null, null);
     }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/attachment/v4_9/CloudStackAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/attachment/v4_9/CloudStackAttachmentPlugin.java
@@ -24,8 +24,6 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.log4j.Logger;
 
-import javax.validation.constraints.NotNull;
-
 import java.util.Properties;
 
 public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUser> {
@@ -157,7 +155,7 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
                  */
                 checkVolumeAttached(attachmentOrder, cloudStackUser);
                 AttachmentJobStatusResponse.Volume volume = response.getVolume();
-                return createCompleteInstance(volume);
+                return buildAttachmentInstance(volume);
             case CloudStackCloudUtils.JOB_STATUS_FAILURE:
                 logFailure(response);
                 return createInstance(response.getJobId(), CloudStackCloudUtils.FAILURE_STATE);
@@ -200,7 +198,7 @@ public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUs
         LOGGER.error(String.format(Messages.Log.ERROR_WHILE_ATTACHING_VOLUME_GENERAL_S, errorText));
     }
 
-    private AttachmentInstance createCompleteInstance(AttachmentJobStatusResponse.Volume volume) {
+    private AttachmentInstance buildAttachmentInstance(AttachmentJobStatusResponse.Volume volume) {
         String source = volume.getVirtualMachineId();
         String target = volume.getId();
         String jobId = volume.getJobId();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/attachment/v4_9/CloudStackAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/attachment/v4_9/CloudStackAttachmentPlugin.java
@@ -31,7 +31,8 @@ import java.util.Properties;
 public class CloudStackAttachmentPlugin implements AttachmentPlugin<CloudStackUser> {
     private static final Logger LOGGER = Logger.getLogger(CloudStackAttachmentPlugin.class);
 
-    protected static final String FAILED_ATTACH_ERROR_MESSAGE = "code: %s, description: %s.";
+    @VisibleForTesting
+    static final String FAILED_ATTACH_ERROR_MESSAGE = "code: %s, description: %s.";
 
     private CloudStackHttpClient client;
     private String cloudStackUrl;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/CloudStackComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/CloudStackComputePlugin.java
@@ -75,7 +75,7 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     }
 
     @Override
-    public String requestInstance(@NotNull ComputeOrder computeOrder, @NotNull CloudStackUser cloudUser)
+    public String requestInstance(ComputeOrder computeOrder, CloudStackUser cloudUser)
             throws FogbowException {
 
         String templateId = getTemplateId(computeOrder);
@@ -101,8 +101,8 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     }
 
     @Override
-    public ComputeInstance getInstance(@NotNull ComputeOrder order,
-                                       @NotNull CloudStackUser cloudUser)
+    public ComputeInstance getInstance(ComputeOrder order,
+                                       CloudStackUser cloudUser)
             throws FogbowException {
 
         GetVirtualMachineRequest request = new GetVirtualMachineRequest.Builder()
@@ -113,7 +113,7 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     }
 
     @Override
-    public void deleteInstance(@NotNull ComputeOrder order, @NotNull CloudStackUser cloudUser)
+    public void deleteInstance(ComputeOrder order, CloudStackUser cloudUser)
             throws FogbowException {
 
         DestroyVirtualMachineRequest request = new DestroyVirtualMachineRequest.Builder()
@@ -124,22 +124,20 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         doDeleteInstance(request, cloudUser, order.getInstanceId());
     }
 
-    @NotNull
     @VisibleForTesting
-    ComputeInstance doGetInstance(@NotNull GetVirtualMachineRequest request,
-                                  @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+    ComputeInstance doGetInstance(GetVirtualMachineRequest request,
+                                  CloudStackUser cloudStackUser) throws FogbowException {
 
         GetVirtualMachineResponse response = requestGetVirtualMachine(request, cloudStackUser);
         return buildComputeInstance(response, cloudStackUser);
     }
 
-    @NotNull
     @VisibleForTesting
-    String doRequestInstance(@NotNull DeployVirtualMachineRequest request,
-                             @NotNull GetAllServiceOfferingsResponse.ServiceOffering serviceOffering,
-                             @NotNull String diskSize,
-                             @NotNull ComputeOrder computeOrder,
-                             @NotNull CloudStackUser cloudUser) throws FogbowException {
+    String doRequestInstance(DeployVirtualMachineRequest request,
+                             GetAllServiceOfferingsResponse.ServiceOffering serviceOffering,
+                             String diskSize,
+                             ComputeOrder computeOrder,
+                             CloudStackUser cloudUser) throws FogbowException {
 
         DeployVirtualMachineResponse response = requestDeployVirtualMachine(request, cloudUser);
         updateComputeOrder(computeOrder, serviceOffering, diskSize);
@@ -147,8 +145,8 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    void doDeleteInstance(@NotNull DestroyVirtualMachineRequest request,
-                          @NotNull CloudStackUser cloudStackUser, String instanceId)
+    void doDeleteInstance(DestroyVirtualMachineRequest request,
+                          CloudStackUser cloudStackUser, String instanceId)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -164,10 +162,9 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         }
     }
 
-    @NotNull
     @VisibleForTesting
     GetAllServiceOfferingsResponse.ServiceOffering getServiceOffering(
-            @NotNull ComputeOrder computeOrder, @NotNull CloudStackUser cloudUser)
+            ComputeOrder computeOrder, CloudStackUser cloudUser)
             throws FogbowException {
 
         GetAllServiceOfferingsResponse response = getServiceOfferings(cloudUser);
@@ -191,8 +188,8 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
 
     @VisibleForTesting
     List<GetAllServiceOfferingsResponse.ServiceOffering> filterServicesOfferingByRequirements(
-            @NotNull List<GetAllServiceOfferingsResponse.ServiceOffering> serviceOfferings,
-            @NotNull ComputeOrder computeOrder) {
+            List<GetAllServiceOfferingsResponse.ServiceOffering> serviceOfferings,
+            ComputeOrder computeOrder) {
 
         List<GetAllServiceOfferingsResponse.ServiceOffering> serviceOfferingsFilted = serviceOfferings;
         Map<String, String> requirements = computeOrder.getRequirements();
@@ -214,9 +211,8 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         return serviceOfferingsFilted;
     }
 
-    @NotNull
     @VisibleForTesting
-    GetAllServiceOfferingsResponse getServiceOfferings(@NotNull CloudStackUser cloudStackUser)
+    GetAllServiceOfferingsResponse getServiceOfferings(CloudStackUser cloudStackUser)
             throws FogbowException {
 
         GetAllServiceOfferingsRequest request = new GetAllServiceOfferingsRequest.Builder()
@@ -229,9 +225,8 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         return GetAllServiceOfferingsResponse.fromJson(jsonResponse);
     }
 
-    @NotNull
     @VisibleForTesting
-    GetAllDiskOfferingsResponse getDiskOfferings(@NotNull CloudStackUser cloudUser)
+    GetAllDiskOfferingsResponse getDiskOfferings(CloudStackUser cloudUser)
             throws FogbowException {
 
         GetAllDiskOfferingsRequest request = new GetAllDiskOfferingsRequest.Builder()
@@ -244,9 +239,8 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         return GetAllDiskOfferingsResponse.fromJson(jsonResponse);
     }
 
-    @NotNull
     @VisibleForTesting
-    String normalizeNetworksID(@NotNull ComputeOrder computeOrder) {
+    String normalizeNetworksID(ComputeOrder computeOrder) {
         List<String> networks = new ArrayList<>();
         networks.add(this.defaultNetworkId);
         List<String> userDefinedNetworks = computeOrder.getNetworkIds();
@@ -256,16 +250,14 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         return StringUtils.join(networks, ",");
     }
 
-    @NotNull
     @VisibleForTesting
     String normalizeInstanceName(String instanceName) {
         return instanceName != null ? instanceName
                 : SystemConstants.FOGBOW_INSTANCE_NAME_PREFIX + getRandomUUID();
     }
 
-    @NotNull
     @VisibleForTesting
-    ComputeInstance createComputeInstance(@NotNull GetVirtualMachineResponse.VirtualMachine virtualMachine,
+    ComputeInstance createComputeInstance(GetVirtualMachineResponse.VirtualMachine virtualMachine,
                                           int disk) {
 
         String instanceId = virtualMachine.getId();
@@ -293,7 +285,7 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    int getVirtualMachineDiskSize(String virtualMachineId, @NotNull CloudStackUser cloudUser) {
+    int getVirtualMachineDiskSize(String virtualMachineId, CloudStackUser cloudUser) {
         try {
             GetVolumeRequest request = new GetVolumeRequest.Builder()
                     .virtualMachineId(virtualMachineId)
@@ -319,9 +311,8 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         return UNKNOWN_DISK_VALUE;
     }
 
-    @NotNull
     @VisibleForTesting
-    String doGet(String url, @NotNull CloudStackUser cloudUser) throws FogbowException {
+    String doGet(String url, CloudStackUser cloudUser) throws FogbowException {
         return this.client.doGetRequest(url, cloudUser);
     }
 
@@ -331,9 +322,9 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    void updateComputeOrder(@NotNull ComputeOrder computeOrder,
-                            @NotNull GetAllServiceOfferingsResponse.ServiceOffering serviceOffering,
-                            @NotNull String diskSize) {
+    void updateComputeOrder(ComputeOrder computeOrder,
+                            GetAllServiceOfferingsResponse.ServiceOffering serviceOffering,
+                            String diskSize) {
 
         synchronized (computeOrder) {
             int disk = Integer.parseInt(diskSize);
@@ -345,11 +336,10 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         }
     }
 
-    @NotNull
     @VisibleForTesting
     DeployVirtualMachineResponse requestDeployVirtualMachine(
-            @NotNull DeployVirtualMachineRequest request,
-            @NotNull CloudStackUser cloudUser)
+            DeployVirtualMachineRequest request,
+            CloudStackUser cloudUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -360,10 +350,9 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         return DeployVirtualMachineResponse.fromJson(jsonResponse);
     }
 
-    @NotNull
     @VisibleForTesting
-    GetVirtualMachineResponse requestGetVirtualMachine(@NotNull GetVirtualMachineRequest request,
-                                                       @NotNull CloudStackUser cloudStackUser)
+    GetVirtualMachineResponse requestGetVirtualMachine(GetVirtualMachineRequest request,
+                                                       CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -374,10 +363,9 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         return GetVirtualMachineResponse.fromJson(jsonResponse);
     }
 
-    @NotNull
     @VisibleForTesting
-    ComputeInstance buildComputeInstance(@NotNull GetVirtualMachineResponse response,
-                                         @NotNull CloudStackUser cloudStackUser)
+    ComputeInstance buildComputeInstance(GetVirtualMachineResponse response,
+                                         CloudStackUser cloudStackUser)
             throws InstanceNotFoundException {
 
         List<GetVirtualMachineResponse.VirtualMachine> virtualMachines = response.getVirtualMachines();
@@ -390,9 +378,8 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
         }
     }
 
-    @NotNull
     @VisibleForTesting
-    String getTemplateId(@NotNull ComputeOrder computeOrder) throws InvalidParameterException {
+    String getTemplateId(ComputeOrder computeOrder) throws InvalidParameterException {
         String templateId = computeOrder.getImageId();
         if (templateId == null || templateId.isEmpty()) {
             throw new InvalidParameterException(Messages.Exception.UNABLE_TO_COMPLETE_REQUEST_CLOUDSTACK);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/CloudStackComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/CloudStackComputePlugin.java
@@ -2,6 +2,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.cloudstack.compute.v4_9;
 
 import cloud.fogbow.common.exceptions.*;
 import cloud.fogbow.common.models.CloudStackUser;
+import cloud.fogbow.common.util.BinaryUnit;
 import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackHttpClient;
 import cloud.fogbow.common.util.connectivity.cloud.cloudstack.CloudStackUrlUtil;
@@ -314,7 +315,7 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
             if (!volumes.isEmpty()) {
                 GetVolumeResponse.Volume firstVolume = volumes.get(0);
                 long sizeInBytes = firstVolume.getSize();
-                return convertBytesToGigabyte(sizeInBytes);
+                return (int) BinaryUnit.bytes(sizeInBytes).asGigabytes();
             }
         } catch (Exception e) {
             LOGGER.debug(Messages.Log.ERROR_WHILE_GETTING_DISK_SIZE, e);
@@ -326,11 +327,6 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     @VisibleForTesting
     String doGet(String url, CloudStackUser cloudUser) throws FogbowException {
         return this.client.doGetRequest(url, cloudUser);
-    }
-
-    @VisibleForTesting
-    int convertBytesToGigabyte(long bytes) {
-        return (int) (bytes / GIGABYTE_IN_BYTES);
     }
 
     @VisibleForTesting

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/CloudStackComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/CloudStackComputePlugin.java
@@ -34,17 +34,25 @@ import java.util.stream.Collectors;
 public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     private static final Logger LOGGER = Logger.getLogger(CloudStackComputePlugin.class);
 
-    protected static final String EXPUNGE_ON_DESTROY_KEY_CONF = "expunge_on_destroy";
-    protected static final String CLOUDSTACK_URL_CONF = "cloudstack_api_url";
-    protected static final String ZONE_ID_KEY_CONF = "zone_id";
+    @VisibleForTesting
+    static final String EXPUNGE_ON_DESTROY_KEY_CONF = "expunge_on_destroy";
+    @VisibleForTesting
+    static final String CLOUDSTACK_URL_CONF = "cloudstack_api_url";
+    @VisibleForTesting
+    static final String ZONE_ID_KEY_CONF = "zone_id";
 
     private static final String DEFAULT_EXPUNGE_ON_DEPLOY_VALUE = "true";
-    protected static final String DEFAULT_VOLUME_TYPE_VALUE = "ROOT";
-    protected static final int UNKNOWN_DISK_VALUE = -1;
+    @VisibleForTesting
+    static final String DEFAULT_VOLUME_TYPE_VALUE = "ROOT";
+    @VisibleForTesting
+    static final int UNKNOWN_DISK_VALUE = -1;
 
-    protected static final String FOGBOW_TAG_SEPARATOR = ":";
-    protected static final double GIGABYTE_IN_BYTES = Math.pow(1024, 3);
-    protected static final int AMOUNT_INSTANCE = 1;
+    @VisibleForTesting
+    static final String FOGBOW_TAG_SEPARATOR = ":";
+    @VisibleForTesting
+    static final double GIGABYTE_IN_BYTES = Math.pow(1024, 3);
+    @VisibleForTesting
+    static final int AMOUNT_INSTANCE = 1;
 
     private LaunchCommandGenerator launchCommandGenerator;
     private CloudStackHttpClient client;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/CloudStackComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/compute/v4_9/CloudStackComputePlugin.java
@@ -85,7 +85,7 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     @Override
     public String requestInstance(ComputeOrder computeOrder, CloudStackUser cloudUser)
             throws FogbowException {
-
+        LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
         String templateId = getTemplateId(computeOrder);
         String userData = this.launchCommandGenerator.createLaunchCommand(computeOrder);
         String networksId = normalizeNetworksID(computeOrder);
@@ -112,9 +112,11 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     public ComputeInstance getInstance(ComputeOrder order,
                                        CloudStackUser cloudUser)
             throws FogbowException {
+        String instanceId = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
 
         GetVirtualMachineRequest request = new GetVirtualMachineRequest.Builder()
-                .id(order.getInstanceId())
+                .id(instanceId)
                 .build(this.cloudStackUrl);
 
         return doGetInstance(request, cloudUser);
@@ -123,13 +125,15 @@ public class CloudStackComputePlugin implements ComputePlugin<CloudStackUser> {
     @Override
     public void deleteInstance(ComputeOrder order, CloudStackUser cloudUser)
             throws FogbowException {
+        String instanceId = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
 
         DestroyVirtualMachineRequest request = new DestroyVirtualMachineRequest.Builder()
-                .id(order.getInstanceId())
+                .id(instanceId)
                 .expunge(this.expungeOnDestroy)
                 .build(this.cloudStackUrl);
 
-        doDeleteInstance(request, cloudUser, order.getInstanceId());
+        doDeleteInstance(request, cloudUser, instanceId);
     }
 
     @VisibleForTesting

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/image/v4_9/CloudStackImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/image/v4_9/CloudStackImagePlugin.java
@@ -23,9 +23,12 @@ import java.util.Properties;
 public class CloudStackImagePlugin implements ImagePlugin<CloudStackUser> {
     private static final Logger LOGGER = Logger.getLogger(CloudStackImagePlugin.class);
 
-    protected static final int DEFAULT_MIN_DISK_VALUE = -1;
-    protected static final int DEFAULT_MIN_RAM_VALUE = -1;
-    protected static final String DEFAULT_STATUS_VALUE = null;
+    @VisibleForTesting
+    static final int DEFAULT_MIN_DISK_VALUE = -1;
+    @VisibleForTesting
+    static final int DEFAULT_MIN_RAM_VALUE = -1;
+    @VisibleForTesting
+    static final String DEFAULT_STATUS_VALUE = null;
 
     private String cloudStackUrl;
     private CloudStackHttpClient client;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/image/v4_9/CloudStackImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/image/v4_9/CloudStackImagePlugin.java
@@ -55,7 +55,7 @@ public class CloudStackImagePlugin implements ImagePlugin<CloudStackUser> {
     public ImageInstance getImage(String imageId, CloudStackUser cloudStackUser)
             throws FogbowException {
 
-        LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
+        LOGGER.info(String.format(Messages.Log.RECEIVING_GET_IMAGE_REQUEST_S, imageId));
 
         GetAllImagesRequest request = new GetAllImagesRequest.Builder()
                 .id(imageId)

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/image/v4_9/CloudStackImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/image/v4_9/CloudStackImagePlugin.java
@@ -37,7 +37,7 @@ public class CloudStackImagePlugin implements ImagePlugin<CloudStackUser> {
     }
 
     @Override
-    public List<ImageSummary> getAllImages(@NotNull CloudStackUser cloudStackUser)
+    public List<ImageSummary> getAllImages(CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(Messages.Log.REQUESTING_GET_ALL_FROM_PROVIDER);
@@ -49,7 +49,7 @@ public class CloudStackImagePlugin implements ImagePlugin<CloudStackUser> {
     }
 
     @Override
-    public ImageInstance getImage(String imageId, @VisibleForTesting CloudStackUser cloudStackUser)
+    public ImageInstance getImage(String imageId, CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
@@ -61,10 +61,9 @@ public class CloudStackImagePlugin implements ImagePlugin<CloudStackUser> {
         return buildImageInstance(request, cloudStackUser);
     }
 
-    @NotNull
     @VisibleForTesting
-    ImageInstance buildImageInstance(@NotNull GetAllImagesRequest request,
-                                     @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+    ImageInstance buildImageInstance(GetAllImagesRequest request,
+                                     CloudStackUser cloudStackUser) throws FogbowException {
 
         GetAllImagesResponse response = doDescribeImagesRequest(request, cloudStackUser);
         List<GetAllImagesResponse.Image> images = response.getImages();
@@ -78,10 +77,9 @@ public class CloudStackImagePlugin implements ImagePlugin<CloudStackUser> {
                 DEFAULT_MIN_DISK_VALUE, DEFAULT_MIN_RAM_VALUE, DEFAULT_STATUS_VALUE);
     }
 
-    @NotNull
     @VisibleForTesting
-    List<ImageSummary> buildImagesSummary(@NotNull GetAllImagesRequest request,
-                                          @NotNull CloudStackUser cloudStackUser)
+    List<ImageSummary> buildImagesSummary(GetAllImagesRequest request,
+                                          CloudStackUser cloudStackUser)
             throws FogbowException {
 
         GetAllImagesResponse response = doDescribeImagesRequest(request, cloudStackUser);
@@ -96,10 +94,9 @@ public class CloudStackImagePlugin implements ImagePlugin<CloudStackUser> {
         return idToImageNames;
     }
 
-    @NotNull
     @VisibleForTesting
-    GetAllImagesResponse doDescribeImagesRequest(@NotNull GetAllImagesRequest request,
-                                                 @NotNull CloudStackUser cloudStackUser)
+    GetAllImagesResponse doDescribeImagesRequest(GetAllImagesRequest request,
+                                                 CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/network/v4_9/CloudStackNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/network/v4_9/CloudStackNetworkPlugin.java
@@ -53,8 +53,8 @@ public class CloudStackNetworkPlugin implements NetworkPlugin<CloudStackUser> {
     }
 
     @Override
-    public String requestInstance(@NotNull NetworkOrder networkOrder,
-                                  @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+    public String requestInstance(NetworkOrder networkOrder,
+                                  CloudStackUser cloudStackUser) throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER));
         SubnetUtils.SubnetInfo subnetInfo = getSubnetInfo(networkOrder.getCidr());
@@ -78,8 +78,8 @@ public class CloudStackNetworkPlugin implements NetworkPlugin<CloudStackUser> {
     }
 
     @Override
-    public NetworkInstance getInstance(@NotNull NetworkOrder networkOrder,
-                                       @NotNull CloudStackUser cloudStackUser)
+    public NetworkInstance getInstance(NetworkOrder networkOrder,
+                                       CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, networkOrder.getInstanceId()));
@@ -91,8 +91,8 @@ public class CloudStackNetworkPlugin implements NetworkPlugin<CloudStackUser> {
     }
 
     @Override
-    public void deleteInstance(@NotNull NetworkOrder networkOrder,
-                               @NotNull CloudStackUser cloudStackUser)
+    public void deleteInstance(NetworkOrder networkOrder,
+                               CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, networkOrder.getInstanceId()));
@@ -104,8 +104,8 @@ public class CloudStackNetworkPlugin implements NetworkPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    void doDeleteInstance(@NotNull DeleteNetworkRequest request,
-                          @NotNull CloudStackUser cloudStackUser)
+    void doDeleteInstance(DeleteNetworkRequest request,
+                          CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -114,10 +114,9 @@ public class CloudStackNetworkPlugin implements NetworkPlugin<CloudStackUser> {
         CloudStackCloudUtils.doRequest(this.client, uriRequest.toString(), cloudStackUser);
     }
 
-    @NotNull
     @VisibleForTesting
-    NetworkInstance doGetInstance(@NotNull GetNetworkRequest request,
-                                  @NotNull CloudStackUser cloudStackUser)
+    NetworkInstance doGetInstance(GetNetworkRequest request,
+                                  CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -129,10 +128,9 @@ public class CloudStackNetworkPlugin implements NetworkPlugin<CloudStackUser> {
         return getNetworkInstance(response);
     }
 
-    @NotNull
     @VisibleForTesting
-    String doRequestInstance(@NotNull CreateNetworkRequest createNetworkRequest,
-                             @NotNull CloudStackUser cloudStackUser)
+    String doRequestInstance(CreateNetworkRequest createNetworkRequest,
+                             CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = createNetworkRequest.getUriBuilder();
@@ -143,7 +141,6 @@ public class CloudStackNetworkPlugin implements NetworkPlugin<CloudStackUser> {
         return response.getId();
     }
 
-    @NotNull
     @VisibleForTesting
     SubnetUtils.SubnetInfo getSubnetInfo(String cidrNotation) throws InvalidParameterException {
         try {
@@ -153,9 +150,8 @@ public class CloudStackNetworkPlugin implements NetworkPlugin<CloudStackUser> {
         }
     }
 
-    @NotNull
     @VisibleForTesting
-    NetworkInstance getNetworkInstance(@NotNull GetNetworkResponse response)
+    NetworkInstance getNetworkInstance(GetNetworkResponse response)
             throws InstanceNotFoundException {
 
         List<GetNetworkResponse.Network> networks = response.getNetworks();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/publicip/v4_9/CloudStackPublicIpPlugin.java
@@ -61,8 +61,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     @Override
-    public String requestInstance(@NotNull PublicIpOrder publicIpOrder,
-                                  @NotNull CloudStackUser cloudStackUser)
+    public String requestInstance(PublicIpOrder publicIpOrder,
+                                  CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
@@ -71,8 +71,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     @Override
-    public PublicIpInstance getInstance(@NotNull PublicIpOrder publicIpOrder,
-                                        @NotNull CloudStackUser cloudStackUser)
+    public PublicIpInstance getInstance(PublicIpOrder publicIpOrder,
+                                        CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, publicIpOrder.getInstanceId()));
@@ -80,17 +80,16 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     @Override
-    public void deleteInstance(@NotNull PublicIpOrder publicIpOrder, @NotNull CloudStackUser cloudStackUser)
+    public void deleteInstance(PublicIpOrder publicIpOrder, CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, publicIpOrder.getInstanceId()));
         doDeleteInstance(publicIpOrder, cloudStackUser);
     }
 
-    @NotNull
     @VisibleForTesting
-    public String doRequestInstance(@NotNull PublicIpOrder publicIpOrder,
-                                    @NotNull CloudStackUser cloudStackUser)
+    public String doRequestInstance(PublicIpOrder publicIpOrder,
+                                    CloudStackUser cloudStackUser)
             throws FogbowException {
 
         AssociateIpAddressRequest request = new AssociateIpAddressRequest.Builder()
@@ -103,7 +102,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     @VisibleForTesting
-    void doDeleteInstance(@NotNull PublicIpOrder publicIpOrder, @NotNull CloudStackUser cloudStackUser)
+    void doDeleteInstance(PublicIpOrder publicIpOrder, CloudStackUser cloudStackUser)
             throws FogbowException {
 
         String instanceId = getInstanceId(publicIpOrder);
@@ -121,8 +120,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     @VisibleForTesting
-    void requestDisassociateIpAddress(@NotNull DisassociateIpAddressRequest request,
-                                      @NotNull CloudStackUser cloudStackUser)
+    void requestDisassociateIpAddress(DisassociateIpAddressRequest request,
+                                      CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -131,10 +130,9 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         CloudStackCloudUtils.doRequest(this.client, uriRequest.toString(), cloudStackUser);
     }
 
-    @NotNull
     @VisibleForTesting
-    PublicIpInstance doGetInstance(@NotNull PublicIpOrder publicIpOrder,
-                                   @NotNull CloudStackUser cloudStackUser)
+    PublicIpInstance doGetInstance(PublicIpOrder publicIpOrder,
+                                   CloudStackUser cloudStackUser)
             throws FogbowException {
 
         String instanceId = getInstanceId(publicIpOrder);
@@ -161,11 +159,10 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
      * Retrieve the current Cloudstack asynchronous job and treat the next operation of the
      * asynchronous request instance flow.
      */
-    @NotNull
     @VisibleForTesting
-    PublicIpInstance createCurrentPublicIpInstance(@NotNull AsyncRequestInstanceState asyncRequestInstanceState,
-                                                  @NotNull PublicIpOrder publicIpOrder,
-                                                  @NotNull CloudStackUser cloudStackUser)
+    PublicIpInstance createCurrentPublicIpInstance(AsyncRequestInstanceState asyncRequestInstanceState,
+                                                  PublicIpOrder publicIpOrder,
+                                                  CloudStackUser cloudStackUser)
             throws FogbowException {
 
         String currentJobId = asyncRequestInstanceState.getCurrentJobId();
@@ -201,10 +198,9 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     /**
      * Execute the next operation of the asynchronous request instance flow.
      */
-    @NotNull
     @VisibleForTesting
-    PublicIpInstance createNextOperationPublicIpInstance(@NotNull AsyncRequestInstanceState asyncRequestInstanceState,
-                                                        @NotNull CloudStackUser cloudStackUser,
+    PublicIpInstance createNextOperationPublicIpInstance(AsyncRequestInstanceState asyncRequestInstanceState,
+                                                        CloudStackUser cloudStackUser,
                                                         String jsonResponse)
             throws FogbowException {
 
@@ -223,8 +219,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     @VisibleForTesting
-    void doCreatingFirewallOperation(@NotNull AsyncRequestInstanceState asyncRequestInstanceState,
-                                     @NotNull CloudStackUser cloudStackUser,
+    void doCreatingFirewallOperation(AsyncRequestInstanceState asyncRequestInstanceState,
+                                     CloudStackUser cloudStackUser,
                                      String jsonResponse)
             throws FogbowException {
 
@@ -242,7 +238,7 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
      * wait the asynchronous Associating Ip Address Operation finishes in the Cloudstack.
      */
     @VisibleForTesting
-    void setAsyncRequestInstanceFirstStep(String jobId, @NotNull PublicIpOrder publicIpOrder) {
+    void setAsyncRequestInstanceFirstStep(String jobId, PublicIpOrder publicIpOrder) {
         String computeId = publicIpOrder.getComputeId();
         String instanceId = getInstanceId(publicIpOrder);
         AsyncRequestInstanceState asyncRequestInstanceState = new AsyncRequestInstanceState(
@@ -258,8 +254,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
      * wait the asynchronous Create Firewall Operation finishes in the Cloudstack.
      */
     @VisibleForTesting
-    void setAsyncRequestInstanceSecondStep(@NotNull SuccessfulAssociateIpAddressResponse response,
-                                           @NotNull AsyncRequestInstanceState asyncRequestInstanceState,
+    void setAsyncRequestInstanceSecondStep(SuccessfulAssociateIpAddressResponse response,
+                                           AsyncRequestInstanceState asyncRequestInstanceState,
                                            String createFirewallRuleJobId) {
 
         SuccessfulAssociateIpAddressResponse.IpAddress ipAddress = response.getIpAddress();
@@ -279,16 +275,15 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
      * Finish the cycle and set as Ready the asynchronous request instance.
      */
     @VisibleForTesting
-    void finishAsyncRequestInstanceSteps(@NotNull AsyncRequestInstanceState asyncRequestInstanceState) {
+    void finishAsyncRequestInstanceSteps(AsyncRequestInstanceState asyncRequestInstanceState) {
         asyncRequestInstanceState.setState(AsyncRequestInstanceState.StateType.READY);
         LOGGER.info(String.format(Messages.Log.ASYNCHRONOUS_PUBLIC_IP_STATE_S,
                 asyncRequestInstanceState.getOrderInstanceId(), AsyncRequestInstanceState.StateType.READY));
     }
 
-    @NotNull
     @VisibleForTesting
-    String doCreateFirewallRule(@NotNull SuccessfulAssociateIpAddressResponse response,
-                                @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+    String doCreateFirewallRule(SuccessfulAssociateIpAddressResponse response,
+                                CloudStackUser cloudStackUser) throws FogbowException {
 
         String ipAddressId = response.getIpAddress().getId();
         CreateFirewallRuleRequest request = new CreateFirewallRuleRequest.Builder()
@@ -302,9 +297,9 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
     }
 
     @VisibleForTesting
-    void doEnableStaticNat(@NotNull SuccessfulAssociateIpAddressResponse response,
-                      @NotNull AsyncRequestInstanceState asyncRequestInstanceState,
-                      @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+    void doEnableStaticNat(SuccessfulAssociateIpAddressResponse response,
+                      AsyncRequestInstanceState asyncRequestInstanceState,
+                      CloudStackUser cloudStackUser) throws FogbowException {
 
         String ipAddressId = response.getIpAddress().getId();
         String computeInstanceId = asyncRequestInstanceState.getComputeInstanceId();
@@ -317,11 +312,10 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         requestEnableStaticNat(request, cloudStackUser);
     }
 
-    @NotNull
     @VisibleForTesting
     PublicIpInstance createReadyPublicIpInstance(
-            @NotNull AsyncRequestInstanceState asyncRequestInstanceState,
-            @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+            AsyncRequestInstanceState asyncRequestInstanceState,
+            CloudStackUser cloudStackUser) throws FogbowException {
 
         /*
          * The jobId used as an identifier in the verification of the status of
@@ -334,11 +328,10 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         return createPublicIpInstance(asyncRequestInstanceState, CloudStackStateMapper.READY_STATUS);
     }
 
-    @NotNull
     @VisibleForTesting
     void checkIpAddressExist(
-            @NotNull AsyncRequestInstanceState asyncRequestInstanceState,
-            @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+            AsyncRequestInstanceState asyncRequestInstanceState,
+            CloudStackUser cloudStackUser) throws FogbowException {
 
         String publicIpAddressId = asyncRequestInstanceState.getIpInstanceId();
         ListPublicIpAddressRequest request = buildPublicIpAddressRequest(publicIpAddressId);
@@ -353,9 +346,8 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         }
     }
 
-    @NotNull
     @VisibleForTesting
-    ListPublicIpAddressRequest buildPublicIpAddressRequest(@NotNull String publicIpAddressId)
+    ListPublicIpAddressRequest buildPublicIpAddressRequest(String publicIpAddressId)
             throws InternalServerErrorException {
 
         ListPublicIpAddressRequest request = new ListPublicIpAddressRequest.Builder()
@@ -365,21 +357,18 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         return request;
     }
 
-    @NotNull
     @VisibleForTesting
     PublicIpInstance createFailedPublicIpInstance() {
         return createPublicIpInstance(null, CloudStackStateMapper.FAILURE_STATUS);
     }
 
-    @NotNull
     @VisibleForTesting
     PublicIpInstance createProcessingPublicIpInstance() {
         return createPublicIpInstance(null, CloudStackStateMapper.PROCESSING_STATUS);
     }
 
-    @NotNull
     @VisibleForTesting
-    PublicIpInstance createPublicIpInstance(@NotNull AsyncRequestInstanceState asyncRequestInstanceState,
+    PublicIpInstance createPublicIpInstance(AsyncRequestInstanceState asyncRequestInstanceState,
                                            String state) {
         String id = null;
         String ip = null;
@@ -394,15 +383,13 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
      * We don't have the id of the ip address yet, but since the instance id is only used
      * by the plugin, we can return an orderId as an instanceId in the plugin
      */
-    @NotNull
-    private String getInstanceId(@NotNull PublicIpOrder publicIpOrder) {
+    private String getInstanceId(PublicIpOrder publicIpOrder) {
         return publicIpOrder.getId();
     }
 
-    @NotNull
     @VisibleForTesting
-    String requestIpAddressAssociation(@NotNull AssociateIpAddressRequest request,
-                                       @NotNull CloudStackUser cloudStackUser)
+    String requestIpAddressAssociation(AssociateIpAddressRequest request,
+                                       CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -413,10 +400,9 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         return response.getJobId();
     }
 
-    @NotNull
     @VisibleForTesting
-    void requestEnableStaticNat(@NotNull EnableStaticNatRequest request,
-                                @NotNull CloudStackUser cloudStackUser)
+    void requestEnableStaticNat(EnableStaticNatRequest request,
+                                CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -425,10 +411,9 @@ public class CloudStackPublicIpPlugin implements PublicIpPlugin<CloudStackUser> 
         CloudStackCloudUtils.doRequest(this.client, uriRequest.toString(), cloudStackUser);
     }
 
-    @NotNull
     @VisibleForTesting
-    String requestCreateFirewallRule(@NotNull CreateFirewallRuleRequest request,
-                                     @NotNull CloudStackUser cloudUser)
+    String requestCreateFirewallRule(CreateFirewallRuleRequest request,
+                                     CloudStackUser cloudUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/quota/v4_9/CloudStackQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/quota/v4_9/CloudStackQuotaPlugin.java
@@ -49,21 +49,21 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     private CloudStackHttpClient client;
     private String cloudStackUrl;
 
-    public CloudStackQuotaPlugin(@NotBlank String confFilePath) {
+    public CloudStackQuotaPlugin(String confFilePath) {
         this.properties = PropertiesUtil.readProperties(confFilePath);
         this.cloudStackUrl = this.properties.getProperty(CLOUDSTACK_URL);
         this.client = new CloudStackHttpClient();
     }
 
     @Override
-    public ResourceQuota getUserQuota(@NotNull CloudStackUser cloudUser) throws FogbowException {
+    public ResourceQuota getUserQuota(CloudStackUser cloudUser) throws FogbowException {
         ResourceAllocation totalQuota = getTotalQuota(cloudUser);
         ResourceAllocation usedQuota = getUsedQuota(cloudUser);
         return new ResourceQuota(totalQuota, usedQuota);
     }
 
     @VisibleForTesting
-    ResourceAllocation getUsedQuota(@NotNull CloudStackUser cloudUser) throws FogbowException {
+    ResourceAllocation getUsedQuota(CloudStackUser cloudUser) throws FogbowException {
         List<VirtualMachine> virtualMachines = getVirtualMachines(cloudUser);
         List<Volume> volumes = getVolumes(cloudUser);
         List<Network> networks = getNetworks(cloudUser);
@@ -72,7 +72,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    List<PublicIpAddress> getPublicIpAddresses(@NotNull CloudStackUser cloudUser) throws FogbowException {
+    List<PublicIpAddress> getPublicIpAddresses(CloudStackUser cloudUser) throws FogbowException {
         ListPublicIpAddressRequest request = new ListPublicIpAddressRequest.Builder().build(this.cloudStackUrl);
         CloudStackUrlUtil.sign(request.getUriBuilder(), cloudUser.getToken());
 
@@ -84,7 +84,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    String doGetRequest(@NotNull CloudStackUser cloudUser, @NotBlank String uri) throws FogbowException {
+    String doGetRequest(CloudStackUser cloudUser, String uri) throws FogbowException {
         String response = null;
 
         try {
@@ -99,7 +99,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    List<Network> getNetworks(@NotNull CloudStackUser cloudUser) throws FogbowException {
+    List<Network> getNetworks(CloudStackUser cloudUser) throws FogbowException {
         GetNetworkRequest request = new GetNetworkRequest.Builder().build(this.cloudStackUrl);
         CloudStackUrlUtil.sign(request.getUriBuilder(), cloudUser.getToken());
 
@@ -111,13 +111,13 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    ResourceAllocation getTotalQuota(@NotNull CloudStackUser cloudUser) throws FogbowException {
+    ResourceAllocation getTotalQuota(CloudStackUser cloudUser) throws FogbowException {
         List<ResourceLimit> resourceLimits = getResourceLimits(cloudUser);
         return getTotalAllocation(resourceLimits, cloudUser);
     }
 
     @VisibleForTesting
-    List<Volume> getVolumes(@NotNull CloudStackUser cloudUser) throws FogbowException {
+    List<Volume> getVolumes(CloudStackUser cloudUser) throws FogbowException {
         GetVolumeRequest volumeRequest = new GetVolumeRequest.Builder().build(this.cloudStackUrl);
         CloudStackUrlUtil.sign(volumeRequest.getUriBuilder(), cloudUser.getToken());
 
@@ -129,7 +129,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    List<VirtualMachine> getVirtualMachines(@NotNull CloudStackUser cloudUser) throws FogbowException {
+    List<VirtualMachine> getVirtualMachines(CloudStackUser cloudUser) throws FogbowException {
         GetVirtualMachineRequest request = new GetVirtualMachineRequest.Builder().build(this.cloudStackUrl);
         CloudStackUrlUtil.sign(request.getUriBuilder(), cloudUser.getToken());
 
@@ -141,7 +141,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    List<ResourceLimit> getResourceLimits(@NotNull CloudStackUser cloudUser) throws FogbowException {
+    List<ResourceLimit> getResourceLimits(CloudStackUser cloudUser) throws FogbowException {
         ListResourceLimitsRequest request = new ListResourceLimitsRequest.Builder()
                 .build(this.cloudStackUrl);
         CloudStackUrlUtil.sign(request.getUriBuilder(), cloudUser.getToken());
@@ -153,10 +153,10 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    ResourceAllocation getUsedAllocation(@NotNull List<VirtualMachine> vms,
-                                         @NotNull List<Volume> volumes,
-                                         @NotNull List<Network> networks,
-                                         @NotNull List<PublicIpAddress> publicIps) {
+    ResourceAllocation getUsedAllocation(List<VirtualMachine> vms,
+                                         List<Volume> volumes,
+                                         List<Network> networks,
+                                         List<PublicIpAddress> publicIps) {
         int usedPublicIps = getPublicIpAllocation(publicIps);
         int usedNetworks = getNetworkAllocation(networks);
         int usedDisk = getVolumeAllocation(volumes);
@@ -177,17 +177,17 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    int getNetworkAllocation(@NotNull List<Network> networks) {
+    int getNetworkAllocation(List<Network> networks) {
         return networks.size();
     }
 
     @VisibleForTesting
-    int getPublicIpAllocation(@NotNull List<PublicIpAddress> publicIps) {
+    int getPublicIpAllocation(List<PublicIpAddress> publicIps) {
         return publicIps.size();
     }
 
     @VisibleForTesting
-    ComputeAllocation buildComputeAllocation(@NotNull List<VirtualMachine> vms) {
+    ComputeAllocation buildComputeAllocation(List<VirtualMachine> vms) {
         int instances = vms.size();
         int cores = 0;
         int ram = 0;
@@ -201,7 +201,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    int getVolumeAllocation(@NotNull List<Volume> volumes) {
+    int getVolumeAllocation(List<Volume> volumes) {
         long sizeInBytes = 0;
 
         for (Volume volume: volumes) {
@@ -212,7 +212,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    ResourceLimit getDomainResourceLimit(@NotNull ResourceLimit limit, @NotNull CloudStackUser cloudUser) {
+    ResourceLimit getDomainResourceLimit(ResourceLimit limit, CloudStackUser cloudUser) {
         try {
             limit = doGetDomainResourceLimit(limit.getResourceType(), limit.getDomainId(), cloudUser);
         } catch (Exception ex) {
@@ -223,7 +223,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    ResourceAllocation getTotalAllocation(@NotNull List<ResourceLimit> resourceLimits, @NotNull CloudStackUser cloudUser) {
+    ResourceAllocation getTotalAllocation(List<ResourceLimit> resourceLimits, CloudStackUser cloudUser) {
         ResourceAllocation.Builder builder = ResourceAllocation.builder();
         int max = 0;
 
@@ -250,7 +250,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    ResourceLimit doGetDomainResourceLimit(@NotBlank String resourceType, @NotBlank String domainId, @NotNull CloudStackUser cloudUser)
+    ResourceLimit doGetDomainResourceLimit(String resourceType, String domainId, CloudStackUser cloudUser)
             throws FogbowException {
         ListResourceLimitsRequest request = new ListResourceLimitsRequest.Builder()
                 .domainId(domainId)
@@ -268,7 +268,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
     }
 
     @VisibleForTesting
-    void setClient(@NotNull CloudStackHttpClient client) {
+    void setClient(CloudStackHttpClient client) {
         this.client = client;
     }
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/quota/v4_9/CloudStackQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/quota/v4_9/CloudStackQuotaPlugin.java
@@ -57,6 +57,7 @@ public class CloudStackQuotaPlugin implements QuotaPlugin<CloudStackUser> {
 
     @Override
     public ResourceQuota getUserQuota(CloudStackUser cloudUser) throws FogbowException {
+        LOGGER.info(Messages.Log.GETTING_QUOTA);
         ResourceAllocation totalQuota = getTotalQuota(cloudUser);
         ResourceAllocation usedQuota = getUsedQuota(cloudUser);
         return new ResourceQuota(totalQuota, usedQuota);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/securityrule/v4_9/CloudStackSecurityRulePlugin.java
@@ -43,9 +43,9 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
     }
 
     @Override
-    public String requestSecurityRule(@NotNull SecurityRule securityRule,
-                                      @NotNull Order majorOrder,
-                                      @NotNull CloudStackUser cloudStackUser)
+    public String requestSecurityRule(SecurityRule securityRule,
+                                      Order majorOrder,
+                                      CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER));
@@ -68,8 +68,8 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
     }
 
     @Override
-    public List<SecurityRuleInstance> getSecurityRules(@NotNull Order majorOrder,
-                                                       @NotNull CloudStackUser cloudStackUser)
+    public List<SecurityRuleInstance> getSecurityRules(Order majorOrder,
+                                                       CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, majorOrder.getInstanceId()));
@@ -77,7 +77,7 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
     }
 
     @Override
-    public void deleteSecurityRule(String securityRuleId, @NotNull CloudStackUser cloudStackUser)
+    public void deleteSecurityRule(String securityRuleId, CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, securityRuleId));
@@ -88,10 +88,9 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         doDeleteInstance(request, cloudStackUser);
     }
 
-    @NotNull
     @VisibleForTesting
-    List<SecurityRuleInstance> doGetSecurityRules(@NotNull Order majorOrder,
-                                                  @NotNull CloudStackUser cloudStackUser)
+    List<SecurityRuleInstance> doGetSecurityRules(Order majorOrder,
+                                                  CloudStackUser cloudStackUser)
             throws FogbowException {
 
         switch (majorOrder.getType()) {
@@ -107,8 +106,8 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
     }
 
     @VisibleForTesting
-    void doDeleteInstance(@NotNull DeleteFirewallRuleRequest request,
-                          @NotNull CloudStackUser cloudStackUser)
+    void doDeleteInstance(DeleteFirewallRuleRequest request,
+                          CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -122,8 +121,8 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
     }
 
     @VisibleForTesting
-    void checkRequestSecurityParameters(@NotNull SecurityRule securityRule,
-                                        @NotNull Order majorOrder) throws InvalidParameterException {
+    void checkRequestSecurityParameters(SecurityRule securityRule,
+                                        Order majorOrder) throws InvalidParameterException {
 
         if (securityRule.getDirection() == SecurityRule.Direction.OUT) {
             throw new InvalidParameterException(Messages.Exception.INVALID_PARAMETER);
@@ -133,10 +132,9 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         }
     }
 
-    @NotNull
     @VisibleForTesting
-    String doRequestInstance(@NotNull CreateFirewallRuleRequest request,
-                             @NotNull CloudStackUser cloudStackUser) throws FogbowException {
+    String doRequestInstance(CreateFirewallRuleRequest request,
+                             CloudStackUser cloudStackUser) throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
         CloudStackUrlUtil.sign(uriRequest, cloudStackUser.getToken());
@@ -153,9 +151,8 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         }
     }
 
-    @NotNull
     @VisibleForTesting
-    List<SecurityRuleInstance> getFirewallRules(String ipAddressId, @NotNull CloudStackUser cloudStackUser)
+    List<SecurityRuleInstance> getFirewallRules(String ipAddressId, CloudStackUser cloudStackUser)
             throws FogbowException {
 
         ListFirewallRulesRequest request = new ListFirewallRulesRequest.Builder()
@@ -171,10 +168,9 @@ public class CloudStackSecurityRulePlugin implements SecurityRulePlugin<CloudSta
         return convertToFogbowSecurityRules(securityRulesResponse);
     }
 
-    @NotNull
     @VisibleForTesting
     List<SecurityRuleInstance> convertToFogbowSecurityRules(
-            @NotNull List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse) {
+            List<ListFirewallRulesResponse.SecurityRuleResponse> securityRulesResponse) {
 
         List<SecurityRuleInstance> securityRuleInstances = new ArrayList<SecurityRuleInstance>();
         for (ListFirewallRulesResponse.SecurityRuleResponse securityRuleResponse : securityRulesResponse) {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/volume/v4_9/CloudStackVolumePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/volume/v4_9/CloudStackVolumePlugin.java
@@ -58,7 +58,7 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
     }
 
     @Override
-    public String requestInstance(@NotNull VolumeOrder volumeOrder, @NotNull CloudStackUser cloudStackUser)
+    public String requestInstance(VolumeOrder volumeOrder, CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
@@ -69,7 +69,7 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
     }
 
     @Override
-    public VolumeInstance getInstance(@NotNull VolumeOrder volumeOrder, @NotNull CloudStackUser cloudStackUser)
+    public VolumeInstance getInstance(VolumeOrder volumeOrder, CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, volumeOrder.getInstanceId()));
@@ -81,7 +81,7 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
     }
 
     @Override
-    public void deleteInstance(@NotNull VolumeOrder volumeOrder, @NotNull CloudStackUser cloudStackUser)
+    public void deleteInstance(VolumeOrder volumeOrder, CloudStackUser cloudStackUser)
             throws FogbowException {
 
         LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, volumeOrder.getInstanceId()));
@@ -92,9 +92,9 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
         doDeleteInstance(request, cloudStackUser);
     }
 
-    @NotNull
+    
     @VisibleForTesting
-    void doDeleteInstance(@NotNull DeleteVolumeRequest request, @NotNull CloudStackUser cloudStackUser)
+    void doDeleteInstance(DeleteVolumeRequest request, CloudStackUser cloudStackUser)
         throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -108,9 +108,9 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
         }
     }
 
-    @NotNull
+    
     @VisibleForTesting
-    VolumeInstance doGetInstance(@NotNull GetVolumeRequest request, @NotNull CloudStackUser cloudStackUser)
+    VolumeInstance doGetInstance(GetVolumeRequest request, CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -127,10 +127,10 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
         return buildVolumeInstance(volume);
     }
 
-    @NotNull
+    
     @VisibleForTesting
-    CreateVolumeRequest buildCreateVolumeRequest(@NotNull VolumeOrder volumeOrder,
-                                                 @NotNull CloudStackUser cloudStackUser)
+    CreateVolumeRequest buildCreateVolumeRequest(VolumeOrder volumeOrder,
+                                                 CloudStackUser cloudStackUser)
             throws FogbowException {
 
         List<GetAllDiskOfferingsResponse.DiskOffering> disksOffering =
@@ -155,9 +155,9 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
         throw new UnacceptableOperationException();
     }
 
-    @NotNull
+    
     @VisibleForTesting
-    String doRequestInstance(@NotNull CreateVolumeRequest request, @NotNull CloudStackUser cloudStackUser)
+    String doRequestInstance(CreateVolumeRequest request, CloudStackUser cloudStackUser)
             throws FogbowException {
 
         URIBuilder uriRequest = request.getUriBuilder();
@@ -175,11 +175,11 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
         }
     }
 
-    @NotNull
+    
     @VisibleForTesting
     List<GetAllDiskOfferingsResponse.DiskOffering> filterDisksOfferingByRequirements(
-            @NotNull List<GetAllDiskOfferingsResponse.DiskOffering> disksOffering,
-            @NotNull VolumeOrder volumeOrder) {
+            List<GetAllDiskOfferingsResponse.DiskOffering> disksOffering,
+            VolumeOrder volumeOrder) {
 
         List<GetAllDiskOfferingsResponse.DiskOffering> disksOfferingFilted = disksOffering;
         Map<String, String> requirements = volumeOrder.getRequirements();
@@ -202,11 +202,24 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
 
         return disksOfferingFilted;
     }
+    
+    @VisibleForTesting
+    String getDiskOfferingIdCompatible(VolumeOrder volumeOrder,
+                                       List<GetAllDiskOfferingsResponse.DiskOffering> diskOfferings) {
 
-    @Nullable
+        int orderVolumeSize = volumeOrder.getVolumeSize();
+        for (GetAllDiskOfferingsResponse.DiskOffering diskOffering : diskOfferings) {
+            int diskSize = diskOffering.getDiskSize();
+            if (diskSize == orderVolumeSize) {
+                return diskOffering.getId();
+            }
+        }
+        return null;
+    }
+    
     @VisibleForTesting
     String getDiskOfferingIdCustomized(
-            @NotNull List<GetAllDiskOfferingsResponse.DiskOffering> diskOfferings) {
+            List<GetAllDiskOfferingsResponse.DiskOffering> diskOfferings) {
 
         for (GetAllDiskOfferingsResponse.DiskOffering diskOffering : diskOfferings) {
             boolean customized = diskOffering.isCustomized();
@@ -218,24 +231,8 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
         return null;
     }
 
-    @Nullable
     @VisibleForTesting
-    String getDiskOfferingIdCompatible(@NotNull VolumeOrder volumeOrder,
-                                       @NotNull List<GetAllDiskOfferingsResponse.DiskOffering> diskOfferings) {
-
-        int orderVolumeSize = volumeOrder.getVolumeSize();
-        for (GetAllDiskOfferingsResponse.DiskOffering diskOffering : diskOfferings) {
-            int diskSize = diskOffering.getDiskSize();
-            if (diskSize == orderVolumeSize) {
-                return diskOffering.getId();
-            }
-        }
-        return null;
-    }
-
-    @NotNull
-    @VisibleForTesting
-    CreateVolumeRequest buildVolumeCustomized(@NotNull VolumeOrder volumeOrder, String diskOfferingId)
+    CreateVolumeRequest buildVolumeCustomized(VolumeOrder volumeOrder, String diskOfferingId)
             throws InternalServerErrorException {
 
         String name = normalizeInstanceName(volumeOrder.getName());
@@ -248,9 +245,8 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
                 .build(this.cloudStackUrl);
     }
 
-    @NotNull
     @VisibleForTesting
-    CreateVolumeRequest buildVolumeCompatible(@NotNull VolumeOrder volumeOrder, String diskOfferingId)
+    CreateVolumeRequest buildVolumeCompatible(VolumeOrder volumeOrder, String diskOfferingId)
             throws InternalServerErrorException {
 
         String name = normalizeInstanceName(volumeOrder.getName());
@@ -261,7 +257,6 @@ public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
                 .build(this.cloudStackUrl);
     }
 
-    @NotNull
     @VisibleForTesting
     VolumeInstance buildVolumeInstance(GetVolumeResponse.Volume volume) {
         String id = volume.getId();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/volume/v4_9/CloudStackVolumePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/cloudstack/volume/v4_9/CloudStackVolumePlugin.java
@@ -34,7 +34,8 @@ import java.util.stream.Collectors;
 public class CloudStackVolumePlugin implements VolumePlugin<CloudStackUser> {
     private static final Logger LOGGER = Logger.getLogger(CloudStackVolumePlugin.class);
 
-    protected static final int CUSTOMIZED_DISK_SIZE_EXPECTED = 0;
+    @VisibleForTesting
+    static final int CUSTOMIZED_DISK_SIZE_EXPECTED = 0;
 
     private CloudStackHttpClient client;
     private String zoneId;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/OpenNebulaStateMapper.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/OpenNebulaStateMapper.java
@@ -3,6 +3,12 @@ package cloud.fogbow.ras.core.plugins.interoperability.opennebula;
 import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.models.ResourceType;
 import cloud.fogbow.ras.api.http.response.InstanceState;
+import cloud.fogbow.ras.core.plugins.interoperability.opennebula.attachment.v5_4.OpenNebulaAttachmentPlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.opennebula.compute.v5_4.OpenNebulaComputePlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.opennebula.image.v5_4.OpenNebulaImagePlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.opennebula.network.v5_4.OpenNebulaNetworkPlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.opennebula.publicip.v5_4.OpenNebulaPublicIpPlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.opennebula.volume.v5_4.OpenNebulaVolumePlugin;
 import org.apache.log4j.Logger;
 
 public class OpenNebulaStateMapper {
@@ -25,12 +31,12 @@ public class OpenNebulaStateMapper {
     public static final int IMAGE_READY_STATE = 1;
     public static final int IMAGE_ERROR_STATE = 5;
 
-    public static final String ATTACHMENT_PLUGIN = "OpenNebulaAttachmentPlugin";
-    public static final String COMPUTE_PLUGIN = "OpenNebulaComputePlugin";
-    public static final String IMAGE_PLUGIN = "OpenNebulaImagePlugin";
-    public static final String NETWORK_PLUGIN = "OpenNebulaComputePlugin";
-    public static final String PUBLIC_IP_PLUGIN = "OpenNebulaPublicIpPlugin";
-    public static final String VOLUME_PLUGIN = "OpenNebulaVolumePlugin";
+    public static final String ATTACHMENT_PLUGIN = OpenNebulaAttachmentPlugin.class.getSimpleName();
+    public static final String COMPUTE_PLUGIN = OpenNebulaComputePlugin.class.getSimpleName();
+    public static final String IMAGE_PLUGIN = OpenNebulaImagePlugin.class.getSimpleName();
+    public static final String NETWORK_PLUGIN = OpenNebulaNetworkPlugin.class.getSimpleName();
+    public static final String PUBLIC_IP_PLUGIN = OpenNebulaPublicIpPlugin.class.getSimpleName();
+    public static final String VOLUME_PLUGIN = OpenNebulaVolumePlugin.class.getSimpleName();
 
     public static InstanceState map(ResourceType type, String state){
         state = state.toLowerCase();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/attachment/v5_4/OpenNebulaAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/attachment/v5_4/OpenNebulaAttachmentPlugin.java
@@ -83,14 +83,13 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
 
     @Override
     public void deleteInstance(AttachmentOrder order, CloudUser cloudUser) throws FogbowException {
-        String instanceId1 = order.getInstanceId();
-        LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId1));
+        String instanceId = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
 
         if (order == null) {
             throw new InstanceNotFoundException(Messages.Exception.INSTANCE_NOT_FOUND);
         }
         Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-        String instanceId = instanceId1;
         String computeId = order.getComputeId();
         doDeleteInstance(client, computeId, instanceId);
     }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/attachment/v5_4/OpenNebulaAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/attachment/v5_4/OpenNebulaAttachmentPlugin.java
@@ -42,23 +42,23 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
 
     private String endpoint;
 
-    public OpenNebulaAttachmentPlugin(@NotBlank String confFilePath) throws FatalErrorException {
+    public OpenNebulaAttachmentPlugin(String confFilePath) throws FatalErrorException {
         Properties properties = PropertiesUtil.readProperties(confFilePath);
         this.endpoint = properties.getProperty(OpenNebulaConfigurationPropertyKeys.OPENNEBULA_RPC_ENDPOINT_KEY);
     }
 
     @Override
-    public boolean isReady(@NotBlank String cloudState) {
+    public boolean isReady(String cloudState) {
         return OpenNebulaStateMapper.map(ResourceType.ATTACHMENT, cloudState).equals(InstanceState.READY);
     }
 
     @Override
-    public boolean hasFailed(@NotBlank String cloudState) {
+    public boolean hasFailed(String cloudState) {
         return OpenNebulaStateMapper.map(ResourceType.ATTACHMENT, cloudState).equals(InstanceState.FAILED);
     }
 
     @Override
-    public String requestInstance(@NotNull AttachmentOrder order, @NotNull CloudUser cloudUser) throws FogbowException {
+    public String requestInstance(AttachmentOrder order, CloudUser cloudUser) throws FogbowException {
         Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
         String virtualMachineId = order.getComputeId();
         String imageId = order.getVolumeId();
@@ -75,7 +75,7 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
     }
 
     @Override
-    public void deleteInstance(@NotNull AttachmentOrder order, @NotNull CloudUser cloudUser) throws FogbowException {
+    public void deleteInstance(AttachmentOrder order, CloudUser cloudUser) throws FogbowException {
         if (order == null) {
             throw new InstanceNotFoundException(Messages.Exception.INSTANCE_NOT_FOUND);
         }
@@ -86,7 +86,7 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
     }
 
     @Override
-    public AttachmentInstance getInstance(@NotNull AttachmentOrder order, @NotNull CloudUser cloudUser)
+    public AttachmentInstance getInstance(AttachmentOrder order, CloudUser cloudUser)
             throws FogbowException {
 
         if (order == null) {
@@ -101,9 +101,9 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
 
     @VisibleForTesting
     String getImageDiskId(
-            @NotNull Client client, 
-            @NotBlank String virtualMachineId, 
-            @NotBlank String imageId) throws FogbowException {
+            Client client, 
+            String virtualMachineId, 
+            String imageId) throws FogbowException {
 
         VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, virtualMachineId);
         String imageIdPath = String.format(DISK_ID_PATH_FORMAT, imageId);
@@ -113,10 +113,10 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
 
     @VisibleForTesting
     void doRequestInstance(
-            @NotNull Client client, 
-            @NotBlank String virtualMachineId, 
-            @NotBlank String imageId,
-            @NotBlank String template) throws FogbowException {
+            Client client, 
+            String virtualMachineId, 
+            String imageId,
+            String template) throws FogbowException {
 
         VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, virtualMachineId);
         OneResponse response = virtualMachine.diskAttach(template);
@@ -128,7 +128,7 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
     }
 
     @VisibleForTesting
-    String normalizeDeviceTarget(@NotNull AttachmentOrder order) {
+    String normalizeDeviceTarget(AttachmentOrder order) {
         // Expecting a default target device such as "/dev/sdb".
         String[] pathSplited = order.getDevice().split(DEVICE_PATH_SEPARATOR);
         String target = pathSplited.length == DEVICE_PATH_LENGTH 
@@ -140,9 +140,9 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
 
     @VisibleForTesting
     void doDeleteInstance(
-            @NotNull Client client, 
-            @NotBlank String computeId, 
-            @NotBlank String instanceId) throws FogbowException {
+            Client client, 
+            String computeId, 
+            String instanceId) throws FogbowException {
 
         VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, computeId);
         int diskId = Integer.parseInt(instanceId);
@@ -156,10 +156,10 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
 
     @VisibleForTesting
     AttachmentInstance doGetInstance(
-            @NotNull Client client, 
-            @NotBlank String instanceId, 
-            @NotBlank String computeId,
-            @NotBlank String volumeId) throws FogbowException {
+            Client client, 
+            String instanceId, 
+            String computeId,
+            String volumeId) throws FogbowException {
 
         VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, computeId);
         String deviceTargetPath = String.format(TARGET_PATH_FORMAT, volumeId);
@@ -170,7 +170,7 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
     }
 
     @VisibleForTesting
-    String getImageState(@NotNull Client client, @NotBlank String volumeId) throws FogbowException {
+    String getImageState(Client client, String volumeId) throws FogbowException {
         ImagePool imagePool = OpenNebulaClientUtil.getImagePool(client);
         Image image = imagePool.getById(Integer.parseInt(volumeId));
         if (image == null)

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/attachment/v5_4/OpenNebulaAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/attachment/v5_4/OpenNebulaAttachmentPlugin.java
@@ -32,13 +32,19 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
 
     private static final Logger LOGGER = Logger.getLogger(OpenNebulaAttachmentPlugin.class);
 
-    protected static final String DEFAULT_TARGET = "hdb";
-    protected static final String DEVICE_PATH_SEPARATOR = "/";
-    protected static final String DISK_ID_PATH_FORMAT = "TEMPLATE/DISK[IMAGE_ID=%s]/DISK_ID";
-    protected static final String TARGET_PATH_FORMAT = "TEMPLATE/DISK[IMAGE_ID=%s]/TARGET";
+    @VisibleForTesting
+    static final String DEFAULT_TARGET = "hdb";
+    @VisibleForTesting
+    static final String DEVICE_PATH_SEPARATOR = "/";
+    @VisibleForTesting
+    static final String DISK_ID_PATH_FORMAT = "TEMPLATE/DISK[IMAGE_ID=%s]/DISK_ID";
+    @VisibleForTesting
+    static final String TARGET_PATH_FORMAT = "TEMPLATE/DISK[IMAGE_ID=%s]/TARGET";
 
-    protected static final int DEVICE_PATH_LENGTH = 3;
-    protected static final int TARGET_INDEX = 2;
+    @VisibleForTesting
+    static final int DEVICE_PATH_LENGTH = 3;
+    @VisibleForTesting
+    static final int TARGET_INDEX = 2;
 
     private String endpoint;
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/attachment/v5_4/OpenNebulaAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/attachment/v5_4/OpenNebulaAttachmentPlugin.java
@@ -140,9 +140,9 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
     @VisibleForTesting
     String normalizeDeviceTarget(AttachmentOrder order) {
         // Expecting a default target device such as "/dev/sdb".
-        String[] pathSplited = order.getDevice().split(DEVICE_PATH_SEPARATOR);
-        String target = pathSplited.length == DEVICE_PATH_LENGTH 
-                ? pathSplited[TARGET_INDEX]
+        String[] splitPath = order.getDevice().split(DEVICE_PATH_SEPARATOR);
+        String target = splitPath.length == DEVICE_PATH_LENGTH
+                ? splitPath[TARGET_INDEX]
                 : DEFAULT_TARGET;
 
         return target;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/attachment/v5_4/OpenNebulaAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/attachment/v5_4/OpenNebulaAttachmentPlugin.java
@@ -65,6 +65,7 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
 
     @Override
     public String requestInstance(AttachmentOrder order, CloudUser cloudUser) throws FogbowException {
+        LOGGER.info(String.format(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER));
         Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
         String virtualMachineId = order.getComputeId();
         String imageId = order.getVolumeId();
@@ -82,11 +83,14 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
 
     @Override
     public void deleteInstance(AttachmentOrder order, CloudUser cloudUser) throws FogbowException {
+        String instanceId1 = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId1));
+
         if (order == null) {
             throw new InstanceNotFoundException(Messages.Exception.INSTANCE_NOT_FOUND);
         }
         Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-        String instanceId = order.getInstanceId();
+        String instanceId = instanceId1;
         String computeId = order.getComputeId();
         doDeleteInstance(client, computeId, instanceId);
     }
@@ -94,12 +98,12 @@ public class OpenNebulaAttachmentPlugin implements AttachmentPlugin<CloudUser> {
     @Override
     public AttachmentInstance getInstance(AttachmentOrder order, CloudUser cloudUser)
             throws FogbowException {
-
+        String instanceId = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
         if (order == null) {
             throw new InstanceNotFoundException(Messages.Exception.INSTANCE_NOT_FOUND);
         }
         Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-        String instanceId = order.getInstanceId();
         String computeId = order.getComputeId();
         String volumeId = order.getVolumeId();
         return doGetInstance(client, instanceId, computeId, volumeId);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/OpenNebulaComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/OpenNebulaComputePlugin.java
@@ -32,24 +32,39 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 
 	private static final Logger LOGGER = Logger.getLogger(OpenNebulaComputePlugin.class);
 
-	protected static final int ONE_GIGABYTE_IN_MEGABYTES = 1024;
-	protected static final int DEFAULT_NUMBER_OF_INSTANCES = 1;
+	@VisibleForTesting
+    static final int ONE_GIGABYTE_IN_MEGABYTES = 1024;
+	@VisibleForTesting
+    static final int DEFAULT_NUMBER_OF_INSTANCES = 1;
 
-	protected static final String DEFAULT_ARCHITECTURE = "x86_64";
-	protected static final String DEFAULT_GRAPHIC_ADDRESS = "0.0.0.0";
-	protected static final String DEFAULT_GRAPHIC_TYPE = "vnc";
-	protected static final String NETWORK_CONFIRMATION_CONTEXT = "YES";
-	protected static final String NIC_IP_EXPRESSION = "//NIC/IP";
+	@VisibleForTesting
+    static final String DEFAULT_ARCHITECTURE = "x86_64";
+	@VisibleForTesting
+    static final String DEFAULT_GRAPHIC_ADDRESS = "0.0.0.0";
+	@VisibleForTesting
+    static final String DEFAULT_GRAPHIC_TYPE = "vnc";
+	@VisibleForTesting
+    static final String NETWORK_CONFIRMATION_CONTEXT = "YES";
+	@VisibleForTesting
+    static final String NIC_IP_EXPRESSION = "//NIC/IP";
 
-	protected static final boolean SHUTS_DOWN_HARD = true;
-	protected static final int VALUE_NOT_DEFINED_BY_USER = 0;
-	protected static final int MINIMUM_VCPU_VALUE = 1;
-	protected static final int MINIMUM_RAM_VALUE = 1;
+	@VisibleForTesting
+    static final boolean SHUTS_DOWN_HARD = true;
+	@VisibleForTesting
+    static final int VALUE_NOT_DEFINED_BY_USER = 0;
+	@VisibleForTesting
+    static final int MINIMUM_VCPU_VALUE = 1;
+	@VisibleForTesting
+    static final int MINIMUM_RAM_VALUE = 1;
 
-	protected static final String IMAGE_SIZE_PATH = "SIZE";
-	protected static final String TEMPLATE_CPU_PATH = "TEMPLATE/CPU";
-	protected static final String TEMPLATE_DISK_SIZE_PATH = "TEMPLATE/DISK/SIZE";
-	protected static final String TEMPLATE_MEMORY_PATH = "TEMPLATE/MEMORY";
+	@VisibleForTesting
+    static final String IMAGE_SIZE_PATH = "SIZE";
+	@VisibleForTesting
+    static final String TEMPLATE_CPU_PATH = "TEMPLATE/CPU";
+	@VisibleForTesting
+    static final String TEMPLATE_DISK_SIZE_PATH = "TEMPLATE/DISK/SIZE";
+	@VisibleForTesting
+    static final String TEMPLATE_MEMORY_PATH = "TEMPLATE/MEMORY";
 
 	private String endpoint;
 	private TreeSet<HardwareRequirements> flavors;
@@ -103,7 +118,8 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 		}
 	}
 
-	protected String doRequestInstance(Client client, CreateComputeRequest request)
+	@VisibleForTesting
+    String doRequestInstance(Client client, CreateComputeRequest request)
 			throws InvalidParameterException, UnacceptableOperationException {
 
 		String template = request.getVirtualMachine().marshalTemplate();
@@ -112,7 +128,8 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 		return instanceId;
 	}
 
-	protected ComputeInstance doGetInstance(VirtualMachine virtualMachine) {
+	@VisibleForTesting
+    ComputeInstance doGetInstance(VirtualMachine virtualMachine) {
 		OneResponse response = virtualMachine.info();
 
 		String id = virtualMachine.getId();
@@ -133,7 +150,8 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 		return computeInstance;
 	}
 
-	protected CreateComputeRequest getCreateComputeRequest(Client client, ComputeOrder computeOrder)
+	@VisibleForTesting
+    CreateComputeRequest getCreateComputeRequest(Client client, ComputeOrder computeOrder)
 			throws InternalServerErrorException, UnacceptableOperationException {
 		String userName = PropertiesHolder.getInstance().getProperty(ConfigurationPropertyKeys.SSH_COMMON_USER_KEY,
 				ConfigurationPropertyDefaults.SSH_COMMON_USER);
@@ -174,7 +192,8 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 		return request;
 	}
 
-	protected synchronized void setOrderAllocation(ComputeOrder computeOrder, VirtualMachineTemplate virtualMachine) {
+	@VisibleForTesting
+    synchronized void setOrderAllocation(ComputeOrder computeOrder, VirtualMachineTemplate virtualMachine) {
 		int sizeInMegabytes = Integer.parseInt(virtualMachine.getDisk().getSize());
 		int size = convertDiskSizeToGb(sizeInMegabytes);
 		ComputeAllocation actualAllocation = new ComputeAllocation(
@@ -189,7 +208,8 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 		return sizeInMegabytes / ONE_GIGABYTE_IN_MEGABYTES;
 	}
 
-	protected List<String> getNetworkIds(List<String> networkIds) {
+	@VisibleForTesting
+    List<String> getNetworkIds(List<String> networkIds) {
 		String defaultNetworkId = this.properties.getProperty(OpenNebulaConfigurationPropertyKeys.DEFAULT_NETWORK_ID_KEY);
 		List<String>  networks = new ArrayList<>();
 		networks.add(defaultNetworkId);
@@ -249,17 +269,20 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 		return Integer.parseInt(minimumImageSizeStr);
 	}
 
-	protected TreeSet<HardwareRequirements> getFlavors() {
+	@VisibleForTesting
+    TreeSet<HardwareRequirements> getFlavors() {
 		synchronized (this.flavors) {
 			return this.flavors;
 		}
 	}
 
-	protected int convertDiskSizeToMb(int diskSizeInGb) {
+	@VisibleForTesting
+    int convertDiskSizeToMb(int diskSizeInGb) {
 		return diskSizeInGb * ONE_GIGABYTE_IN_MEGABYTES;
 	}
 
-	protected Map<String, String> getImagesSizes(Client client) throws InternalServerErrorException {
+	@VisibleForTesting
+    Map<String, String> getImagesSizes(Client client) throws InternalServerErrorException {
 		Map<String, String> imagesSizeMap = new HashMap<>();
 		ImagePool imagePool = OpenNebulaClientUtil.getImagePool(client);
 		for (Image image : imagePool) {
@@ -269,7 +292,8 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 		return imagesSizeMap;
 	}
 
-	protected boolean containsFlavor(HardwareRequirements flavor) {
+	@VisibleForTesting
+    boolean containsFlavor(HardwareRequirements flavor) {
 		List<HardwareRequirements> list = new ArrayList<>(this.getFlavors());
 		for (HardwareRequirements item : list) {
 			if (item.getName().equals(flavor.getName())) {
@@ -279,7 +303,8 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 		return false;
 	}
 
-	protected void setComputeInstanceNetworks(ComputeInstance computeInstance) {
+	@VisibleForTesting
+    void setComputeInstanceNetworks(ComputeInstance computeInstance) {
 		// The default network is always included in the order by the OpenNebula plugin, thus it should be added
 		// in the map of networks in the ComputeInstance by the plugin. The remaining networks passed by the user
 		// are appended by the LocalCloudConnector.
@@ -289,13 +314,15 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 		computeInstance.setNetworks(computeNetworks);
 	}
 
-	protected void setFlavors(TreeSet<HardwareRequirements> flavors) {
+	@VisibleForTesting
+    void setFlavors(TreeSet<HardwareRequirements> flavors) {
 		synchronized (this.flavors) {
 			this.flavors = flavors;
 		}
 	}
 
-	protected void setLaunchCommandGenerator(LaunchCommandGenerator launchCommandGenerator) {
+	@VisibleForTesting
+    void setLaunchCommandGenerator(LaunchCommandGenerator launchCommandGenerator) {
 		this.launchCommandGenerator = launchCommandGenerator;
 	}
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/OpenNebulaComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/OpenNebulaComputePlugin.java
@@ -2,6 +2,7 @@ package cloud.fogbow.ras.core.plugins.interoperability.opennebula.compute.v5_4;
 
 import cloud.fogbow.common.exceptions.*;
 import cloud.fogbow.common.models.CloudUser;
+import cloud.fogbow.common.util.BinaryUnit;
 import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.ras.api.http.response.ComputeInstance;
 import cloud.fogbow.ras.api.http.response.InstanceState;
@@ -195,7 +196,7 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 	@VisibleForTesting
     synchronized void setOrderAllocation(ComputeOrder computeOrder, VirtualMachineTemplate virtualMachine) {
 		int sizeInMegabytes = Integer.parseInt(virtualMachine.getDisk().getSize());
-		int size = convertDiskSizeToGb(sizeInMegabytes);
+		int size = (int) BinaryUnit.megabytes(sizeInMegabytes).asGigabytes();
 		ComputeAllocation actualAllocation = new ComputeAllocation(
                 DEFAULT_NUMBER_OF_INSTANCES, Integer.parseInt(virtualMachine.getCpu()),
 				Integer.parseInt(virtualMachine.getMemory()),

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/OpenNebulaComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/compute/v5_4/OpenNebulaComputePlugin.java
@@ -91,6 +91,7 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 
 	@Override
 	public String requestInstance(ComputeOrder computeOrder, CloudUser cloudUser) throws FogbowException {
+		LOGGER.info(String.format(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 		CreateComputeRequest request = this.getCreateComputeRequest(client, computeOrder);
 		VirtualMachineTemplate virtualMachine = request.getVirtualMachine();
@@ -103,6 +104,8 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 
 	@Override
 	public ComputeInstance getInstance(ComputeOrder computeOrder, CloudUser cloudUser) throws FogbowException {
+		String instanceId = computeOrder.getInstanceId();
+		LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, computeOrder.getInstanceId());
 		return this.doGetInstance(virtualMachine);
@@ -110,12 +113,14 @@ public class OpenNebulaComputePlugin implements ComputePlugin<CloudUser> {
 
 	@Override
 	public void deleteInstance(ComputeOrder computeOrder, CloudUser cloudUser) throws FogbowException {
+		String instanceId = computeOrder.getInstanceId();
+		LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, computeOrder.getInstanceId());
+		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, instanceId);
 		OneResponse response = virtualMachine.terminate(SHUTS_DOWN_HARD);
 		if (response.isError()) {
-			throw new InternalServerErrorException(String.format(Messages.Exception.ERROR_WHILE_REMOVING_VM_S_S, computeOrder.getInstanceId(),
-					response.getMessage()));
+			throw new InternalServerErrorException(String.format(Messages.Exception.ERROR_WHILE_REMOVING_VM_S_S,
+					instanceId, response.getMessage()));
 		}
 	}
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePlugin.java
@@ -42,6 +42,7 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 	
 	@Override
 	public List<ImageSummary> getAllImages(CloudUser cloudUser) throws FogbowException {
+		LOGGER.info(Messages.Log.RECEIVING_GET_ALL_IMAGES_REQUEST);
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 		ImagePool imagePool = OpenNebulaClientUtil.getImagePool(client);
 		return getImageSummaryList(imagePool);
@@ -49,6 +50,7 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 
 	@Override
 	public ImageInstance getImage(String imageId, CloudUser cloudUser) throws FogbowException {
+		LOGGER.info(String.format(Messages.Log.RECEIVING_GET_IMAGE_REQUEST_S, imageId));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 		Image image = OpenNebulaClientUtil.getImage(client, imageId);
 		return buildImageInstance(image);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePlugin.java
@@ -7,6 +7,7 @@ import cloud.fogbow.ras.api.http.response.ImageSummary;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 import org.opennebula.client.Client;
+import org.opennebula.client.image.Image;
 import org.opennebula.client.image.ImagePool;
 
 import cloud.fogbow.common.exceptions.FatalErrorException;
@@ -49,8 +50,8 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 	@Override
 	public ImageInstance getImage(String imageId, CloudUser cloudUser) throws FogbowException {
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-		org.opennebula.client.image.Image image = OpenNebulaClientUtil.getImage(client, imageId);
-		return mount(image);
+		Image image = OpenNebulaClientUtil.getImage(client, imageId);
+		return buildImageInstance(image);
 	}
 
 	@VisibleForTesting
@@ -58,7 +59,7 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 		String type;
 		int index = 1;
 		List<ImageSummary> images = new ArrayList<>();
-		for (org.opennebula.client.image.Image image : imagePool) {
+		for (Image image : imagePool) {
 			type = image.xpath(String.format(FORMAT_IMAGE_TYPE_PATH, index));
 			if (type != null && type.equals(OPERATIONAL_SYSTEM_IMAGE_TYPE)) {
 				ImageSummary imageSummary = new ImageSummary(image.getId(), image.getName());
@@ -70,7 +71,7 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 	}
 	
 	@VisibleForTesting
-    ImageInstance mount(org.opennebula.client.image.Image image) {
+    ImageInstance buildImageInstance(Image image) {
 		String id = image.getId();
 		String name = image.getName();
 		String imageSize = image.xpath(IMAGE_SIZE_PATH);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePlugin.java
@@ -32,6 +32,8 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
     static final String IMAGE_SIZE_PATH = "/IMAGE/SIZE";
 	@VisibleForTesting
     static final String OPERATIONAL_SYSTEM_IMAGE_TYPE = "0";
+	@VisibleForTesting
+	static final int NO_VALUE_FLAG = -1;
 
 	private String endpoint;
 	
@@ -78,8 +80,8 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 		String name = image.getName();
 		String imageSize = image.xpath(IMAGE_SIZE_PATH);
 		int size = convertToInteger(imageSize);
-		int minDisk = -1;
-		int minRam = -1;
+		int minDisk = NO_VALUE_FLAG;
+		int minRam = NO_VALUE_FLAG;
 		int state = image.state();
 		InstanceState instanceState = OpenNebulaStateMapper.map(ResourceType.IMAGE, state);
 		String status = instanceState.getValue();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePlugin.java
@@ -4,6 +4,7 @@ import java.util.*;
 
 import cloud.fogbow.ras.api.http.response.ImageInstance;
 import cloud.fogbow.ras.api.http.response.ImageSummary;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 import org.opennebula.client.Client;
 import org.opennebula.client.image.ImagePool;
@@ -24,9 +25,12 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 
 	private static final Logger LOGGER = Logger.getLogger(OpenNebulaImagePlugin.class);
 
-	protected static final String FORMAT_IMAGE_TYPE_PATH = "//IMAGE[%s]/TYPE";
-	protected static final String IMAGE_SIZE_PATH = "/IMAGE/SIZE";
-	protected static final String OPERATIONAL_SYSTEM_IMAGE_TYPE = "0";
+	@VisibleForTesting
+    static final String FORMAT_IMAGE_TYPE_PATH = "//IMAGE[%s]/TYPE";
+	@VisibleForTesting
+    static final String IMAGE_SIZE_PATH = "/IMAGE/SIZE";
+	@VisibleForTesting
+    static final String OPERATIONAL_SYSTEM_IMAGE_TYPE = "0";
 
 	private String endpoint;
 	
@@ -49,7 +53,8 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 		return mount(image);
 	}
 
-	protected List<ImageSummary> getImageSummaryList(ImagePool imagePool) {
+	@VisibleForTesting
+    List<ImageSummary> getImageSummaryList(ImagePool imagePool) {
 		String type;
 		int index = 1;
 		List<ImageSummary> images = new ArrayList<>();
@@ -64,7 +69,8 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 		return images;
 	}
 	
-	protected ImageInstance mount(org.opennebula.client.image.Image image) {
+	@VisibleForTesting
+    ImageInstance mount(org.opennebula.client.image.Image image) {
 		String id = image.getId();
 		String name = image.getName();
 		String imageSize = image.xpath(IMAGE_SIZE_PATH);
@@ -77,7 +83,8 @@ public class OpenNebulaImagePlugin implements ImagePlugin<CloudUser> {
 		return new ImageInstance(id, name, size, minDisk, minRam, status);
 	}
 	
-	protected int convertToInteger(String number) {
+	@VisibleForTesting
+    int convertToInteger(String number) {
 	    int size = 0;
 		try {
 			size =  Integer.parseInt(number);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/network/v5_4/OpenNebulaNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/network/v5_4/OpenNebulaNetworkPlugin.java
@@ -8,6 +8,7 @@ import cloud.fogbow.common.exceptions.*;
 import cloud.fogbow.ras.constants.SystemConstants;
 import cloud.fogbow.ras.core.models.ResourceType;
 import cloud.fogbow.ras.core.plugins.interoperability.opennebula.OpenNebulaStateMapper;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.net.util.SubnetUtils;
 import org.apache.log4j.Logger;
@@ -43,19 +44,30 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 
 	private static final int BASE_VALUE = 2;
 
-	protected static final String VIRTUAL_NETWORK_RESOURCE = "VirtualNetwork";
-	protected static final String SECURITY_GROUPS_SEPARATOR = ",";
-	protected static final String VNET_ADDRESS_RANGE_IP_PATH = "/VNET/AR_POOL/AR/IP";
-	protected static final String VNET_ADDRESS_RANGE_SIZE_PATH = "/VNET/AR_POOL/AR/SIZE";
-	protected static final String VNET_TEMPLATE_SECURITY_GROUPS_PATH = "/VNET/TEMPLATE/SECURITY_GROUPS";
-	protected static final String VNET_TEMPLATE_VLAN_ID_PATH = "/VNET/TEMPLATE/VLAN_ID";
+	@VisibleForTesting
+    static final String VIRTUAL_NETWORK_RESOURCE = "VirtualNetwork";
+	@VisibleForTesting
+    static final String SECURITY_GROUPS_SEPARATOR = ",";
+	@VisibleForTesting
+    static final String VNET_ADDRESS_RANGE_IP_PATH = "/VNET/AR_POOL/AR/IP";
+	@VisibleForTesting
+    static final String VNET_ADDRESS_RANGE_SIZE_PATH = "/VNET/AR_POOL/AR/SIZE";
+	@VisibleForTesting
+    static final String VNET_TEMPLATE_SECURITY_GROUPS_PATH = "/VNET/TEMPLATE/SECURITY_GROUPS";
+	@VisibleForTesting
+    static final String VNET_TEMPLATE_VLAN_ID_PATH = "/VNET/TEMPLATE/VLAN_ID";
 
-	protected static final String ADDRESS_RANGE_ID_PATH_FORMAT = "/VNET/AR_POOL/AR[%s]/AR_ID";
-	protected static final String ADDRESS_RANGE_IP_PATH_FORMAT = "/VNET/AR_POOL/AR[%s]/IP";
-	protected static final String ADDRESS_RANGE_SIZE_PATH_FORMAT = "/VNET/AR_POOL/AR[%s]/SIZE";
-	protected static final String ADDRESS_RANGE_USED_LEASES_PATH_FORMAT = "/VNET/AR_POOL/AR[%s]/USED_LEASES";
+	@VisibleForTesting
+    static final String ADDRESS_RANGE_ID_PATH_FORMAT = "/VNET/AR_POOL/AR[%s]/AR_ID";
+	@VisibleForTesting
+    static final String ADDRESS_RANGE_IP_PATH_FORMAT = "/VNET/AR_POOL/AR[%s]/IP";
+	@VisibleForTesting
+    static final String ADDRESS_RANGE_SIZE_PATH_FORMAT = "/VNET/AR_POOL/AR[%s]/SIZE";
+	@VisibleForTesting
+    static final String ADDRESS_RANGE_USED_LEASES_PATH_FORMAT = "/VNET/AR_POOL/AR[%s]/USED_LEASES";
 
-	protected static final int IPV4_AMOUNT_BITS = 32;
+	@VisibleForTesting
+    static final int IPV4_AMOUNT_BITS = 32;
 
 	private String endpoint;
 	private String defaultNetwork;
@@ -106,7 +118,8 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		this.doDeleteInstance(virtualNetwork);
 	}
 
-	protected String doRequestInstance(Client client, String networkOrderId, CreateNetworkReserveRequest createNetworkReserveRequest)
+	@VisibleForTesting
+    String doRequestInstance(Client client, String networkOrderId, CreateNetworkReserveRequest createNetworkReserveRequest)
 			throws InvalidParameterException, InstanceNotFoundException, UnauthorizedRequestException {
 
 		int defaultNetworkId = this.convertToInteger(this.defaultNetwork);
@@ -117,7 +130,8 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		return OpenNebulaClientUtil.updateVirtualNetwork(client, this.convertToInteger(networkInstanceId), networkUpdateTemplate);
 	}
 
-	protected NetworkInstance doGetInstance(VirtualNetwork virtualNetwork) throws InvalidParameterException {
+	@VisibleForTesting
+    NetworkInstance doGetInstance(VirtualNetwork virtualNetwork) throws InvalidParameterException {
 		String id = virtualNetwork.getId();
 		String name = virtualNetwork.getName();
 		String vLan = virtualNetwork.xpath(VNET_TEMPLATE_VLAN_ID_PATH);
@@ -145,7 +159,8 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		return networkInstance;
 	}
 
-	protected void doDeleteInstance(VirtualNetwork virtualNetwork) throws InternalServerErrorException {
+	@VisibleForTesting
+    void doDeleteInstance(VirtualNetwork virtualNetwork) throws InternalServerErrorException {
 		OneResponse response = virtualNetwork.delete();
 		if (response.isError()) {
 			throw new InternalServerErrorException(String.format(
@@ -153,7 +168,8 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		}
 	}
 
-	protected Integer getAddressRangeIndex(VirtualNetwork virtualNetwork, String lowAddress, int addressRangeSize)
+	@VisibleForTesting
+    Integer getAddressRangeIndex(VirtualNetwork virtualNetwork, String lowAddress, int addressRangeSize)
 			throws InvalidParameterException {
 
 		for (int i = 1; i < Integer.MAX_VALUE; i++) {
@@ -180,7 +196,8 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		return null;
 	}
 
-	protected String getAddressRangeId(VirtualNetwork virtualNetwork, Integer addressRangeIndex, String cidr)
+	@VisibleForTesting
+    String getAddressRangeId(VirtualNetwork virtualNetwork, Integer addressRangeIndex, String cidr)
 			throws UnacceptableOperationException {
 
 		if (addressRangeIndex != null) {
@@ -191,7 +208,8 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		}
 	}
 
-	protected String getNextAvailableAddress(VirtualNetwork virtualNetwork, Integer addressRangeIndex)
+	@VisibleForTesting
+    String getNextAvailableAddress(VirtualNetwork virtualNetwork, Integer addressRangeIndex)
 			throws InvalidParameterException {
 
 		String addressRangeFirstIp = virtualNetwork.xpath(String.format(ADDRESS_RANGE_IP_PATH_FORMAT, addressRangeIndex));
@@ -210,7 +228,8 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		return addressRangeFirstIp;
 	}
 
-	protected CreateNetworkReserveRequest getCreateNetworkReserveRequest(NetworkOrder networkOrder, VirtualNetwork virtualNetwork)
+	@VisibleForTesting
+    CreateNetworkReserveRequest getCreateNetworkReserveRequest(NetworkOrder networkOrder, VirtualNetwork virtualNetwork)
 			throws InvalidParameterException, UnacceptableOperationException {
 		String cidr = networkOrder.getCidr();
 		SubnetUtils.SubnetInfo subnetInfo = new SubnetUtils(cidr).getInfo();
@@ -230,7 +249,8 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 				.build();
 	}
 
-	protected String getNetworkUpdateTemplate(Client client, String networkInstanceId)
+	@VisibleForTesting
+    String getNetworkUpdateTemplate(Client client, String networkInstanceId)
 			throws InvalidParameterException, UnauthorizedRequestException, InstanceNotFoundException {
 
 		String securityGroupId = this.createSecurityGroup(client, networkInstanceId);
@@ -242,7 +262,8 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		return updateRequest.getVirtualNetworkUpdate().marshalTemplate();
 	}
 
-	protected String createSecurityGroup(Client client, String virtualNetworkId)
+	@VisibleForTesting
+    String createSecurityGroup(Client client, String virtualNetworkId)
 			throws InvalidParameterException, UnauthorizedRequestException, InstanceNotFoundException {
 
 		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, virtualNetworkId);
@@ -297,14 +318,16 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		return OpenNebulaClientUtil.allocateSecurityGroup(client, template);
 	}
 
-	protected void deleteSecurityGroup(SecurityGroup securityGroup) {
+	@VisibleForTesting
+    void deleteSecurityGroup(SecurityGroup securityGroup) {
 		OneResponse response = securityGroup.delete();
 		if (response.isError()) {
 			LOGGER.error(String.format(Messages.Log.ERROR_WHILE_REMOVING_RESOURCE_S_S, SECURITY_GROUP_RESOURCE, response.getMessage()));
 		}
 	}
 
-	protected SecurityGroup getSecurityGroupForVirtualNetwork(Client client, VirtualNetwork virtualNetwork, String instanceId)
+	@VisibleForTesting
+    SecurityGroup getSecurityGroupForVirtualNetwork(Client client, VirtualNetwork virtualNetwork, String instanceId)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
 		SecurityGroup securityGroup = null;
 		String securityGroupIdsStr = virtualNetwork.xpath(VNET_TEMPLATE_SECURITY_GROUPS_PATH);
@@ -326,15 +349,18 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		return securityGroup;
 	}
 
-	protected String generateSecurityGroupName(String instanceId) {
+	@VisibleForTesting
+    String generateSecurityGroupName(String instanceId) {
 		return SystemConstants.PN_SECURITY_GROUP_PREFIX + instanceId;
 	}
 	
-	protected String generateAddressCidr(String address, String rangeSize) throws InvalidParameterException {
+	@VisibleForTesting
+    String generateAddressCidr(String address, String rangeSize) throws InvalidParameterException {
 		return String.format(CIDR_FORMAT, address, this.calculateCidr(this.convertToInteger(rangeSize)));
 	}
 	
-	protected int calculateCidr(int size) {
+	@VisibleForTesting
+    int calculateCidr(int size) {
 		int exponent = 1;
 		int value = 0;
 		for (int i = 0; i < IPV4_AMOUNT_BITS; i++) {
@@ -349,7 +375,8 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		return value;
 	}
 
-	protected int convertToInteger(String number) throws InvalidParameterException {
+	@VisibleForTesting
+    int convertToInteger(String number) throws InvalidParameterException {
 		try {
 			return Integer.parseInt(number);
 		} catch (NumberFormatException e) {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/network/v5_4/OpenNebulaNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/network/v5_4/OpenNebulaNetworkPlugin.java
@@ -153,7 +153,6 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		}
 	}
 
-	@Nullable
 	protected Integer getAddressRangeIndex(VirtualNetwork virtualNetwork, String lowAddress, int addressRangeSize)
 			throws InvalidParameterException {
 
@@ -305,7 +304,6 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		}
 	}
 
-	@Nullable
 	protected SecurityGroup getSecurityGroupForVirtualNetwork(Client client, VirtualNetwork virtualNetwork, String instanceId)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
 		SecurityGroup securityGroup = null;

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/network/v5_4/OpenNebulaNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/network/v5_4/OpenNebulaNetworkPlugin.java
@@ -90,6 +90,7 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 
 	@Override
 	public String requestInstance(NetworkOrder networkOrder, CloudUser cloudUser) throws FogbowException {
+		LOGGER.info(String.format(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, this.defaultNetwork);
 		CreateNetworkReserveRequest request = this.getCreateNetworkReserveRequest(networkOrder, virtualNetwork);
@@ -100,17 +101,21 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 
 	@Override
 	public NetworkInstance getInstance(NetworkOrder networkOrder, CloudUser cloudUser) throws FogbowException {
+		String instanceId = networkOrder.getInstanceId();
+		LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, networkOrder.getInstanceId());
+		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, instanceId);
 		return this.doGetInstance(virtualNetwork);
 	}
 
 	@Override
 	public void deleteInstance(NetworkOrder networkOrder, CloudUser cloudUser) throws FogbowException {
+		String instanceId = networkOrder.getInstanceId();
+		LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, networkOrder.getInstanceId());
+		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, instanceId);
 
-		SecurityGroup securityGroup = this.getSecurityGroupForVirtualNetwork(client, virtualNetwork, networkOrder.getInstanceId());
+		SecurityGroup securityGroup = this.getSecurityGroupForVirtualNetwork(client, virtualNetwork, instanceId);
 		if (securityGroup != null) {
 			this.deleteSecurityGroup(securityGroup);
 		}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/network/v5_4/OpenNebulaNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/network/v5_4/OpenNebulaNetworkPlugin.java
@@ -30,8 +30,6 @@ import cloud.fogbow.ras.core.plugins.interoperability.opennebula.OpenNebulaConfi
 import cloud.fogbow.ras.core.plugins.interoperability.opennebula.securityrule.v5_4.CreateSecurityGroupRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.opennebula.securityrule.v5_4.Rule;
 
-import javax.annotation.Nullable;
-
 public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 
 	private static final Logger LOGGER = Logger.getLogger(OpenNebulaNetworkPlugin.class);
@@ -95,7 +93,7 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, this.defaultNetwork);
 		CreateNetworkReserveRequest request = this.getCreateNetworkReserveRequest(networkOrder, virtualNetwork);
 
-		String instanceId = this.doRequestInstance(client, networkOrder.getId(), request);
+		String instanceId = this.doRequestInstance(client, request);
 		return instanceId;
 	}
 
@@ -124,7 +122,7 @@ public class OpenNebulaNetworkPlugin implements NetworkPlugin<CloudUser> {
 	}
 
 	@VisibleForTesting
-    String doRequestInstance(Client client, String networkOrderId, CreateNetworkReserveRequest createNetworkReserveRequest)
+    String doRequestInstance(Client client, CreateNetworkReserveRequest createNetworkReserveRequest)
 			throws InvalidParameterException, InstanceNotFoundException, UnauthorizedRequestException {
 
 		int defaultNetworkId = this.convertToInteger(this.defaultNetwork);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPublicIpPlugin.java
@@ -83,6 +83,7 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 
 	@Override
 	public String requestInstance(PublicIpOrder publicIpOrder, CloudUser cloudUser) throws FogbowException {
+		LOGGER.info(String.format(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 
 		int size = SIZE_ADDRESS_PUBLIC_IP;
@@ -99,16 +100,20 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 
 	@Override
 	public void deleteInstance(PublicIpOrder publicIpOrder, CloudUser cloudUser) throws FogbowException {
+		String instanceId = publicIpOrder.getInstanceId();
+		LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
+
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
 		this.doDeleteInstance(client, publicIpOrder);
 	}
 
 	@Override
 	public PublicIpInstance getInstance(PublicIpOrder publicIpOrder, CloudUser cloudUser) throws FogbowException {
+		String instanceId = publicIpOrder.getInstanceId();
+		LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
 		Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-		String publicIpInstanceId = publicIpOrder.getInstanceId();
 
-		return this.doGetInstance(client, publicIpInstanceId, publicIpOrder.getComputeId());
+		return this.doGetInstance(client, instanceId, publicIpOrder.getComputeId());
 	}
 
 	@VisibleForTesting

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/publicip/v5_4/OpenNebulaPublicIpPlugin.java
@@ -6,6 +6,7 @@ import java.util.Properties;
 import java.util.UUID;
 
 import cloud.fogbow.common.exceptions.*;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 import org.opennebula.client.Client;
 import org.opennebula.client.OneResponse;
@@ -41,18 +42,25 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 	private static final String INPUT_RULE_TYPE = "inbound";
 	private static final String OUTPUT_RULE_TYPE = "outbound";
 	private static final String SECURITY_GROUP_SEPARATOR = ",";
-	protected static final String PUBLIC_IP_RESOURCE = "Public IP";
+	@VisibleForTesting
+    static final String PUBLIC_IP_RESOURCE = "Public IP";
 
 	private static final int SIZE_ADDRESS_PUBLIC_IP = 1;
 	private static final int ATTEMPTS_LIMIT_NUMBER = 5;
 
-	protected static final String EXPRESSION_IP_FROM_NETWORK_ID_S_FORMAT = "TEMPLATE/NIC[NETWORK_ID=%s]/IP";
-	protected static final String EXPRESSION_NIC_ID_FROM_NETWORK_ID_S_FORMAT = "TEMPLATE/NIC[NETWORK_ID=%s]/NIC_ID";
-	protected static final String SECURITY_GROUPS_PATH = "TEMPLATE/SECURITY_GROUPS";
-	protected static final String POWEROFF_STATE = "POWEROFF";
+	@VisibleForTesting
+    static final String EXPRESSION_IP_FROM_NETWORK_ID_S_FORMAT = "TEMPLATE/NIC[NETWORK_ID=%s]/IP";
+	@VisibleForTesting
+    static final String EXPRESSION_NIC_ID_FROM_NETWORK_ID_S_FORMAT = "TEMPLATE/NIC[NETWORK_ID=%s]/NIC_ID";
+	@VisibleForTesting
+    static final String SECURITY_GROUPS_PATH = "TEMPLATE/SECURITY_GROUPS";
+	@VisibleForTesting
+    static final String POWEROFF_STATE = "POWEROFF";
 	
-	protected static final long ONE_POINT_TWO_SECONDS = 1200;
-	protected static final boolean SHUT_OFF = true;
+	@VisibleForTesting
+    static final long ONE_POINT_TWO_SECONDS = 1200;
+	@VisibleForTesting
+    static final boolean SHUT_OFF = true;
 
 	private String endpoint;
 	private String defaultPublicNetwork;
@@ -103,7 +111,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		return this.doGetInstance(client, publicIpInstanceId, publicIpOrder.getComputeId());
 	}
 
-	protected String doRequestInstance(Client client, PublicIpOrder publicIpOrder, CreateNetworkReserveRequest reserveRequest)
+	@VisibleForTesting
+    String doRequestInstance(Client client, PublicIpOrder publicIpOrder, CreateNetworkReserveRequest reserveRequest)
 			throws InvalidParameterException, InstanceNotFoundException, UnauthorizedRequestException {
 
 		int defaultPublicNetworkId = this.convertToInteger(this.defaultPublicNetwork);
@@ -118,7 +127,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		return instanceId;
 	}
 
-	protected void doDeleteInstance(Client client, PublicIpOrder order)
+	@VisibleForTesting
+    void doDeleteInstance(Client client, PublicIpOrder order)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException, InternalServerErrorException {
 		// NOTE(pauloewerton): ONe does not allow deleting a resource associated to a VM, so we're using a workaround
 		// by shutting down the VM, releasing network and secgroup resources, and then resuming it afterwards.
@@ -136,7 +146,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		}
 	}
 
-	protected void deletePublicIp(Client client, String virtualNetworkId)
+	@VisibleForTesting
+    void deletePublicIp(Client client, String virtualNetworkId)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException, InternalServerErrorException {
 
 		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, virtualNetworkId);
@@ -147,7 +158,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		}
 	}
 
-	protected PublicIpInstance doGetInstance(Client client, String publicIpInstanceId, String computeId)
+	@VisibleForTesting
+    PublicIpInstance doGetInstance(Client client, String publicIpInstanceId, String computeId)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
 
 		VirtualMachine virtualMachine = OpenNebulaClientUtil.getVirtualMachine(client, computeId);
@@ -156,7 +168,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		return new PublicIpInstance(publicIpInstanceId, OpenNebulaStateMapper.DEFAULT_READY_STATE, publicIp);
 	}
 
-	protected String createSecurityGroup(Client client, String instanceId) throws InvalidParameterException {
+	@VisibleForTesting
+    String createSecurityGroup(Client client, String instanceId) throws InvalidParameterException {
 		String name = generateSecurityGroupName(instanceId);
 
 		// "ALL" setting applies to all protocols if a port range is not defined
@@ -207,7 +220,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		return OpenNebulaClientUtil.allocateSecurityGroup(client, template);
 	}
 
-	protected void addSecurityGroupToPublicIp(Client client, String publicIpInstanceId, String securityGroupInstanceId)
+	@VisibleForTesting
+    void addSecurityGroupToPublicIp(Client client, String publicIpInstanceId, String securityGroupInstanceId)
 			throws InvalidParameterException {
 
 		CreateNetworkUpdateRequest updateSecurityGroupsRequest = new CreateNetworkUpdateRequest.Builder()
@@ -220,7 +234,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		OpenNebulaClientUtil.updateVirtualNetwork(client, virtualNetworkId, publicNetworkUpdateTemplate);
 	}
 
-	protected void attachPublicIpToCompute(Client client, String publicIpId, String computeInstanceId)
+	@VisibleForTesting
+    void attachPublicIpToCompute(Client client, String publicIpId, String computeInstanceId)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
 
 		String template = this.createNicTemplate(publicIpId);
@@ -232,7 +247,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		}
 	}
 
-	protected String createNicTemplate(String virtualNetworkId) {
+	@VisibleForTesting
+    String createNicTemplate(String virtualNetworkId) {
 		CreateNicRequest request = new CreateNicRequest.Builder()
 				.networkId(virtualNetworkId)
 				.build();
@@ -240,7 +256,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		return request.getNic().marshalTemplate();
 	}
 
-	protected boolean isPowerOff(VirtualMachine virtualMachine) {
+	@VisibleForTesting
+    boolean isPowerOff(VirtualMachine virtualMachine) {
 		String state;
 		int count = 0;
 		while (count < ATTEMPTS_LIMIT_NUMBER) {
@@ -255,7 +272,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		return false;
 	}
 
-	protected void waitMoment() {
+	@VisibleForTesting
+    void waitMoment() {
 		try {
 			Thread.sleep(ONE_POINT_TWO_SECONDS);
 		} catch (InterruptedException e) {
@@ -263,7 +281,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		}
 	}
 
-	protected void detachPublicIpFromCompute(VirtualMachine virtualMachine, String publicIpInstanceId)
+	@VisibleForTesting
+    void detachPublicIpFromCompute(VirtualMachine virtualMachine, String publicIpInstanceId)
 			throws InvalidParameterException, InternalServerErrorException {
 
 		String nicId = virtualMachine.xpath(String.format(EXPRESSION_NIC_ID_FROM_NETWORK_ID_S_FORMAT, publicIpInstanceId));
@@ -275,7 +294,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		}
 	}
 
-	protected void deleteSecurityGroup(Client client, String publicIpInstanceId)
+	@VisibleForTesting
+    void deleteSecurityGroup(Client client, String publicIpInstanceId)
 			throws UnauthorizedRequestException, InvalidParameterException, InstanceNotFoundException, InternalServerErrorException {
 		SecurityGroup securityGroup = this.getSecurityGroupForPublicIpNetwork(client, publicIpInstanceId);
 
@@ -290,7 +310,8 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 	}
 
 	@Nullable
-	protected SecurityGroup getSecurityGroupForPublicIpNetwork(Client client, String publicIpInstanceId)
+	@VisibleForTesting
+    SecurityGroup getSecurityGroupForPublicIpNetwork(Client client, String publicIpInstanceId)
 			throws UnauthorizedRequestException, InstanceNotFoundException, InvalidParameterException {
 
 		VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, publicIpInstanceId);
@@ -317,11 +338,13 @@ public class OpenNebulaPublicIpPlugin implements PublicIpPlugin<CloudUser> {
 		return SystemConstants.PIP_SECURITY_GROUP_PREFIX + instanceId;
 	}
 
-	protected String getRandomUUID() {
+	@VisibleForTesting
+    String getRandomUUID() {
 		return UUID.randomUUID().toString();
 	}
 
-	protected int convertToInteger(String number) throws InvalidParameterException {
+	@VisibleForTesting
+    int convertToInteger(String number) throws InvalidParameterException {
 		try {
 			return Integer.parseInt(number);
 		} catch (NumberFormatException e) {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/quota/v5_4/OpenNebulaQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/quota/v5_4/OpenNebulaQuotaPlugin.java
@@ -5,6 +5,7 @@ import java.util.Properties;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+import cloud.fogbow.common.constants.FogbowConstants;
 import cloud.fogbow.common.util.BinaryUnit;
 import org.apache.log4j.Logger;
 import org.opennebula.client.Client;
@@ -40,7 +41,6 @@ public class OpenNebulaQuotaPlugin implements QuotaPlugin<CloudUser> {
     protected static final String QUOTA_CPU_USED_PATH = "VM_QUOTA/VM/CPU_USED";
     protected static final String QUOTA_MEMORY_USED_PATH = "VM_QUOTA/VM/MEMORY_USED";
     protected static final String QUOTA_VMS_USED_PATH = "VM_QUOTA/VM/VMS_USED";
-    protected static final int UNLIMITED_NETWORK_QUOTA_VALUE = -1;
 
     private String defaultDatastore;
     private String defaultPublicNetwork;
@@ -115,7 +115,7 @@ public class OpenNebulaQuotaPlugin implements QuotaPlugin<CloudUser> {
          * be created, so the value -1 will be adopted to inform this resource as
          * unlimited.
          */
-        int maxNetworks = UNLIMITED_NETWORK_QUOTA_VALUE;
+        int maxNetworks = FogbowConstants.UNLIMITED_RESOURCE;
         
         ResourceAllocation totalAllocation = ResourceAllocation.builder()
                 .instances(maxInstances)

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/quota/v5_4/OpenNebulaQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/quota/v5_4/OpenNebulaQuotaPlugin.java
@@ -47,7 +47,7 @@ public class OpenNebulaQuotaPlugin implements QuotaPlugin<CloudUser> {
     private String defaultPublicNetwork;
     private String endpoint;
 
-    public OpenNebulaQuotaPlugin(@NotBlank String confFilePath) {
+    public OpenNebulaQuotaPlugin(String confFilePath) {
         Properties properties = PropertiesUtil.readProperties(confFilePath);
         this.defaultDatastore = properties.getProperty(OpenNebulaConfigurationPropertyKeys.DEFAULT_DATASTORE_ID_KEY);
         this.defaultPublicNetwork = properties.getProperty(OpenNebulaConfigurationPropertyKeys.DEFAULT_PUBLIC_NETWORK_ID_KEY);
@@ -55,7 +55,7 @@ public class OpenNebulaQuotaPlugin implements QuotaPlugin<CloudUser> {
     }
 
     @Override
-    public ResourceQuota getUserQuota(@NotNull CloudUser cloudUser) throws FogbowException {
+    public ResourceQuota getUserQuota(CloudUser cloudUser) throws FogbowException {
         LOGGER.info(Messages.Log.GETTING_QUOTA);
         Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
         UserPool userPool = OpenNebulaClientUtil.getUserPool(client);
@@ -68,7 +68,7 @@ public class OpenNebulaQuotaPlugin implements QuotaPlugin<CloudUser> {
     }
 
     @VisibleForTesting
-    ResourceAllocation getUsedAllocation(@NotNull User user, @NotNull Client client) throws FogbowException {
+    ResourceAllocation getUsedAllocation(User user, Client client) throws FogbowException {
         String diskSizeQuotaUsedPath = String.format(FORMAT_QUOTA_DATASTORE_S_SIZE_USED_PATH, this.defaultDatastore);
         String volumeQuotaUsedPath = String.format(FORMAT_QUOTA_DATASTORE_S_IMAGES_USED_PATH, this.defaultDatastore);
         String publicIpQuotaUsedPath = String.format(FORMAT_QUOTA_NETWORK_S_USED_PATH, this.defaultPublicNetwork);
@@ -102,7 +102,7 @@ public class OpenNebulaQuotaPlugin implements QuotaPlugin<CloudUser> {
     }
 
     @VisibleForTesting
-    ResourceAllocation getTotalAllocation(@NotNull User user) {
+    ResourceAllocation getTotalAllocation(User user) {
         String diskSizeQuotaPath = String.format(FORMAT_QUOTA_DATASTORE_S_SIZE_PATH, this.defaultDatastore);
         String volumeQuotaPath = String.format(FORMAT_QUOTA_DATASTORE_S_IMAGES_PATH, this.defaultDatastore);
         String publicIpQuotaPath = String.format(FORMAT_QUOTA_NETWORK_S_PATH, this.defaultPublicNetwork);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/securityrule/v5_4/OpenNebulaSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/securityrule/v5_4/OpenNebulaSecurityRulePlugin.java
@@ -76,7 +76,7 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
     @Override
     public String requestSecurityRule(SecurityRule securityRule, Order majorOrder, CloudUser cloudUser)
             throws FogbowException {
-
+        LOGGER.info(String.format(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER));
         Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
         SecurityGroup securityGroup = getSecurityGroup(client, majorOrder);
         Rule rule = createSecurityRuleRequest(securityRule, securityGroup);
@@ -85,6 +85,7 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
     
     @Override
     public List<SecurityRuleInstance> getSecurityRules(Order majorOrder, CloudUser cloudUser) throws FogbowException {
+        LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, majorOrder.getInstanceId()));
         Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
         SecurityGroup securityGroup = getSecurityGroup(client, majorOrder);
         return doGetSecurityRules(securityGroup);
@@ -92,6 +93,7 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
 
     @Override
     public void deleteSecurityRule(String securityRuleId, CloudUser cloudUser) throws FogbowException {
+        LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, securityRuleId));
         Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
         Rule rule = doUnpakingSecurityRuleId(securityRuleId);
         String securityGroupId = rule.getGroupId();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/securityrule/v5_4/OpenNebulaSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/securityrule/v5_4/OpenNebulaSecurityRulePlugin.java
@@ -95,7 +95,7 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
     public void deleteSecurityRule(String securityRuleId, CloudUser cloudUser) throws FogbowException {
         LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, securityRuleId));
         Client client = OpenNebulaClientUtil.createClient(this.endpoint, cloudUser.getToken());
-        Rule rule = doUnpakingSecurityRuleId(securityRuleId);
+        Rule rule = doUnpackingSecurityRuleId(securityRuleId);
         String securityGroupId = rule.getGroupId();
         doDeleteSecurityRule(client, rule, securityGroupId);
     }
@@ -143,7 +143,7 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
     }
 
     @VisibleForTesting
-    Rule doUnpakingSecurityRuleId(String securityRuleId) throws FogbowException {
+    Rule doUnpackingSecurityRuleId(String securityRuleId) throws FogbowException {
         String[] fields = securityRuleId.split(ID_SEPARATOR);
         if (fields.length == SECURITY_RULE_ID_FIELDS_NUMBER) {
             String groupId = getValueFrom(fields[GROUP_ID_INDEX]);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/securityrule/v5_4/OpenNebulaSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/securityrule/v5_4/OpenNebulaSecurityRulePlugin.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Properties;
 
 import cloud.fogbow.common.exceptions.*;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.net.util.SubnetUtils;
 import org.apache.commons.net.util.SubnetUtils.SubnetInfo;
@@ -38,10 +39,14 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
     private static final String ID_SEPARATOR = "@";
     private static final String RANGE_SEPARATOR = ":";
     
-    protected static final String ALL_ADDRESSES_REMOTE_PREFIX = "0.0.0.0/0";
-    protected static final String SECURITY_GROUPS_PATH = "/VNET/TEMPLATE/SECURITY_GROUPS";
-    protected static final int MINIMUM_RANGE_PORT = 1;
-    protected static final int MAXIMUM_RANGE_PORT = 65536;
+    @VisibleForTesting
+    static final String ALL_ADDRESSES_REMOTE_PREFIX = "0.0.0.0/0";
+    @VisibleForTesting
+    static final String SECURITY_GROUPS_PATH = "/VNET/TEMPLATE/SECURITY_GROUPS";
+    @VisibleForTesting
+    static final int MINIMUM_RANGE_PORT = 1;
+    @VisibleForTesting
+    static final int MAXIMUM_RANGE_PORT = 65536;
     
     // fields indexes for instance id
     private static final int GROUP_ID_INDEX = 0;
@@ -93,7 +98,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         doDeleteSecurityRule(client, rule, securityGroupId);
     }
 
-    protected void doDeleteSecurityRule(Client client, Rule rule, String securityGroupId)
+    @VisibleForTesting
+    void doDeleteSecurityRule(Client client, Rule rule, String securityGroupId)
             throws FogbowException {
 
         SecurityGroup securityGroup = OpenNebulaClientUtil.getSecurityGroup(client, securityGroupId);
@@ -108,7 +114,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         }
     }
 
-    protected String generateUpdateRequest(GetSecurityGroupResponse group, List<Rule> rules) {
+    @VisibleForTesting
+    String generateUpdateRequest(GetSecurityGroupResponse group, List<Rule> rules) {
         String id = group.getId();
         String name = group.getName();
 
@@ -121,7 +128,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return request.marshalTemplate();
     }
 
-    protected boolean removeRule(List<Rule> rules, Rule ruleToRemove) {
+    @VisibleForTesting
+    boolean removeRule(List<Rule> rules, Rule ruleToRemove) {
         if (rules != null) {
             for (Rule rule : rules) {
                 if (rule.equals(ruleToRemove)) {
@@ -132,7 +140,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return false;
     }
 
-    protected Rule doUnpakingSecurityRuleId(String securityRuleId) throws FogbowException {
+    @VisibleForTesting
+    Rule doUnpakingSecurityRuleId(String securityRuleId) throws FogbowException {
         String[] fields = securityRuleId.split(ID_SEPARATOR);
         if (fields.length == SECURITY_RULE_ID_FIELDS_NUMBER) {
             String groupId = getValueFrom(fields[GROUP_ID_INDEX]);
@@ -162,7 +171,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return !value.isEmpty() ? value : null;
     }
     
-    protected List<SecurityRuleInstance> doGetSecurityRules(SecurityGroup securityGroup) {
+    @VisibleForTesting
+    List<SecurityRuleInstance> doGetSecurityRules(SecurityGroup securityGroup) {
         List<SecurityRuleInstance> instances = new ArrayList<>();
         GetSecurityGroupResponse group = doGetSecurityGroupResponse(securityGroup);
         List<Rule> rules = getRulesFrom(group);
@@ -174,7 +184,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return instances;
     }
 
-    protected SecurityRuleInstance buildSecurityRule(Rule rule) {
+    @VisibleForTesting
+    SecurityRuleInstance buildSecurityRule(Rule rule) {
         String id = doPackingSecurityRuleId(rule);
         String cidr = SecurityRuleUtil.getAddressCidr(rule);
         String range = rule.getRange();
@@ -190,7 +201,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return new SecurityRuleInstance(id, direction, portFrom, portTo, cidr, etherType, protocol);
     }
     
-    protected String doRequestSecurityRule(SecurityGroup securityGroup, Rule rule) throws FogbowException {
+    @VisibleForTesting
+    String doRequestSecurityRule(SecurityGroup securityGroup, Rule rule) throws FogbowException {
         GetSecurityGroupResponse securityGroupResponse = doGetSecurityGroupResponse(securityGroup);
         String id = securityGroupResponse.getId();
         String name = securityGroupResponse.getName();
@@ -208,7 +220,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return doPackingSecurityRuleId(rule);
     }
     
-    protected List<Rule> getRulesFrom(GetSecurityGroupResponse response) {
+    @VisibleForTesting
+    List<Rule> getRulesFrom(GetSecurityGroupResponse response) {
         List<Rule> rules = new ArrayList<>();
         if (response.getTemplate().getRules() != null) {
             rules = response.getTemplate().getRules();
@@ -216,7 +229,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return rules;
     }
 
-    protected void updateSecurityGroup(SecurityGroup securityGroup, String template) throws FogbowException {
+    @VisibleForTesting
+    void updateSecurityGroup(SecurityGroup securityGroup, String template) throws FogbowException {
         OneResponse response = securityGroup.update(template);
         if (response.isError()) {
             String message = String.format(Messages.Log.ERROR_WHILE_UPDATING_SECURITY_GROUPS_S, template);
@@ -225,7 +239,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         }
     }
 
-    protected String doPackingSecurityRuleId(Rule rule) {
+    @VisibleForTesting
+    String doPackingSecurityRuleId(Rule rule) {
         String[] attributes = new String[SECURITY_RULE_ID_FIELDS_NUMBER];
         attributes[GROUP_ID_INDEX] = rule.getGroupId();
         attributes[NETWORK_ID_INDEX] = getNetworkIdFrom(rule);
@@ -239,13 +254,15 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return instanceId;
     }
 
-    protected String getNetworkIdFrom(Rule rule) {
+    @VisibleForTesting
+    String getNetworkIdFrom(Rule rule) {
         return rule.getNetworkId() != null 
                 ? String.valueOf(rule.getNetworkId()) 
                 : EMPTY_STRING;
     }
     
-    protected GetSecurityGroupResponse doGetSecurityGroupResponse(SecurityGroup securityGroup) {
+    @VisibleForTesting
+    GetSecurityGroupResponse doGetSecurityGroupResponse(SecurityGroup securityGroup) {
         String xml = securityGroup.info().getMessage();
         
         GetSecurityGroupResponse response = GetSecurityGroupResponse.unmarshaller()
@@ -255,7 +272,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return response;
     }
 
-    protected Rule createSecurityRuleRequest(SecurityRule securityRule, SecurityGroup securityGroup) {
+    @VisibleForTesting
+    Rule createSecurityRuleRequest(SecurityRule securityRule, SecurityGroup securityGroup) {
         int portFrom = securityRule.getPortFrom();
         int portTo = securityRule.getPortTo();
 
@@ -280,7 +298,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return rule;
     }
 
-    protected String getRuleTypeBy(Direction direction) {
+    @VisibleForTesting
+    String getRuleTypeBy(Direction direction) {
         String type = null;
         switch (direction) {
         case IN:
@@ -291,17 +310,20 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return type;
     }
     
-    protected String getIpAddress(SecurityRule securityRule) {
+    @VisibleForTesting
+    String getIpAddress(SecurityRule securityRule) {
         String[] cidrSliced = getCidrFrom(securityRule);
         return cidrSliced != null ? cidrSliced[IP_POSITION] : null;
     }
     
-    protected String getAddressSize(SecurityRule securityRule) {
+    @VisibleForTesting
+    String getAddressSize(SecurityRule securityRule) {
         String[] cidrSliced = getCidrFrom(securityRule);
         return cidrSliced != null ? cidrSliced[SIZE_POSITION] : null;
     }
 
-    protected String[] getCidrFrom(SecurityRule securityRule) {
+    @VisibleForTesting
+    String[] getCidrFrom(SecurityRule securityRule) {
         SubnetUtils subnetUtils = new SubnetUtils(securityRule.getCidr());
         SubnetInfo subnetInfo = subnetUtils.getInfo();
 
@@ -315,7 +337,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return null;
     }
 
-    protected SecurityGroup getSecurityGroup(Client client, Order majorOrder) throws FogbowException {
+    @VisibleForTesting
+    SecurityGroup getSecurityGroup(Client client, Order majorOrder) throws FogbowException {
         String securityGroupName = retrieveSecurityGroupName(majorOrder);
         String virtualNetworkId = majorOrder.getInstanceId();
         VirtualNetwork virtualNetwork = OpenNebulaClientUtil.getVirtualNetwork(client, virtualNetworkId);
@@ -324,7 +347,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return securityGroup;
     }
 
-    protected SecurityGroup findSecurityGroupByName(Client client, String content, String name) throws FogbowException {
+    @VisibleForTesting
+    SecurityGroup findSecurityGroupByName(Client client, String content, String name) throws FogbowException {
         String[] securityGroupIds = content.split(CONTENT_SEPARATOR);
         SecurityGroup securityGroup = null;
         for (String securityGroupId : securityGroupIds) {
@@ -336,7 +360,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         throw new InstanceNotFoundException(Messages.Exception.INSTANCE_NOT_FOUND);
     }
 
-    protected String getSecurityGroupContentFrom(VirtualNetwork virtualNetwork) throws FogbowException {
+    @VisibleForTesting
+    String getSecurityGroupContentFrom(VirtualNetwork virtualNetwork) throws FogbowException {
         String content = virtualNetwork.xpath(SECURITY_GROUPS_PATH);
         if (content == null || content.isEmpty()) {
             String message = Messages.Log.CONTENT_SECURITY_GROUP_NOT_DEFINED;
@@ -345,7 +370,8 @@ public class OpenNebulaSecurityRulePlugin implements SecurityRulePlugin<CloudUse
         return content;
     }
 
-    protected String retrieveSecurityGroupName(Order majorOrder) throws FogbowException {
+    @VisibleForTesting
+    String retrieveSecurityGroupName(Order majorOrder) throws FogbowException {
         switch (majorOrder.getType()) {
         case NETWORK:
             return SystemConstants.PN_SECURITY_GROUP_PREFIX + majorOrder.getInstanceId();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/volume/v5_4/OpenNebulaVolumePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/volume/v5_4/OpenNebulaVolumePlugin.java
@@ -142,7 +142,6 @@ public class OpenNebulaVolumePlugin implements VolumePlugin<CloudUser> {
 		return image;
 	}
 
-	@Nullable
 	protected Integer getDataStoreId(Client client, long diskSize) throws InternalServerErrorException {
 		DatastorePool datastorePool = OpenNebulaClientUtil.getDatastorePool(client);
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/volume/v5_4/OpenNebulaVolumePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/volume/v5_4/OpenNebulaVolumePlugin.java
@@ -33,15 +33,23 @@ public class OpenNebulaVolumePlugin implements VolumePlugin<CloudUser> {
 
 	private static final Logger LOGGER = Logger.getLogger(OpenNebulaVolumePlugin.class);
 
-	protected static final String BLOCK_DISK_TYPE = "BLOCK";
-	protected static final String DATABLOCK_IMAGE_TYPE = "DATABLOCK";
-	protected static final String DEFAULT_DATASTORE_DEVICE_PREFIX = "vd";
-	protected static final String DRIVER_RAW = "raw";
-	protected static final String PERSISTENT_DISK_CONFIRMATION = "YES";
-	protected static final int CONVERT_DISK = 1024;
+	@VisibleForTesting
+    static final String BLOCK_DISK_TYPE = "BLOCK";
+	@VisibleForTesting
+    static final String DATABLOCK_IMAGE_TYPE = "DATABLOCK";
+	@VisibleForTesting
+    static final String DEFAULT_DATASTORE_DEVICE_PREFIX = "vd";
+	@VisibleForTesting
+    static final String DRIVER_RAW = "raw";
+	@VisibleForTesting
+    static final String PERSISTENT_DISK_CONFIRMATION = "YES";
+	@VisibleForTesting
+    static final int CONVERT_DISK = 1024;
 
-	protected static final String DATASTORE_FREE_PATH_FORMAT = "//DATASTORE[%s]/FREE_MB";
-	protected static final String IMAGE_TYPE = "IMAGE";
+	@VisibleForTesting
+    static final String DATASTORE_FREE_PATH_FORMAT = "//DATASTORE[%s]/FREE_MB";
+	@VisibleForTesting
+    static final String IMAGE_TYPE = "IMAGE";
 
 	private String endpoint;
 
@@ -119,7 +127,8 @@ public class OpenNebulaVolumePlugin implements VolumePlugin<CloudUser> {
 		}
 	}
 
-	protected String doRequestInstance(CreateVolumeRequest createVolumeRequest, Client client)
+	@VisibleForTesting
+    String doRequestInstance(CreateVolumeRequest createVolumeRequest, Client client)
 			throws UnacceptableOperationException, InternalServerErrorException, InvalidParameterException {
 		VolumeImage volumeImage = createVolumeRequest.getVolumeImage();
 
@@ -132,7 +141,8 @@ public class OpenNebulaVolumePlugin implements VolumePlugin<CloudUser> {
 		return OpenNebulaClientUtil.allocateImage(client, template, datastoreId);
 	}
 
-	protected Image doGetInstance(Client client, String instanceId) throws InternalServerErrorException, InstanceNotFoundException {
+	@VisibleForTesting
+    Image doGetInstance(Client client, String instanceId) throws InternalServerErrorException, InstanceNotFoundException {
 		ImagePool imagePool = OpenNebulaClientUtil.getImagePool(client);
 		Image image = imagePool.getById(Integer.parseInt(instanceId));
 		if (image == null) {
@@ -142,7 +152,8 @@ public class OpenNebulaVolumePlugin implements VolumePlugin<CloudUser> {
 		return image;
 	}
 
-	protected Integer getDataStoreId(Client client, long diskSize) throws InternalServerErrorException {
+	@VisibleForTesting
+    Integer getDataStoreId(Client client, long diskSize) throws InternalServerErrorException {
 		DatastorePool datastorePool = OpenNebulaClientUtil.getDatastorePool(client);
 
 		int index = 1;
@@ -167,7 +178,8 @@ public class OpenNebulaVolumePlugin implements VolumePlugin<CloudUser> {
 		return null;
 	}
 
-	protected int getImageSize(String size) {
+	@VisibleForTesting
+    int getImageSize(String size) {
 		int imageSize = 0;
 		try {
 			imageSize = Integer.parseInt(size) / CONVERT_DISK;
@@ -178,7 +190,8 @@ public class OpenNebulaVolumePlugin implements VolumePlugin<CloudUser> {
 		return imageSize;
 	}
 
-	protected String getRandomUUID() {
+	@VisibleForTesting
+    String getRandomUUID() {
 		return UUID.randomUUID().toString();
 	}
 }

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/image/v5_4/OpenNebulaImagePluginTest.java
@@ -84,7 +84,7 @@ public class OpenNebulaImagePluginTest extends OpenNebulaBaseTests {
 		ImageInstance imageInstance = Mockito.mock(ImageInstance.class);
 
 		Mockito.when(OpenNebulaClientUtil.getImage(Mockito.any(Client.class), Mockito.anyString())).thenReturn(image);
-		Mockito.doReturn(imageInstance).when(this.plugin).mount(this.image);
+		Mockito.doReturn(imageInstance).when(this.plugin).buildImageInstance(this.image);
 
 		// exercise
 		this.plugin.getImage(FAKE_ID, cloudUser);
@@ -96,7 +96,7 @@ public class OpenNebulaImagePluginTest extends OpenNebulaBaseTests {
 		PowerMockito.verifyStatic(OpenNebulaClientUtil.class, Mockito.times(TestUtils.RUN_ONCE));
 		OpenNebulaClientUtil.getImage(Mockito.any(Client.class), Mockito.eq(FAKE_ID));
 
-		Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).mount(Mockito.eq(this.image));
+		Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).buildImageInstance(Mockito.eq(this.image));
 	}
 
 	// test case: when calling getImageSummaryList with a valid image pool, return a list
@@ -136,7 +136,7 @@ public class OpenNebulaImagePluginTest extends OpenNebulaBaseTests {
 				.thenReturn(InstanceState.READY);
 
 		// exercise
-		ImageInstance instance = this.plugin.mount(this.image);
+		ImageInstance instance = this.plugin.buildImageInstance(this.image);
 
 		// verify
         Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).convertToInteger(ID_VALUE_ONE);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/network/v5_4/OpenNebulaNetworkPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/network/v5_4/OpenNebulaNetworkPluginTest.java
@@ -78,7 +78,7 @@ public class OpenNebulaNetworkPluginTest extends OpenNebulaBaseTests {
 		Mockito.doReturn(request).when(this.plugin).getCreateNetworkReserveRequest(
 				Mockito.any(NetworkOrder.class), Mockito.any(VirtualNetwork.class));
 		Mockito.doReturn(this.networkOrder.getInstanceId()).when(this.plugin).doRequestInstance(
-				Mockito.any(Client.class), Mockito.anyString(), Mockito.any(CreateNetworkReserveRequest.class));
+				Mockito.any(Client.class),Mockito.any(CreateNetworkReserveRequest.class));
 
 		// exercise
 		this.plugin.requestInstance(this.networkOrder, this.cloudUser);
@@ -90,7 +90,7 @@ public class OpenNebulaNetworkPluginTest extends OpenNebulaBaseTests {
 		OpenNebulaClientUtil.getVirtualNetwork(Mockito.any(Client.class), Mockito.anyString());
 
 		Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).doRequestInstance(
-				Mockito.any(Client.class), Mockito.anyString(), Mockito.any(CreateNetworkReserveRequest.class));
+				Mockito.any(Client.class), Mockito.any(CreateNetworkReserveRequest.class));
 	}
 
 	// test case: when invoking getCreateNetworkReserveRequest with valid network order and virtual network,
@@ -221,7 +221,7 @@ public class OpenNebulaNetworkPluginTest extends OpenNebulaBaseTests {
 				Mockito.any(Client.class), Mockito.anyString());
 
 		// exercise
-		this.plugin.doRequestInstance(this.client, this.orderId, request);
+		this.plugin.doRequestInstance(this.client, request);
 
 		// verify
 		PowerMockito.verifyStatic(OpenNebulaClientUtil.class);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/quota/v5_4/OpenNebulaQuotaPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/quota/v5_4/OpenNebulaQuotaPluginTest.java
@@ -1,5 +1,6 @@
 package cloud.fogbow.ras.core.plugins.interoperability.opennebula.quota.v5_4;
 
+import cloud.fogbow.common.constants.FogbowConstants;
 import cloud.fogbow.common.util.BinaryUnit;
 import org.junit.Assert;
 import org.junit.Before;
@@ -238,7 +239,7 @@ public class OpenNebulaQuotaPluginTest extends OpenNebulaBaseTests {
         int maxRam = Integer.parseInt(MEMORY_MAX_VALUE);
         int maxDiskInMB = Integer.parseInt(DISK_MAX_VALUE);
         int maxDiskInGB = (int) BinaryUnit.megabytes(maxDiskInMB).asGigabytes();
-        int maxNetworks = OpenNebulaQuotaPlugin.UNLIMITED_NETWORK_QUOTA_VALUE;
+        int maxNetworks = FogbowConstants.UNLIMITED_RESOURCE;
         int maxPublicIps = Integer.parseInt(PUBLIC_IP_MAX_VALUE);
         int maxVolumes = Integer.parseInt(MAX_VOLUMES);
         

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/quota/v5_4/OpenNebulaQuotaPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/quota/v5_4/OpenNebulaQuotaPluginTest.java
@@ -1,5 +1,6 @@
 package cloud.fogbow.ras.core.plugins.interoperability.opennebula.quota.v5_4;
 
+import cloud.fogbow.common.util.BinaryUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -235,8 +236,8 @@ public class OpenNebulaQuotaPluginTest extends OpenNebulaBaseTests {
         int maxInstances = Integer.parseInt(VMS_MAX_VALUE);
         int maxCPU = Integer.parseInt(CPU_MAX_VALUE);
         int maxRam = Integer.parseInt(MEMORY_MAX_VALUE);
-        int maxDisk = Integer.parseInt(DISK_MAX_VALUE);
-        int maxDiskInGB = this.plugin.convertMegabytesIntoGigabytes(maxDisk);
+        int maxDiskInMB = Integer.parseInt(DISK_MAX_VALUE);
+        int maxDiskInGB = (int) BinaryUnit.megabytes(maxDiskInMB).asGigabytes();
         int maxNetworks = OpenNebulaQuotaPlugin.UNLIMITED_NETWORK_QUOTA_VALUE;
         int maxPublicIps = Integer.parseInt(PUBLIC_IP_MAX_VALUE);
         int maxVolumes = Integer.parseInt(MAX_VOLUMES);
@@ -258,8 +259,8 @@ public class OpenNebulaQuotaPluginTest extends OpenNebulaBaseTests {
         int usedInstances = Integer.parseInt(VMS_USED_VALUE);
         int usedCPU = Integer.parseInt(CPU_USED_VALUE);
         int usedRam = Integer.parseInt(MEMORY_USED_VALUE);
-        int usedDisk = Integer.parseInt(DISK_USED_VALUE);
-        int usedDiskInGB = this.plugin.convertMegabytesIntoGigabytes(usedDisk);
+        int usedDiskMB = Integer.parseInt(DISK_USED_VALUE);
+        int usedDiskInGB = (int) BinaryUnit.megabytes(usedDiskMB).asGigabytes();
         int usedNetworks = Integer.parseInt(NETWORK_USED_VALUE);
         int usedPublicIps = Integer.parseInt(PUBLIC_IP_USED_VALUE);
         int usedVolumes = Integer.parseInt(USED_VOLUMES);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/securityrule/v5_4/OpenNebulaSecurityRulePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/securityrule/v5_4/OpenNebulaSecurityRulePluginTest.java
@@ -120,7 +120,7 @@ public class OpenNebulaSecurityRulePluginTest extends OpenNebulaBaseTests {
         String securityGroupId = TestUtils.FAKE_SECURITY_GROUP_ID;
 
         Rule rule = buildRule();
-        Mockito.doReturn(rule).when(this.plugin).doUnpakingSecurityRuleId(Mockito.eq(securityRuleId));
+        Mockito.doReturn(rule).when(this.plugin).doUnpackingSecurityRuleId(Mockito.eq(securityRuleId));
         Mockito.doNothing().when(this.plugin).doDeleteSecurityRule(Mockito.eq(this.client), Mockito.eq(rule),
                 Mockito.eq(securityGroupId));
 
@@ -132,7 +132,7 @@ public class OpenNebulaSecurityRulePluginTest extends OpenNebulaBaseTests {
         OpenNebulaClientUtil.createClient(Mockito.eq(this.endpoint), Mockito.eq(this.cloudUser.getToken()));
 
         Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE))
-                .doUnpakingSecurityRuleId(Mockito.eq(securityRuleId));
+                .doUnpackingSecurityRuleId(Mockito.eq(securityRuleId));
         Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).doDeleteSecurityRule(Mockito.eq(this.client),
                 Mockito.eq(rule), Mockito.eq(securityGroupId));
     }
@@ -210,7 +210,7 @@ public class OpenNebulaSecurityRulePluginTest extends OpenNebulaBaseTests {
         Rule expected = buildRule();
         
         // exercise
-        Rule rule = this.plugin.doUnpakingSecurityRuleId(securityRuleId);
+        Rule rule = this.plugin.doUnpackingSecurityRuleId(securityRuleId);
         
         // verify
         Assert.assertEquals(expected, rule);
@@ -228,7 +228,7 @@ public class OpenNebulaSecurityRulePluginTest extends OpenNebulaBaseTests {
         
         try {
             // exercise
-            this.plugin.doUnpakingSecurityRuleId(securityRuleId);
+            this.plugin.doUnpackingSecurityRuleId(securityRuleId);
             Assert.fail();
         } catch (InvalidParameterException e) {
             // verify

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/volume/v5_4/OpenNebulaVolumePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/opennebula/volume/v5_4/OpenNebulaVolumePluginTest.java
@@ -367,7 +367,7 @@ public class OpenNebulaVolumePluginTest extends OpenNebulaBaseTests {
 		Mockito.verify(this.plugin, Mockito.times(TestUtils.RUN_ONCE)).doGetInstance(
 				Mockito.any(Client.class), Mockito.eq(this.volumeOrder.getInstanceId()));
 		Mockito.verify(response, Mockito.times(TestUtils.RUN_ONCE)).isError();
-		Mockito.verify(response, Mockito.times(TestUtils.RUN_TWICE)).getMessage();
+		Mockito.verify(response, Mockito.times(TestUtils.RUN_ONCE)).getMessage();
 	}
 
 	private String getTemplate() {


### PR DESCRIPTION
This pull request refactors the OpenNebula and CloudStack plugins

**Requires:** https://github.com/fogbow/common/pull/171

## CloudStack
- **[All interoperability plugins]** Remove @NotNull annotations
- **[All interoperability plugins]** Change protected for default visibility and add @VisibleForTesting annotation
- **[All interoperability plugins]** Add logging for request and get instance actions
- **[Several interoperability plugins]** Change local byte conversion implementation for a common one
- **[StateMapper]** Update hardcoded constants holding class names for a call on class.getSimpleName()

## OpenNebula
- **[All interoperability plugins]** Remove @NotNull annotations
- **[All interoperability plugins]** Change protected for default visibility and add @VisibleForTesting annotation
- **[All interoperability plugins]** Add logging for request and get instance actions
- **[AttachmentPlugin]** Fix typo in variable names
- **[Compute/Quota/Volume plugins]** Change local byte conversion implementation for a common one
- **[ImagePlugin]** Rename methods for better understanding
- **[ImagePlugin]** Replace hardcoded values for constants from common
- **[NetworkPlugin]** Remove unused parameters
- **[QuotaPlugin]** Replace local constants for common constants
- **[SecurityRulePlugin]** Fix typo in method names
- **[StateMapper]** Update hardcoded constants holding class names for a call on class.getSimpleName()

