### PR TITLE
Openstack intraplugin refactor

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/attachment/v2/OpenStackAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/attachment/v2/OpenStackAttachmentPlugin.java
@@ -7,6 +7,7 @@ import cloud.fogbow.common.exceptions.InternalServerErrorException;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.requests.CreateAttachmentRequest;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.CreateAttachmentResponse;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.GetAttachmentResponse;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
 import com.google.gson.JsonSyntaxException;
@@ -29,7 +30,8 @@ public class OpenStackAttachmentPlugin implements AttachmentPlugin<OpenStackV3Us
     
     private static final Logger LOGGER = Logger.getLogger(OpenStackAttachmentPlugin.class);
 
-    protected static final String EMPTY_STRING = "";
+    @VisibleForTesting
+    static final String EMPTY_STRING = "";
 
     private Properties properties;
     private OpenStackHttpClient client;
@@ -108,7 +110,8 @@ public class OpenStackAttachmentPlugin implements AttachmentPlugin<OpenStackV3Us
         return attachmentInstance;
     }
 
-    protected AttachmentInstance buildAttachmentInstanceFrom(GetAttachmentResponse response) {
+    @VisibleForTesting
+    AttachmentInstance buildAttachmentInstanceFrom(GetAttachmentResponse response) {
         String id = response.getId();
         String computeId = response.getServerId();
         String volumeId = response.getVolumeId();
@@ -123,12 +126,14 @@ public class OpenStackAttachmentPlugin implements AttachmentPlugin<OpenStackV3Us
         return attachmentInstance;
     }
 
-    protected GetAttachmentResponse doGetInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    GetAttachmentResponse doGetInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         String jsonResponse = this.client.doGetRequest(endpoint, cloudUser);
         return doGetAttachmentResponseFrom(jsonResponse);
     }
 
-    protected GetAttachmentResponse doGetAttachmentResponseFrom(String json) throws InternalServerErrorException {
+    @VisibleForTesting
+    GetAttachmentResponse doGetAttachmentResponseFrom(String json) throws InternalServerErrorException {
         try {
             return GetAttachmentResponse.fromJson(json);
         } catch (JsonSyntaxException e) {
@@ -137,18 +142,21 @@ public class OpenStackAttachmentPlugin implements AttachmentPlugin<OpenStackV3Us
         }
     }
 
-    protected void doDeleteInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    void doDeleteInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         this.client.doDeleteRequest(endpoint, cloudUser);
     }
 
-    protected CreateAttachmentResponse doRequestInstance(String endpoint, String jsonRequest,
+    @VisibleForTesting
+    CreateAttachmentResponse doRequestInstance(String endpoint, String jsonRequest,
             OpenStackV3User cloudUser) throws FogbowException {
         
         String jsonResponse = this.client.doPostRequest(endpoint, jsonRequest, cloudUser);
         return doCreateAttachmentResponseFrom(jsonResponse);
     }
 
-    protected CreateAttachmentResponse doCreateAttachmentResponseFrom(String json) throws InternalServerErrorException {
+    @VisibleForTesting
+    CreateAttachmentResponse doCreateAttachmentResponseFrom(String json) throws InternalServerErrorException {
         try {
             return CreateAttachmentResponse.fromJson(json);
         } catch (JsonSyntaxException e) {
@@ -157,7 +165,8 @@ public class OpenStackAttachmentPlugin implements AttachmentPlugin<OpenStackV3Us
         }
     }
 
-    protected String generateJsonRequest(String volumeId, String device) {
+    @VisibleForTesting
+    String generateJsonRequest(String volumeId, String device) {
         CreateAttachmentRequest request = new CreateAttachmentRequest.Builder()
                 .volumeId(volumeId)
                 .device(device)
@@ -166,7 +175,8 @@ public class OpenStackAttachmentPlugin implements AttachmentPlugin<OpenStackV3Us
         return request.toJson();
     }
     
-    protected String getPrefixEndpoint(String projectId) {
+    @VisibleForTesting
+    String getPrefixEndpoint(String projectId) {
         return this.properties.getProperty(OpenStackPluginUtils.COMPUTE_NOVA_URL_KEY) +
                 OpenStackConstants.NOVA_V2_API_ENDPOINT + OpenStackConstants.ENDPOINT_SEPARATOR + projectId;
     }
@@ -175,7 +185,8 @@ public class OpenStackAttachmentPlugin implements AttachmentPlugin<OpenStackV3Us
         this.client = new OpenStackHttpClient();
     }
 
-    protected void setClient(OpenStackHttpClient client) {
+    @VisibleForTesting
+    void setClient(OpenStackHttpClient client) {
         this.client = client;
     }
     

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/attachment/v2/OpenStackAttachmentPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/attachment/v2/OpenStackAttachmentPlugin.java
@@ -51,9 +51,10 @@ public class OpenStackAttachmentPlugin implements AttachmentPlugin<OpenStackV3Us
 
     @Override
     public String requestInstance(AttachmentOrder attachmentOrder, OpenStackV3User cloudUser) throws FogbowException {
+        LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String serverId = attachmentOrder.getComputeId();
-        String endpoint = getPrefixEndpoint(projectId) 
+        String endpoint = getPrefixEndpoint(projectId)
                 + OpenStackConstants.SERVERS_ENDPOINT
                 + OpenStackConstants.ENDPOINT_SEPARATOR
                 + serverId 
@@ -69,6 +70,9 @@ public class OpenStackAttachmentPlugin implements AttachmentPlugin<OpenStackV3Us
 
     @Override
     public void deleteInstance(AttachmentOrder attachmentOrder, OpenStackV3User cloudUser) throws FogbowException {
+        String instanceId = attachmentOrder.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
+
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String serverId = attachmentOrder.getComputeId();
         String volumeId = attachmentOrder.getVolumeId();
@@ -85,6 +89,9 @@ public class OpenStackAttachmentPlugin implements AttachmentPlugin<OpenStackV3Us
 
     @Override
     public AttachmentInstance getInstance(AttachmentOrder order, OpenStackV3User cloudUser) throws FogbowException {
+        String instanceId = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
+
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String serverId = order.getComputeId();
         String volumeId = order.getVolumeId();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/compute/v2/OpenStackComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/compute/v2/OpenStackComputePlugin.java
@@ -6,6 +6,7 @@ import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.common.util.connectivity.cloud.openstack.OpenStackHttpClient;
 import cloud.fogbow.common.models.OpenStackV3User;
 import cloud.fogbow.ras.api.http.response.NetworkSummary;
+import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.constants.SystemConstants;
 import cloud.fogbow.ras.core.models.HardwareRequirements;
 import cloud.fogbow.ras.core.models.ResourceType;
@@ -51,6 +52,7 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
 
     @Override
     public String requestInstance(ComputeOrder computeOrder, OpenStackV3User cloudUser) throws FogbowException {
+        LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
         HardwareRequirements hardwareRequirements = findSmallestFlavor(computeOrder, cloudUser);
         String flavorId = hardwareRequirements.getFlavorId();
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
@@ -77,6 +79,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
     }
     @Override
     public ComputeInstance getInstance(ComputeOrder computeOrder, OpenStackV3User cloudUser) throws FogbowException {
+        String instanceId = computeOrder.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String endpoint = getComputeEndpoint(projectId, OpenStackConstants.SERVERS_ENDPOINT + "/" + computeOrder.getInstanceId());
 
@@ -91,6 +95,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
 
     @Override
     public void deleteInstance(ComputeOrder computeOrder, OpenStackV3User cloudUser) throws FogbowException {
+        String instanceId = computeOrder.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String endpoint = getComputeEndpoint(projectId, OpenStackConstants.SERVERS_ENDPOINT + "/" + computeOrder.getInstanceId());
         this.doDeleteRequest(endpoint, cloudUser);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/compute/v2/OpenStackComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/compute/v2/OpenStackComputePlugin.java
@@ -22,6 +22,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializ
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.*;
 import cloud.fogbow.ras.core.plugins.interoperability.util.DefaultLaunchCommandGenerator;
 import cloud.fogbow.ras.core.plugins.interoperability.util.LaunchCommandGenerator;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
 import java.util.*;
@@ -102,12 +103,14 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         this.doDeleteRequest(endpoint, cloudUser);
     }
 
-    protected String doGetInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    String doGetInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         String jsonResponse = this.client.doGetRequest(endpoint, cloudUser);
         return jsonResponse;
     }
 
-    protected List<NetworkSummary> getComputeNetworks() {
+    @VisibleForTesting
+    List<NetworkSummary> getComputeNetworks() {
         // The default network is always included in the order by the OpenStack plugin, thus it should be added
         // in the map of networks in the ComputeInstance by the plugin. The remaining networks passed by the user
         // are appended by the LocalCloudConnector.
@@ -117,7 +120,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return computeNetworks;
     }
 
-    protected List<String> getNetworkIds(ComputeOrder computeOrder) {
+    @VisibleForTesting
+    List<String> getNetworkIds(ComputeOrder computeOrder) {
         List<String> networkIds = new ArrayList<>();
         String defaultNetworkId = this.properties.getProperty(OpenStackPluginUtils.DEFAULT_NETWORK_ID_KEY);
         networkIds.add(defaultNetworkId);
@@ -128,7 +132,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return networkIds;
     }
 
-    protected String doRequestInstance(String projectId, String keyName, String body, OpenStackV3User cloudUser)
+    @VisibleForTesting
+    String doRequestInstance(String projectId, String keyName, String body, OpenStackV3User cloudUser)
             throws FogbowException {
         String endpoint = getComputeEndpoint(projectId, OpenStackConstants.SERVERS_ENDPOINT);
 
@@ -149,7 +154,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return instanceId;
     }
 
-    protected void setAllocationToOrder(ComputeOrder computeOrder, HardwareRequirements hardwareRequirements) {
+    @VisibleForTesting
+    void setAllocationToOrder(ComputeOrder computeOrder, HardwareRequirements hardwareRequirements) {
         synchronized (computeOrder) {
             ComputeAllocation actualAllocation = new ComputeAllocation(
                     1, hardwareRequirements.getCpu(),
@@ -171,7 +177,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         this.client = new OpenStackHttpClient();
     }
 
-    protected String getKeyName(String projectId, String publicKey, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    String getKeyName(String projectId, String publicKey, OpenStackV3User cloudUser) throws FogbowException {
         String keyName = null;
 
         if (publicKey != null && !publicKey.isEmpty()) {
@@ -189,23 +196,27 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return keyName;
     }
 
-    protected void doCreateKeyName(String osKeypairEndpoint, String body, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    void doCreateKeyName(String osKeypairEndpoint, String body, OpenStackV3User cloudUser) throws FogbowException {
         this.client.doPostRequest(osKeypairEndpoint, body, cloudUser);
     }
 
-    protected String getComputeEndpoint(String projectId, String suffix) {
+    @VisibleForTesting
+    String getComputeEndpoint(String projectId, String suffix) {
         return this.properties.getProperty(OpenStackPluginUtils.COMPUTE_NOVA_URL_KEY) +
                 OpenStackConstants.NOVA_V2_API_ENDPOINT + OpenStackConstants.ENDPOINT_SEPARATOR + projectId + suffix;
     }
 
-    protected void deleteKeyName(String projectId, String keyName, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    void deleteKeyName(String projectId, String keyName, OpenStackV3User cloudUser) throws FogbowException {
         String suffixEndpoint = OpenStackConstants.KEYPAIRS_ENDPOINT + "/" + keyName;
         String keyNameEndpoint = getComputeEndpoint(projectId, suffixEndpoint);
 
         doDeleteRequest(keyNameEndpoint, cloudUser);
     }
 
-    protected CreateComputeRequest getRequestBody(String instanceName, String imageRef, String flavorRef, String userdata,
+    @VisibleForTesting
+    CreateComputeRequest getRequestBody(String instanceName, String imageRef, String flavorRef, String userdata,
                                                   String keyName, List<String> networksIds) {
         List<CreateComputeRequest.Network> networks = new ArrayList<>();
         List<CreateComputeRequest.SecurityGroup> securityGroups = new ArrayList<>();
@@ -222,7 +233,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return getCreateComputeRequest(instanceName, imageRef, flavorRef, userdata, keyName, networks, securityGroups);
     }
 
-    protected CreateComputeRequest getCreateComputeRequest(String instanceName, String imageRef, String flavorRef,
+    @VisibleForTesting
+    CreateComputeRequest getCreateComputeRequest(String instanceName, String imageRef, String flavorRef,
                                                         String userdata, String keyName, List<CreateComputeRequest.Network> networks,
                                                         List<CreateComputeRequest.SecurityGroup> securityGroups) {
         // do not specify security groups if no additional network was given
@@ -241,7 +253,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return createComputeRequest;
     }
 
-    protected HardwareRequirements findSmallestFlavor(ComputeOrder computeOrder, OpenStackV3User cloudUser)
+    @VisibleForTesting
+    HardwareRequirements findSmallestFlavor(ComputeOrder computeOrder, OpenStackV3User cloudUser)
             throws FogbowException {
         HardwareRequirements bestFlavor = getBestFlavor(computeOrder, cloudUser);
         if (bestFlavor == null) {
@@ -250,7 +263,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return bestFlavor;
     }
 
-    protected HardwareRequirements getBestFlavor(ComputeOrder computeOrder, OpenStackV3User cloudUser)
+    @VisibleForTesting
+    HardwareRequirements getBestFlavor(ComputeOrder computeOrder, OpenStackV3User cloudUser)
             throws FogbowException {
         updateFlavors(computeOrder, cloudUser);
         TreeSet<HardwareRequirements> hardwareRequirementsList = getHardwareRequirementsList();
@@ -264,7 +278,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return null;
     }
 
-    protected void updateFlavors(ComputeOrder computeOrder, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    void updateFlavors(ComputeOrder computeOrder, OpenStackV3User cloudUser) throws FogbowException {
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String flavorsEndpoint = getComputeEndpoint(projectId, OpenStackConstants.FLAVORS_ENDPOINT);
 
@@ -286,7 +301,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         setHardwareRequirementsList(newHardwareRequirements);
     }
 
-    protected boolean flavorHasRequirements(OpenStackV3User cloudUser, Map<String, String> requirements,
+    @VisibleForTesting
+    boolean flavorHasRequirements(OpenStackV3User cloudUser, Map<String, String> requirements,
                                           String flavorId) throws FogbowException {
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String specsEndpoint = getComputeEndpoint(projectId, OpenStackConstants.FLAVORS_ENDPOINT)  + "/" + flavorId +
@@ -305,7 +321,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return true;
     }
 
-    protected TreeSet<HardwareRequirements> detailFlavors(String endpoint, List<String> flavorsIds, OpenStackV3User cloudUser)
+    @VisibleForTesting
+    TreeSet<HardwareRequirements> detailFlavors(String endpoint, List<String> flavorsIds, OpenStackV3User cloudUser)
             throws FogbowException {
         TreeSet<HardwareRequirements> newHardwareRequirements = new TreeSet<>();
         TreeSet<HardwareRequirements> flavorsCopy = getHardwareRequirementsList();
@@ -329,7 +346,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return newHardwareRequirements;
     }
 
-    protected HardwareRequirements fetchHardwareRequirements(String endpoint, String flavorId, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    HardwareRequirements fetchHardwareRequirements(String endpoint, String flavorId, OpenStackV3User cloudUser) throws FogbowException {
         String hardwareRequirementsEndpoint = endpoint + "/" + flavorId;
 
         String getJsonResponse = null;
@@ -346,7 +364,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return new HardwareRequirements(name, id, vcpusCount, memory, disk);
     }
 
-    protected ComputeInstance getInstanceFromJson(String getRawResponse) {
+    @VisibleForTesting
+    ComputeInstance getInstanceFromJson(String getRawResponse) {
         GetComputeResponse getComputeResponse = GetComputeResponse.fromJson(getRawResponse);
 
         String openStackState = getComputeResponse.getStatus();
@@ -368,22 +387,26 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return new ComputeInstance(instanceId, openStackState, hostName, ipAddresses, faultMessage);
     }
 
-    protected String doGetRequest(String endpoint, OpenStackV3User clouUser) throws FogbowException {
+    @VisibleForTesting
+    String doGetRequest(String endpoint, OpenStackV3User clouUser) throws FogbowException {
         String responseStr = this.client.doGetRequest(endpoint, clouUser);
         return responseStr;
     }
 
-    protected void doDeleteRequest(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    void doDeleteRequest(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         this.client.doDeleteRequest(endpoint, cloudUser);
     }
 
-    protected TreeSet<HardwareRequirements> getHardwareRequirementsList() {
+    @VisibleForTesting
+    TreeSet<HardwareRequirements> getHardwareRequirementsList() {
         synchronized (this.hardwareRequirementsList) {
             return new TreeSet<HardwareRequirements>(this.hardwareRequirementsList);
         }
     }
 
-    protected void setHardwareRequirementsList(TreeSet<HardwareRequirements> hardwareRequirementsList) {
+    @VisibleForTesting
+    void setHardwareRequirementsList(TreeSet<HardwareRequirements> hardwareRequirementsList) {
         synchronized (this.hardwareRequirementsList) {
             this.hardwareRequirementsList = hardwareRequirementsList;
         }
@@ -393,12 +416,13 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         return UUID.randomUUID().toString();
     }
 
-    // for testing only
-    protected void setClient(OpenStackHttpClient client) {
+    @VisibleForTesting
+    void setClient(OpenStackHttpClient client) {
         this.client = client;
     }
 
-    protected void setLaunchCommandGenerator(LaunchCommandGenerator launchCommandGenerator) {
+    @VisibleForTesting
+    void setLaunchCommandGenerator(LaunchCommandGenerator launchCommandGenerator) {
         this.launchCommandGenerator = launchCommandGenerator;
     }
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/compute/v2/OpenStackComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/compute/v2/OpenStackComputePlugin.java
@@ -83,7 +83,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         String instanceId = computeOrder.getInstanceId();
         LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
-        String endpoint = getComputeEndpoint(projectId, OpenStackConstants.SERVERS_ENDPOINT + "/" + computeOrder.getInstanceId());
+        String endpoint = getComputeEndpoint(projectId, OpenStackConstants.SERVERS_ENDPOINT
+                + OpenStackConstants.ENDPOINT_SEPARATOR + computeOrder.getInstanceId());
 
         String jsonResponse = doGetInstance(endpoint, cloudUser);
 
@@ -99,7 +100,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         String instanceId = computeOrder.getInstanceId();
         LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
-        String endpoint = getComputeEndpoint(projectId, OpenStackConstants.SERVERS_ENDPOINT + "/" + computeOrder.getInstanceId());
+        String endpoint = getComputeEndpoint(projectId, OpenStackConstants.SERVERS_ENDPOINT
+                + OpenStackConstants.ENDPOINT_SEPARATOR + computeOrder.getInstanceId());
         this.doDeleteRequest(endpoint, cloudUser);
     }
 
@@ -209,7 +211,7 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
 
     @VisibleForTesting
     void deleteKeyName(String projectId, String keyName, OpenStackV3User cloudUser) throws FogbowException {
-        String suffixEndpoint = OpenStackConstants.KEYPAIRS_ENDPOINT + "/" + keyName;
+        String suffixEndpoint = OpenStackConstants.KEYPAIRS_ENDPOINT + OpenStackConstants.ENDPOINT_SEPARATOR + keyName;
         String keyNameEndpoint = getComputeEndpoint(projectId, suffixEndpoint);
 
         doDeleteRequest(keyNameEndpoint, cloudUser);
@@ -305,8 +307,10 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
     boolean flavorHasRequirements(OpenStackV3User cloudUser, Map<String, String> requirements,
                                           String flavorId) throws FogbowException {
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
-        String specsEndpoint = getComputeEndpoint(projectId, OpenStackConstants.FLAVORS_ENDPOINT)  + "/" + flavorId +
-                OpenStackConstants.EXTRA_SPECS_ENDPOINT;
+        String specsEndpoint = getComputeEndpoint(projectId, OpenStackConstants.FLAVORS_ENDPOINT)
+                + OpenStackConstants.ENDPOINT_SEPARATOR
+                + flavorId
+                + OpenStackConstants.EXTRA_SPECS_ENDPOINT;
 
         String jsonResponse = doGetRequest(specsEndpoint, cloudUser);
         GetFlavorExtraSpecsResponse getFlavorExtraSpecsResponse = GetFlavorExtraSpecsResponse.fromJson(jsonResponse);
@@ -348,7 +352,7 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
 
     @VisibleForTesting
     HardwareRequirements fetchHardwareRequirements(String endpoint, String flavorId, OpenStackV3User cloudUser) throws FogbowException {
-        String hardwareRequirementsEndpoint = endpoint + "/" + flavorId;
+        String hardwareRequirementsEndpoint = endpoint + OpenStackConstants.ENDPOINT_SEPARATOR + flavorId;
 
         String getJsonResponse = null;
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePlugin.java
@@ -8,15 +8,19 @@ import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.common.util.connectivity.cloud.openstack.OpenStackHttpClient;
 import cloud.fogbow.ras.api.http.response.ImageInstance;
 import cloud.fogbow.ras.api.http.response.ImageSummary;
+import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.plugins.interoperability.ImagePlugin;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.OpenStackPluginUtils;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.GetAllImagesResponse;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.GetImageResponse;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.util.*;
 
 public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
+    private static final Logger LOGGER = Logger.getLogger(OpenStackImagePlugin.class);
+
     private Properties properties;
     private OpenStackHttpClient client;
 
@@ -27,12 +31,14 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
 
     @Override
     public List<ImageSummary> getAllImages(OpenStackV3User cloudUser) throws FogbowException {
+        LOGGER.info(Messages.Log.REQUESTING_GET_ALL_FROM_PROVIDER);
         List<ImageSummary> availableImages = getAvailableImages(cloudUser);
         return availableImages;
     }
 
     @Override
     public ImageInstance getImage(String imageId, OpenStackV3User cloudUser) throws FogbowException {
+        LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
         GetImageResponse getImageResponse = getImageResponse(imageId, cloudUser);
         String id = getImageResponse.getId();
         String status = getImageResponse.getStatus();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePlugin.java
@@ -41,20 +41,26 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
     public ImageInstance getImage(String imageId, OpenStackV3User cloudUser) throws FogbowException {
         LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
         GetImageResponse getImageResponse = getImageResponse(imageId, cloudUser);
-        String id = getImageResponse.getId();
         String status = getImageResponse.getStatus();
+
+        ImageInstance imageInstance = null;
+
         if (status.equals(OpenStackConstants.ACTIVE_STATE)) {
-            ImageInstance imageInstance = new ImageInstance(id,
-                    getImageResponse.getName(),
-                    getImageResponse.getSize(),
-                    getImageResponse.getMinDisk(),
-                    getImageResponse.getMinRam(),
-                    status
-            );
-            return imageInstance;
+            imageInstance = buildImageInstance(getImageResponse);
         }
 
-        return null;
+        return imageInstance;
+    }
+
+    @VisibleForTesting
+    ImageInstance buildImageInstance(GetImageResponse getImageResponse) {
+        String id = getImageResponse.getId();
+        String status = getImageResponse.getStatus();
+        String name = getImageResponse.getName();
+        Long size = getImageResponse.getSize();
+        Long minDisk = getImageResponse.getMinDisk();
+        Long minRam = getImageResponse.getMinRam();
+        return new ImageInstance(id, name, size, minDisk, minRam, status);
     }
 
     @VisibleForTesting

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePlugin.java
@@ -27,7 +27,7 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
 
     public OpenStackImagePlugin(String confFilePath) throws FatalErrorException {
         this.properties = PropertiesUtil.readProperties(confFilePath);
-        this.client = new OpenStackHttpClient();
+        this.initClient();
     }
 
     @Override
@@ -151,5 +151,9 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
     @VisibleForTesting
     void setProperties(Properties properties) {
         this.properties = properties;
+    }
+
+    private void initClient() {
+        this.client = new OpenStackHttpClient();
     }
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePlugin.java
@@ -13,6 +13,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.ImagePlugin;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.OpenStackPluginUtils;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.GetAllImagesResponse;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.GetImageResponse;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
 import java.io.File;
@@ -56,7 +57,8 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
         return null;
     }
 
-    protected GetImageResponse getImageResponse(String imageId, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    GetImageResponse getImageResponse(String imageId, OpenStackV3User cloudUser) throws FogbowException {
         String endpoint = this.properties.getProperty(OpenStackPluginUtils.IMAGE_GLANCE_URL_KEY)
                     + OpenStackConstants.GLANCE_V2_API_ENDPOINT + OpenStackConstants.ENDPOINT_SEPARATOR +
                     OpenStackConstants.IMAGE_ENDPOINT + File.separator + imageId;
@@ -65,7 +67,8 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
         return GetImageResponse.fromJson(jsonResponse);
     }
 
-    protected List<GetImageResponse> getImagesResponse(OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    List<GetImageResponse> getImagesResponse(OpenStackV3User cloudUser) throws FogbowException {
         String endpoint = this.properties.getProperty(OpenStackPluginUtils.IMAGE_GLANCE_URL_KEY)
                     + OpenStackConstants.GLANCE_V2_API_ENDPOINT + OpenStackConstants.ENDPOINT_SEPARATOR +
                     OpenStackConstants.IMAGE_ENDPOINT + OpenStackConstants.QUERY_ACTIVE_IMAGES;
@@ -78,7 +81,8 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
         return getImageResponses;
     }
 
-    protected void getNextImageListResponseByPagination(OpenStackV3User cloudUser, GetAllImagesResponse getAllImagesResponse,
+    @VisibleForTesting
+    void getNextImageListResponseByPagination(OpenStackV3User cloudUser, GetAllImagesResponse getAllImagesResponse,
         List<GetImageResponse> imagesJson) throws FogbowException {
         String next = getAllImagesResponse.getNext();
         if (next != null && !next.isEmpty()) {
@@ -90,7 +94,8 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
         }
     }
 
-    protected List<GetImageResponse> getPublicImagesResponse(List<GetImageResponse> imagesResponse) {
+    @VisibleForTesting
+    List<GetImageResponse> getPublicImagesResponse(List<GetImageResponse> imagesResponse) {
         List<GetImageResponse> publicImagesResponse = new ArrayList<GetImageResponse>();
         for (GetImageResponse getImageResponse : imagesResponse) {
             if (getImageResponse.getVisibility().equals(OpenStackConstants.PUBLIC_VISIBILITY)) {
@@ -100,7 +105,8 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
         return publicImagesResponse;
     }
 
-    protected List<GetImageResponse> getPrivateImagesResponse(List<GetImageResponse> imagesResponse, String tenantId) {
+    @VisibleForTesting
+    List<GetImageResponse> getPrivateImagesResponse(List<GetImageResponse> imagesResponse, String tenantId) {
         List<GetImageResponse> privateImagesResponse = new ArrayList<GetImageResponse>();
         for (GetImageResponse getImageResponse : imagesResponse) {
             if (getImageResponse.getOwner().equals(tenantId)
@@ -111,7 +117,8 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
         return privateImagesResponse;
     }
 
-    protected List<ImageSummary> getAvailableImages(OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    List<ImageSummary> getAvailableImages(OpenStackV3User cloudUser) throws FogbowException {
         List<ImageSummary> availableImages = new ArrayList<>();
 
         List<GetImageResponse> allImagesResponse = getImagesResponse(cloudUser);
@@ -131,15 +138,18 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
         return filteredImages;
     }
 
-    protected void setClient(OpenStackHttpClient client) {
+    @VisibleForTesting
+    void setClient(OpenStackHttpClient client) {
         this.client = client;
     }
 
-    protected GetAllImagesResponse getAllImagesResponse(String json) {
+    @VisibleForTesting
+    GetAllImagesResponse getAllImagesResponse(String json) {
         return GetAllImagesResponse.fromJson(json);
     }
 
-    protected void setProperties(Properties properties) {
+    @VisibleForTesting
+    void setProperties(Properties properties) {
         this.properties = properties;
     }
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePlugin.java
@@ -39,7 +39,7 @@ public class OpenStackImagePlugin implements ImagePlugin<OpenStackV3User> {
 
     @Override
     public ImageInstance getImage(String imageId, OpenStackV3User cloudUser) throws FogbowException {
-        LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
+        LOGGER.info(String.format(Messages.Log.RECEIVING_GET_IMAGE_REQUEST_S, imageId));
         GetImageResponse getImageResponse = getImageResponse(imageId, cloudUser);
         String status = getImageResponse.getStatus();
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/network/v2/OpenStackNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/network/v2/OpenStackNetworkPlugin.java
@@ -26,6 +26,7 @@ import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializ
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.CreateSecurityGroupResponse;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.GetNetworkResponse;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.GetSubnetResponse;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonSyntaxException;
 import org.apache.log4j.Logger;
 import org.json.JSONException;
@@ -39,10 +40,14 @@ import java.util.UUID;
 public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
     private static final Logger LOGGER = Logger.getLogger(OpenStackNetworkPlugin.class);
 
-    protected static final String KEY_DNS_NAMESERVERS = "dns_nameservers";
-    protected static final int DEFAULT_IP_VERSION = 4;
-    protected static final String[] DEFAULT_DNS_NAME_SERVERS = new String[]{"8.8.8.8", "8.8.4.4"};
-    protected static final String DEFAULT_NETWORK_CIDR = "192.168.0.1/24";
+    @VisibleForTesting
+    static final String KEY_DNS_NAMESERVERS = "dns_nameservers";
+    @VisibleForTesting
+    static final int DEFAULT_IP_VERSION = 4;
+    @VisibleForTesting
+    static final String[] DEFAULT_DNS_NAME_SERVERS = new String[]{"8.8.8.8", "8.8.4.4"};
+    @VisibleForTesting
+    static final String DEFAULT_NETWORK_CIDR = "192.168.0.1/24";
 
     private OpenStackHttpClient client;
     private String networkV2APIEndpoint;
@@ -99,17 +104,20 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         doDeleteInstance(instanceId, securityGroupId, cloudUser);
     }
 
-    protected String doGetInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    String doGetInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         String responseStr = doGetRequest(cloudUser, endpoint);
         return responseStr;
     }
 
-    protected String doGetRequest(OpenStackV3User cloudUser, String endpoint) throws FogbowException {
+    @VisibleForTesting
+    String doGetRequest(OpenStackV3User cloudUser, String endpoint) throws FogbowException {
         String responseStr = this.client.doGetRequest(endpoint, cloudUser);
         return responseStr;
     }
 
-    protected void doDeleteInstance(String instanceId, String securityGroupId, OpenStackV3User cloudUser) throws FogbowException{
+    @VisibleForTesting
+    void doDeleteInstance(String instanceId, String securityGroupId, OpenStackV3User cloudUser) throws FogbowException{
         try {
             removeNetwork(cloudUser, instanceId);
         } catch (InstanceNotFoundException e) {
@@ -123,7 +131,8 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         doDeleteSecurityGroup(securityGroupId, cloudUser);
     }
 
-    protected void doDeleteSecurityGroup(String securityGroupId, OpenStackV3User cloudUser) throws FogbowException{
+    @VisibleForTesting
+    void doDeleteSecurityGroup(String securityGroupId, OpenStackV3User cloudUser) throws FogbowException{
         try {
             removeSecurityGroup(cloudUser, securityGroupId);
         } catch (FogbowException e) {
@@ -132,14 +141,16 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         }
     }
 
-    protected void setDNSList(Properties properties) {
+    @VisibleForTesting
+    void setDNSList(Properties properties) {
         String dnsProperty = properties.getProperty(KEY_DNS_NAMESERVERS);
         if (dnsProperty != null) {
             this.dnsList = dnsProperty.split(",");
         }
     }
 
-    protected CreateNetworkResponse createNetwork(String networkName, OpenStackV3User cloudUser, String tenantId) throws FogbowException {
+    @VisibleForTesting
+    CreateNetworkResponse createNetwork(String networkName, OpenStackV3User cloudUser, String tenantId) throws FogbowException {
         CreateNetworkResponse createNetworkResponse = null;
 
         CreateNetworkRequest createNetworkRequest = new CreateNetworkRequest.Builder()
@@ -160,7 +171,8 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         return createNetworkResponse;
     }
 
-    protected void createSubNet(OpenStackV3User cloudUser, NetworkOrder order, String networkId, String tenantId)
+    @VisibleForTesting
+    void createSubNet(OpenStackV3User cloudUser, NetworkOrder order, String networkId, String tenantId)
             throws FogbowException {
         try {
             String jsonRequest = generateJsonEntityToCreateSubnet(networkId, tenantId, order);
@@ -172,7 +184,8 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         }
     }
 
-    protected CreateSecurityGroupResponse createSecurityGroup(OpenStackV3User cloudUser, String name,
+    @VisibleForTesting
+    CreateSecurityGroupResponse createSecurityGroup(OpenStackV3User cloudUser, String name,
                                                             String tenantId, String networkId) throws FogbowException {
         CreateSecurityGroupResponse creationResponse = null;
         try {
@@ -192,7 +205,8 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         return creationResponse;
     }
 
-    protected CreateSecurityGroupRuleRequest createIcmpRuleRequest(String remoteIpPrefix, String securityGroupId) {
+    @VisibleForTesting
+    CreateSecurityGroupRuleRequest createIcmpRuleRequest(String remoteIpPrefix, String securityGroupId) {
         return new CreateSecurityGroupRuleRequest.Builder()
                 .direction(OpenStackConstants.INGRESS_DIRECTION)
                 .securityGroupId(securityGroupId)
@@ -201,7 +215,8 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
                 .build();
     }
 
-    protected CreateSecurityGroupRuleRequest createAllTcpRuleRequest(String remoteIpPrefix, String securityGroupId,
+    @VisibleForTesting
+    CreateSecurityGroupRuleRequest createAllTcpRuleRequest(String remoteIpPrefix, String securityGroupId,
                                                                    String protocol) {
         return new CreateSecurityGroupRuleRequest.Builder()
                 .direction(OpenStackConstants.INGRESS_DIRECTION)
@@ -211,7 +226,8 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
                 .build();
     }
 
-    protected void createSecurityGroupRules(NetworkOrder order, OpenStackV3User cloudUser, String networkId, String securityGroupId)
+    @VisibleForTesting
+    void createSecurityGroupRules(NetworkOrder order, OpenStackV3User cloudUser, String networkId, String securityGroupId)
             throws FogbowException {
         try {
             CreateSecurityGroupRuleRequest allTcp = createAllTcpRuleRequest(order.getCidr(), securityGroupId, OpenStackConstants.TCP_PROTOCOL);
@@ -229,23 +245,27 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         }
     }
 
-    protected String getRandomUUID() {
+    @VisibleForTesting
+    String getRandomUUID() {
         return UUID.randomUUID().toString();
     }
 
-    protected String retrieveSecurityGroupId(String securityGroupName, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    String retrieveSecurityGroupId(String securityGroupName, OpenStackV3User cloudUser) throws FogbowException {
         String endpoint = this.networkV2APIEndpoint + OpenStackConstants.SECURITY_GROUPS_ENDPOINT +
                 OpenStackConstants.QUERY_NAME + securityGroupName;
         String responseStr = doGetRequest(cloudUser, endpoint);
         return OpenStackCloudUtils.getSecurityGroupIdFromGetResponse(responseStr);
     }
 
-    protected void removeSecurityGroup(OpenStackV3User cloudUser, String securityGroupId) throws FogbowException {
+    @VisibleForTesting
+    void removeSecurityGroup(OpenStackV3User cloudUser, String securityGroupId) throws FogbowException {
         String endpoint = this.networkV2APIEndpoint + OpenStackConstants.SECURITY_GROUPS_ENDPOINT + "/" + securityGroupId;
         this.client.doDeleteRequest(endpoint, cloudUser);
     }
 
-    protected NetworkInstance buildInstance(String json, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    NetworkInstance buildInstance(String json, OpenStackV3User cloudUser) throws FogbowException {
         GetNetworkResponse getNetworkResponse = GetNetworkResponse.fromJson(json);
         String networkId = getNetworkResponse.getId();
         String name = getNetworkResponse.getName();
@@ -279,14 +299,16 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         return instance;
     }
 
-    protected GetSubnetResponse getSubnetInformation(OpenStackV3User cloudUser, String subnetId) throws FogbowException {
+    @VisibleForTesting
+    GetSubnetResponse getSubnetInformation(OpenStackV3User cloudUser, String subnetId) throws FogbowException {
         String endpoint = this.networkV2APIEndpoint + OpenStackConstants.SUBNET_ENDPOINT + "/" + subnetId;
         String response = this.client.doGetRequest(endpoint, cloudUser);
         GetSubnetResponse getSubnetResponse = GetSubnetResponse.fromJson(response);
         return getSubnetResponse;
     }
 
-    protected String getNetworkIdFromJson(String json) throws InternalServerErrorException {
+    @VisibleForTesting
+    String getNetworkIdFromJson(String json) throws InternalServerErrorException {
         String networkId = null;
         try {
             JSONObject rootServer = new JSONObject(json);
@@ -299,7 +321,8 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         return networkId;
     }
 
-    protected String generateJsonEntityToCreateSubnet(String networkId, String tenantId, NetworkOrder order) {
+    @VisibleForTesting
+    String generateJsonEntityToCreateSubnet(String networkId, String tenantId, NetworkOrder order) {
         String subnetName = order.getName() + "-subnet";
         int ipVersion = DEFAULT_IP_VERSION;
 
@@ -326,7 +349,8 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         return createSubnetRequest.toJson();
     }
 
-    protected void removeNetwork(OpenStackV3User cloudUser, String networkId) throws InternalServerErrorException, FogbowException {
+    @VisibleForTesting
+    void removeNetwork(OpenStackV3User cloudUser, String networkId) throws InternalServerErrorException, FogbowException {
         String endpoint = this.networkV2APIEndpoint + OpenStackConstants.NETWORK_ENDPOINT + "/" + networkId;
         this.client.doDeleteRequest(endpoint, cloudUser);
     }
@@ -335,11 +359,13 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         this.client = new OpenStackHttpClient();
     }
 
-    protected void setClient(OpenStackHttpClient client) {
+    @VisibleForTesting
+    void setClient(OpenStackHttpClient client) {
         this.client = client;
     }
 
-    protected String[] getDnsList() {
+    @VisibleForTesting
+    String[] getDnsList() {
         return dnsList;
     }
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/network/v2/OpenStackNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/network/v2/OpenStackNetworkPlugin.java
@@ -92,7 +92,7 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
         LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
         String endpoint = this.networkV2APIEndpoint + OpenStackConstants.NETWORK_ENDPOINT + "/" + order.getInstanceId();
         String responseStr = doGetInstance(endpoint, cloudUser);
-        return buildInstance(responseStr, cloudUser);
+        return buildNetworkInstance(responseStr, cloudUser);
     }
 
     @Override
@@ -265,7 +265,7 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
     }
 
     @VisibleForTesting
-    NetworkInstance buildInstance(String json, OpenStackV3User cloudUser) throws FogbowException {
+    NetworkInstance buildNetworkInstance(String json, OpenStackV3User cloudUser) throws FogbowException {
         GetNetworkResponse getNetworkResponse = GetNetworkResponse.fromJson(json);
         String networkId = getNetworkResponse.getId();
         String name = getNetworkResponse.getName();

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/network/v2/OpenStackNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/network/v2/OpenStackNetworkPlugin.java
@@ -49,6 +49,8 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
     @VisibleForTesting
     static final String DEFAULT_NETWORK_CIDR = "192.168.0.1/24";
 
+    private static final String SUBNET_PREFIX = "-subnet";
+
     private OpenStackHttpClient client;
     private String networkV2APIEndpoint;
     private String[] dnsList;
@@ -90,7 +92,10 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
     public NetworkInstance getInstance(NetworkOrder order, OpenStackV3User cloudUser) throws FogbowException {
         String instanceId = order.getInstanceId();
         LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
-        String endpoint = this.networkV2APIEndpoint + OpenStackConstants.NETWORK_ENDPOINT + "/" + order.getInstanceId();
+        String endpoint = this.networkV2APIEndpoint
+                + OpenStackConstants.NETWORK_ENDPOINT
+                + OpenStackConstants.ENDPOINT_SEPARATOR
+                + order.getInstanceId();
         String responseStr = doGetInstance(endpoint, cloudUser);
         return buildNetworkInstance(responseStr, cloudUser);
     }
@@ -252,15 +257,20 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
 
     @VisibleForTesting
     String retrieveSecurityGroupId(String securityGroupName, OpenStackV3User cloudUser) throws FogbowException {
-        String endpoint = this.networkV2APIEndpoint + OpenStackConstants.SECURITY_GROUPS_ENDPOINT +
-                OpenStackConstants.QUERY_NAME + securityGroupName;
+        String endpoint = this.networkV2APIEndpoint
+                + OpenStackConstants.SECURITY_GROUPS_ENDPOINT
+                + OpenStackConstants.QUERY_NAME
+                + securityGroupName;
         String responseStr = doGetRequest(cloudUser, endpoint);
         return OpenStackCloudUtils.getSecurityGroupIdFromGetResponse(responseStr);
     }
 
     @VisibleForTesting
     void removeSecurityGroup(OpenStackV3User cloudUser, String securityGroupId) throws FogbowException {
-        String endpoint = this.networkV2APIEndpoint + OpenStackConstants.SECURITY_GROUPS_ENDPOINT + "/" + securityGroupId;
+        String endpoint = this.networkV2APIEndpoint
+                + OpenStackConstants.SECURITY_GROUPS_ENDPOINT
+                + OpenStackConstants.ENDPOINT_SEPARATOR
+                + securityGroupId;
         this.client.doDeleteRequest(endpoint, cloudUser);
     }
 
@@ -301,7 +311,10 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
 
     @VisibleForTesting
     GetSubnetResponse getSubnetInformation(OpenStackV3User cloudUser, String subnetId) throws FogbowException {
-        String endpoint = this.networkV2APIEndpoint + OpenStackConstants.SUBNET_ENDPOINT + "/" + subnetId;
+        String endpoint = this.networkV2APIEndpoint
+                + OpenStackConstants.SUBNET_ENDPOINT
+                + OpenStackConstants.ENDPOINT_SEPARATOR
+                + subnetId;
         String response = this.client.doGetRequest(endpoint, cloudUser);
         GetSubnetResponse getSubnetResponse = GetSubnetResponse.fromJson(response);
         return getSubnetResponse;
@@ -323,7 +336,7 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
 
     @VisibleForTesting
     String generateJsonEntityToCreateSubnet(String networkId, String tenantId, NetworkOrder order) {
-        String subnetName = order.getName() + "-subnet";
+        String subnetName = order.getName() + SUBNET_PREFIX;
         int ipVersion = DEFAULT_IP_VERSION;
 
         String gateway = order.getGateway();
@@ -351,7 +364,10 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
 
     @VisibleForTesting
     void removeNetwork(OpenStackV3User cloudUser, String networkId) throws InternalServerErrorException, FogbowException {
-        String endpoint = this.networkV2APIEndpoint + OpenStackConstants.NETWORK_ENDPOINT + "/" + networkId;
+        String endpoint = this.networkV2APIEndpoint
+                + OpenStackConstants.NETWORK_ENDPOINT
+                + OpenStackConstants.ENDPOINT_SEPARATOR
+                + networkId;
         this.client.doDeleteRequest(endpoint, cloudUser);
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/network/v2/OpenStackNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/network/v2/OpenStackNetworkPlugin.java
@@ -68,6 +68,7 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
 
     @Override
     public String requestInstance(NetworkOrder order, OpenStackV3User cloudUser) throws FogbowException {
+        LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
         String tenantId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
 
         CreateNetworkResponse createNetworkResponse = createNetwork(order.getName(), cloudUser, tenantId);
@@ -82,6 +83,8 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
 
     @Override
     public NetworkInstance getInstance(NetworkOrder order, OpenStackV3User cloudUser) throws FogbowException {
+        String instanceId = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
         String endpoint = this.networkV2APIEndpoint + OpenStackConstants.NETWORK_ENDPOINT + "/" + order.getInstanceId();
         String responseStr = doGetInstance(endpoint, cloudUser);
         return buildInstance(responseStr, cloudUser);
@@ -90,6 +93,7 @@ public class OpenStackNetworkPlugin implements NetworkPlugin<OpenStackV3User> {
     @Override
     public void deleteInstance(NetworkOrder order, OpenStackV3User cloudUser) throws FogbowException {
         String instanceId = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
         String securityGroupName = OpenStackPluginUtils.getNetworkSecurityGroupName(instanceId);
         String securityGroupId = retrieveSecurityGroupId(securityGroupName, cloudUser);
         doDeleteInstance(instanceId, securityGroupId, cloudUser);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/publicip/v2/OpenStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/publicip/v2/OpenStackPublicIpPlugin.java
@@ -56,6 +56,7 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
 
     @Override
     public String requestInstance(PublicIpOrder order, OpenStackV3User cloudUser) throws FogbowException {
+        LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         // Network port id is the connection between the virtual machine and the network
         String networkPortId = getNetworkPortId(order, cloudUser);
@@ -77,7 +78,8 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
     @Override
     public PublicIpInstance getInstance(PublicIpOrder order, OpenStackV3User cloudUser) throws FogbowException {
         String instanceId = order.getInstanceId();
-        String endpoint = getFloatingIpEndpoint() 
+        LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
+        String endpoint = getFloatingIpEndpoint()
                 + OpenStackConstants.ENDPOINT_SEPARATOR
                 + instanceId;
         
@@ -87,6 +89,7 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
     @Override
     public void deleteInstance(PublicIpOrder order, OpenStackV3User cloudUser) throws FogbowException {
         String instanceId = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
         String securityGroupName = getSecurityGroupName(instanceId);
         String securityGroupId = retrieveSecurityGroupId(securityGroupName, cloudUser);
         disassociateSecurityGroup(securityGroupName, order, cloudUser);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/publicip/v2/OpenStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/publicip/v2/OpenStackPublicIpPlugin.java
@@ -8,6 +8,7 @@ import cloud.fogbow.common.constants.OpenStackConstants;
 import cloud.fogbow.common.exceptions.InternalServerErrorException;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.requests.*;
 import cloud.fogbow.ras.core.plugins.interoperability.openstack.util.v2.serializables.responses.*;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.log4j.Logger;
 
 import com.google.gson.JsonSyntaxException;
@@ -97,14 +98,16 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         doDeleteInstance(instanceId, cloudUser);
     }
     
-    protected void doDeleteInstance(String instanceId, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    void doDeleteInstance(String instanceId, OpenStackV3User cloudUser) throws FogbowException {
         String endpoint = getFloatingIpEndpoint() 
                 + OpenStackConstants.ENDPOINT_SEPARATOR
                 + instanceId;
         this.client.doDeleteRequest(endpoint, cloudUser);
     }
     
-    protected void disassociateSecurityGroup(String name, PublicIpOrder order, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    void disassociateSecurityGroup(String name, PublicIpOrder order, OpenStackV3User cloudUser) throws FogbowException {
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String computeId = order.getComputeId();
         String endpoint = getComputeAssociationEndpoint(projectId, computeId);
@@ -115,7 +118,8 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         this.client.doPostRequest(endpoint, request.toJson(), cloudUser);
     }
     
-    protected String retrieveSecurityGroupId(String securityGroupName, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    String retrieveSecurityGroupId(String securityGroupName, OpenStackV3User cloudUser) throws FogbowException {
         String endpoint = getSecurityGroupsEndpoint() + OpenStackConstants.QUERY_NAME + securityGroupName;
         String json = doGetResponseFromCloud(endpoint, cloudUser);
         GetSecurityGroupsResponse response = doGetSecurityGroupsResponseFrom(json);
@@ -128,7 +132,8 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         }
     }
 
-    protected GetSecurityGroupsResponse doGetSecurityGroupsResponseFrom(String json) throws FogbowException {
+    @VisibleForTesting
+    GetSecurityGroupsResponse doGetSecurityGroupsResponseFrom(String json) throws FogbowException {
         try {
             return GetSecurityGroupsResponse.fromJson(json);
         } catch (JsonSyntaxException e) {
@@ -139,13 +144,15 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         }
     }
     
-    protected PublicIpInstance doGetInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    PublicIpInstance doGetInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         String jsonResponse = doGetResponseFromCloud(endpoint, cloudUser);
         GetFloatingIpResponse response = doGetFloatingIpResponseFrom(jsonResponse);
         return buildPublicIpInstance(response);
     }
     
-    protected PublicIpInstance buildPublicIpInstance(GetFloatingIpResponse response) {
+    @VisibleForTesting
+    PublicIpInstance buildPublicIpInstance(GetFloatingIpResponse response) {
         FloatingIp floatingIp = response.getFloatingIp();
         String id = floatingIp.getId();
         String cloudStatus = floatingIp.getStatus();
@@ -153,7 +160,8 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         return new PublicIpInstance(id, cloudStatus, ip);
     }
 
-    protected GetFloatingIpResponse doGetFloatingIpResponseFrom(String json) throws FogbowException {
+    @VisibleForTesting
+    GetFloatingIpResponse doGetFloatingIpResponseFrom(String json) throws FogbowException {
         try {
             return GetFloatingIpResponse.fromJson(json);
         } catch (JsonSyntaxException e) {
@@ -164,13 +172,15 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         }
     }
     
-    protected String getFloatingIpEndpoint() {
+    @VisibleForTesting
+    String getFloatingIpEndpoint() {
         return getNeutronPrefixEndpoint() 
                 + OpenStackConstants.NEUTRON_V2_API_ENDPOINT
                 + OpenStackConstants.FLOATINGIPS_ENDPOINT;
     }
 
-    protected void associateSecurityGroup(String securityGroupId, String floatingIpId, PublicIpOrder order,
+    @VisibleForTesting
+    void associateSecurityGroup(String securityGroupId, String floatingIpId, PublicIpOrder order,
             OpenStackV3User cloudUser) throws FogbowException {
         
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
@@ -189,11 +199,13 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         }
     }
 
-    protected String getSecurityGroupName(String publicIpId) {
+    @VisibleForTesting
+    String getSecurityGroupName(String publicIpId) {
         return SystemConstants.PIP_SECURITY_GROUP_PREFIX + publicIpId;
     }
 
-    protected String getComputeAssociationEndpoint(String projectId, String computeId) {
+    @VisibleForTesting
+    String getComputeAssociationEndpoint(String projectId, String computeId) {
         return this.properties.getProperty(OpenStackPluginUtils.COMPUTE_NOVA_URL_KEY)
                 + OpenStackConstants.NOVA_V2_API_ENDPOINT
                 + OpenStackConstants.ENDPOINT_SEPARATOR
@@ -205,14 +217,16 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
                 + OpenStackConstants.ACTION;
     }
 
-    protected void deleteSecurityGroup(String securityGroupId, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    void deleteSecurityGroup(String securityGroupId, OpenStackV3User cloudUser) throws FogbowException {
         String endpoint = getSecurityGroupsEndpoint() 
                 + OpenStackConstants.ENDPOINT_SEPARATOR
                 + securityGroupId;
         this.client.doDeleteRequest(endpoint, cloudUser);
     }
 
-    protected void allowAllIngressSecurityRules(String securityGroupId, OpenStackV3User cloudUser)
+    @VisibleForTesting
+    void allowAllIngressSecurityRules(String securityGroupId, OpenStackV3User cloudUser)
             throws FogbowException {
 
         String[] etherTypes = { OpenStackConstants.IPV4_ETHER_TYPE, OpenStackConstants.IPV6_ETHER_TYPE };
@@ -231,18 +245,21 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         }
     }
 
-    protected void doPostRequestFromCloud(CreateSecurityGroupRuleRequest request, OpenStackV3User cloudUser)
+    @VisibleForTesting
+    void doPostRequestFromCloud(CreateSecurityGroupRuleRequest request, OpenStackV3User cloudUser)
             throws FogbowException {
         this.client.doPostRequest(getSecurityGroupRulesEndpoint(), request.toJson(), cloudUser);
     }
 
-    protected String getSecurityGroupRulesEndpoint() {
+    @VisibleForTesting
+    String getSecurityGroupRulesEndpoint() {
         return getNeutronPrefixEndpoint() 
                 + OpenStackConstants.NEUTRON_V2_API_ENDPOINT
                 + OpenStackConstants.SECURITY_GROUP_RULES_ENDPOINT;
     }
 
-    protected String doCreateSecurityGroup(String floatingIpId, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    String doCreateSecurityGroup(String floatingIpId, OpenStackV3User cloudUser) throws FogbowException {
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String securityGroupName = getSecurityGroupName(floatingIpId);
         
@@ -256,7 +273,8 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         return securityGroupResponse.getId();
     }
 
-    protected CreateSecurityGroupResponse doCreateSecurityGroupResponseFrom(String json) throws FogbowException {
+    @VisibleForTesting
+    CreateSecurityGroupResponse doCreateSecurityGroupResponseFrom(String json) throws FogbowException {
         try {
             return CreateSecurityGroupResponse.fromJson(json);
         } catch (JsonSyntaxException e) {
@@ -269,13 +287,15 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         }
     }
 
-    protected String getSecurityGroupsEndpoint() {
+    @VisibleForTesting
+    String getSecurityGroupsEndpoint() {
         return getNeutronPrefixEndpoint() 
                 + OpenStackConstants.NEUTRON_V2_API_ENDPOINT
                 + OpenStackConstants.SECURITY_GROUPS_ENDPOINT;
     }
 
-    protected String doRequestInstance(CreateFloatingIpRequest request, OpenStackV3User cloudUser)
+    @VisibleForTesting
+    String doRequestInstance(CreateFloatingIpRequest request, OpenStackV3User cloudUser)
             throws FogbowException {
         
         String jsonResponse = this.client.doPostRequest(getFloatingIpEndpoint(), request.toJson(), cloudUser);
@@ -284,7 +304,8 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         return response.getFloatingIp().getId();
     }
 
-    protected CreateFloatingIpResponse doCreateFloatingIpResponseFrom(String json) throws FogbowException {
+    @VisibleForTesting
+    CreateFloatingIpResponse doCreateFloatingIpResponseFrom(String json) throws FogbowException {
         try {
             return CreateFloatingIpResponse.fromJson(json);
         } catch (JsonSyntaxException e) {
@@ -295,7 +316,8 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         }
     }
 
-    protected String getNetworkPortId(PublicIpOrder order, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    String getNetworkPortId(PublicIpOrder order, OpenStackV3User cloudUser) throws FogbowException {
         String computeId = order.getComputeId();
         String defaulNetworkId = getDefaultNetworkId();
         String endpointBase = getNetworkPortsEndpoint();
@@ -311,7 +333,8 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         }
     }
 
-    protected GetNetworkPortsResponse doGetNetworkPortsResponseFrom(String json) throws FogbowException {
+    @VisibleForTesting
+    GetNetworkPortsResponse doGetNetworkPortsResponseFrom(String json) throws FogbowException {
         try {
             return GetNetworkPortsResponse.fromJson(json);
         } catch (JsonSyntaxException e) {
@@ -322,12 +345,14 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         }
     }
 
-    protected String doGetResponseFromCloud(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    String doGetResponseFromCloud(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         String json = this.client.doGetRequest(endpoint, cloudUser);
         return json;
     }
 
-    protected String buildNetworkPortsEndpoint(String deviceId, String networkId, String endpoint)
+    @VisibleForTesting
+    String buildNetworkPortsEndpoint(String deviceId, String networkId, String endpoint)
             throws InternalServerErrorException {
         
         GetNetworkPortsResquest resquest = null;
@@ -344,13 +369,15 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         return resquest.getUrl();
     }
     
-    protected String getNetworkPortsEndpoint() {
+    @VisibleForTesting
+    String getNetworkPortsEndpoint() {
         return getNeutronPrefixEndpoint() 
                 + OpenStackConstants.NEUTRON_V2_API_ENDPOINT
                 + OpenStackConstants.PORTS_ENDPOINT;
     }
     
-    protected void checkProperties() {
+    @VisibleForTesting
+    void checkProperties() {
         String defaultNetworkId = getDefaultNetworkId();
         if (defaultNetworkId == null || defaultNetworkId.isEmpty()) {
             throw new FatalErrorException(Messages.Exception.DEFAULT_NETWORK_NOT_FOUND);
@@ -365,19 +392,23 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         }
     }
     
-    protected String getNeutronPrefixEndpoint() {
+    @VisibleForTesting
+    String getNeutronPrefixEndpoint() {
         return this.properties.getProperty(OpenStackPluginUtils.NETWORK_NEUTRON_URL_KEY);
     }
     
-    protected String getExternalNetworkId() {
+    @VisibleForTesting
+    String getExternalNetworkId() {
         return this.properties.getProperty(OpenStackPluginUtils.EXTERNAL_NETWORK_ID_KEY);
     }
     
-    protected String getDefaultNetworkId() {
+    @VisibleForTesting
+    String getDefaultNetworkId() {
         return this.properties.getProperty(OpenStackPluginUtils.DEFAULT_NETWORK_ID_KEY);
     }
 
-    protected void setClient(OpenStackHttpClient client) {
+    @VisibleForTesting
+    void setClient(OpenStackHttpClient client) {
         this.client = client;
     }
     

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/publicip/v2/OpenStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/publicip/v2/OpenStackPublicIpPlugin.java
@@ -280,10 +280,8 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         } catch (JsonSyntaxException e) {
             String message = String.format(Messages.Log.ERROR_WHILE_CREATING_RESOURCE_S,
                     OpenStackConstants.SECURITY_GROUP_RESOURCE);
-            LOGGER.error(String.format(Messages.Log.ERROR_WHILE_CREATING_RESOURCE_S,
-                    OpenStackConstants.SECURITY_GROUP_RESOURCE), e);
-            throw new InternalServerErrorException(String.format(Messages.Exception.ERROR_WHILE_CREATING_RESOURCE_S,
-                    OpenStackConstants.SECURITY_GROUP_RESOURCE));
+            LOGGER.error(message, e);
+            throw new InternalServerErrorException(message);
         }
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/publicip/v2/OpenStackPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/publicip/v2/OpenStackPublicIpPlugin.java
@@ -353,9 +353,9 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
     String buildNetworkPortsEndpoint(String deviceId, String networkId, String endpoint)
             throws InternalServerErrorException {
         
-        GetNetworkPortsResquest resquest = null;
+        GetNetworkPortsRequest request = null;
         try {
-            resquest = new GetNetworkPortsResquest.Builder()
+            request = new GetNetworkPortsRequest.Builder()
                     .deviceId(deviceId)
                     .networkId(networkId)
                     .url(endpoint)
@@ -364,7 +364,7 @@ public class OpenStackPublicIpPlugin implements PublicIpPlugin<OpenStackV3User> 
         } catch (URISyntaxException e) {
             throw new InternalServerErrorException(String.format(Messages.Exception.WRONG_URI_SYNTAX_S, endpoint));
         }
-        return resquest.getUrl();
+        return request.getUrl();
     }
     
     @VisibleForTesting

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/quota/v2/OpenStackQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/quota/v2/OpenStackQuotaPlugin.java
@@ -32,7 +32,7 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     
     public OpenStackQuotaPlugin(@NotBlank String confFilePath) {
         this.properties = PropertiesUtil.readProperties(confFilePath);
-        this.client = new OpenStackHttpClient();
+        this.initClient();
     }
     
     @Override
@@ -181,4 +181,7 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
         this.client = client;
     }
 
+    private void initClient() {
+        this.client = new OpenStackHttpClient();
+    }
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/quota/v2/OpenStackQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/quota/v2/OpenStackQuotaPlugin.java
@@ -37,6 +37,7 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     
     @Override
     public ResourceQuota getUserQuota(@NotNull OpenStackV3User cloudUser) throws FogbowException {
+        LOGGER.info(Messages.Log.GETTING_QUOTA);
         GetComputeQuotasResponse computeQuotas = getComputeQuotas(cloudUser);
         GetNetworkQuotasResponse networkQuotas = getNetworkQuotas(cloudUser);
         GetVolumeQuotasResponse volumeQuotas = getVolumeQuotas(cloudUser);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/quota/v2/OpenStackQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/quota/v2/OpenStackQuotaPlugin.java
@@ -30,13 +30,13 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     private Properties properties;
     private OpenStackHttpClient client;
     
-    public OpenStackQuotaPlugin(@NotBlank String confFilePath) {
+    public OpenStackQuotaPlugin(String confFilePath) {
         this.properties = PropertiesUtil.readProperties(confFilePath);
         this.initClient();
     }
     
     @Override
-    public ResourceQuota getUserQuota(@NotNull OpenStackV3User cloudUser) throws FogbowException {
+    public ResourceQuota getUserQuota(OpenStackV3User cloudUser) throws FogbowException {
         LOGGER.info(Messages.Log.GETTING_QUOTA);
         GetComputeQuotasResponse computeQuotas = getComputeQuotas(cloudUser);
         GetNetworkQuotasResponse networkQuotas = getNetworkQuotas(cloudUser);
@@ -46,9 +46,9 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
 
     @VisibleForTesting
     ResourceQuota buildResourceQuota(
-            @NotNull GetComputeQuotasResponse computeQuotas, 
-            @NotNull GetNetworkQuotasResponse networkQuotas,
-            @NotNull GetVolumeQuotasResponse volumeQuotas) {
+            GetComputeQuotasResponse computeQuotas, 
+            GetNetworkQuotasResponse networkQuotas,
+            GetVolumeQuotasResponse volumeQuotas) {
         
         ResourceAllocation totalQuota = getTotalQuota(computeQuotas, networkQuotas, volumeQuotas);
         ResourceAllocation usedQuota = getUsedQuota(computeQuotas, networkQuotas, volumeQuotas);
@@ -57,9 +57,9 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     
     @VisibleForTesting
     ResourceAllocation getUsedQuota(
-            @NotNull GetComputeQuotasResponse computeQuotas, 
-            @NotNull GetNetworkQuotasResponse networkQuotas,
-            @NotNull GetVolumeQuotasResponse volumeQuotas) {
+            GetComputeQuotasResponse computeQuotas, 
+            GetNetworkQuotasResponse networkQuotas,
+            GetVolumeQuotasResponse volumeQuotas) {
         
         int totalCoresUsed = computeQuotas.getTotalCoresUsed();
         int totalRamUsed = computeQuotas.getTotalRamUsed();
@@ -84,9 +84,9 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
 
     @VisibleForTesting
     ResourceAllocation getTotalQuota(
-            @NotNull GetComputeQuotasResponse computeQuotas, 
-            @NotNull GetNetworkQuotasResponse networkQuotas,
-            @NotNull GetVolumeQuotasResponse volumeQuotas) {
+            GetComputeQuotasResponse computeQuotas, 
+            GetNetworkQuotasResponse networkQuotas,
+            GetVolumeQuotasResponse volumeQuotas) {
         
         int maxTotalCores = computeQuotas.getMaxTotalCores();
         int maxTotalRamSize = computeQuotas.getMaxTotalRamSize();
@@ -110,7 +110,7 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     }
 
     @VisibleForTesting
-    GetVolumeQuotasResponse getVolumeQuotas(@NotNull OpenStackV3User cloudUser) throws FogbowException {
+    GetVolumeQuotasResponse getVolumeQuotas(OpenStackV3User cloudUser) throws FogbowException {
         String tenantId = getTenantId(cloudUser);
         String endpoint = getVolumeQuotaEndpoint(tenantId);
         String response = doGetQuota(endpoint, cloudUser);
@@ -118,7 +118,7 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     }
 
     @VisibleForTesting
-    String getVolumeQuotaEndpoint(@NotBlank String tenantId) {
+    String getVolumeQuotaEndpoint(String tenantId) {
         return this.properties.getProperty(OpenStackPluginUtils.VOLUME_CINDER_URL_KEY)
                 .concat(OpenStackConstants.CINDER_V3_API_ENDPOINT)
                 .concat(OpenStackConstants.ENDPOINT_SEPARATOR)
@@ -127,7 +127,7 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     }
 
     @VisibleForTesting
-    GetNetworkQuotasResponse getNetworkQuotas(@NotNull OpenStackV3User cloudUser) throws FogbowException {
+    GetNetworkQuotasResponse getNetworkQuotas(OpenStackV3User cloudUser) throws FogbowException {
         String tenantId = getTenantId(cloudUser);
         String endpoint = getNetworkQuotaEndpoint(tenantId);
         String response = doGetQuota(endpoint, cloudUser);
@@ -135,7 +135,7 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     }
 
     @VisibleForTesting
-    String getNetworkQuotaEndpoint(@NotBlank String tenantId) {
+    String getNetworkQuotaEndpoint(String tenantId) {
         return this.properties.getProperty(OpenStackPluginUtils.NETWORK_NEUTRON_URL_KEY)
                 .concat(OpenStackConstants.NEUTRON_V2_API_ENDPOINT)
                 .concat(OpenStackConstants.QUOTAS_ENDPOINT)
@@ -145,12 +145,12 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     }
     
     @VisibleForTesting
-    String getTenantId(@NotNull OpenStackV3User cloudUser) throws FogbowException {
+    String getTenantId(OpenStackV3User cloudUser) throws FogbowException {
         return OpenStackPluginUtils.getProjectIdFrom(cloudUser);
     }
 
     @VisibleForTesting
-    GetComputeQuotasResponse getComputeQuotas(@NotNull OpenStackV3User cloudUser) throws FogbowException {
+    GetComputeQuotasResponse getComputeQuotas(OpenStackV3User cloudUser) throws FogbowException {
         String endpoint = getComputeQuotaEndpoint();
         String response = doGetQuota(endpoint, cloudUser);
         return GetComputeQuotasResponse.fromJson(response);
@@ -164,7 +164,7 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     }
 
     @VisibleForTesting
-    String doGetQuota(@NotBlank String endpoint, @NotNull OpenStackV3User cloudUser) throws FogbowException {
+    String doGetQuota(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         String response = null;
         try {
             LOGGER.debug(Messages.Log.GETTING_QUOTA);
@@ -177,7 +177,7 @@ public class OpenStackQuotaPlugin implements QuotaPlugin<OpenStackV3User> {
     }
     
     @VisibleForTesting
-    void setClient(@NotNull OpenStackHttpClient client) {
+    void setClient(OpenStackHttpClient client) {
         this.client = client;
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/util/OpenStackStateMapper.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/util/OpenStackStateMapper.java
@@ -3,10 +3,17 @@ package cloud.fogbow.ras.core.plugins.interoperability.openstack.util;
 import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.models.ResourceType;
 import cloud.fogbow.ras.api.http.response.InstanceState;
+import cloud.fogbow.ras.core.plugins.interoperability.openstack.compute.v2.OpenStackComputePlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.openstack.network.v2.OpenStackNetworkPlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.openstack.volume.v2.OpenStackVolumePlugin;
 import org.apache.log4j.Logger;
 
 public class OpenStackStateMapper {
     private static final Logger LOGGER = Logger.getLogger(OpenStackStateMapper.class);
+
+    public static final String COMPUTE_PLUGIN = OpenStackComputePlugin.class.getSimpleName();
+    public static final String VOLUME_PLUGIN = OpenStackVolumePlugin.class.getSimpleName();
+    public static final String NETWORK_PLUGIN = OpenStackNetworkPlugin.class.getSimpleName();
 
     public static final String ACTIVE_STATUS = "active";
     public static final String ATTACHING_STATUS = "attaching";
@@ -14,7 +21,6 @@ public class OpenStackStateMapper {
     public static final String AWAITING_TRANSFER_STATUS = "awaiting-transfer";
     public static final String BACKING_UP_STATUS = "backing-up";
     public static final String BUILD_STATUS = "build";
-    public static final String COMPUTE_PLUGIN = "OpenstackComputePlugin";
     public static final String CREATING_STATUS = "creating";
     public static final String DELETED_STATUS = "deleted";
     public static final String DELETING_STATUS = "deleting";
@@ -31,7 +37,6 @@ public class OpenStackStateMapper {
     public static final String IN_USE_STATUS = "in-use";
     public static final String MAINTENANCE_STATUS = "maintenance";
     public static final String MIGRATING_STATUS = "migrating";
-    public static final String NETWORK_PLUGIN = "OpenstackNetworkPlugin";
     public static final String PASSWORD_STATUS = "password";
     public static final String PAUSED_STATUS = "paused";
     public static final String REBOOT_STATUS = "reboot";
@@ -49,8 +54,6 @@ public class OpenStackStateMapper {
     public static final String UNKNOWN_STATUS = "unknown";
     public static final String UPLOADING_STATUS = "uploading";
     public static final String VERIFY_RESIZE_STATUS = "verify_resize";
-    public static final String VOLUME_PLUGIN = "OpenstackVolumePlugin";
-
 
     public static InstanceState map(ResourceType type, String openStackState) {
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/util/v2/serializables/requests/GetNetworkPortsRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/util/v2/serializables/requests/GetNetworkPortsRequest.java
@@ -10,14 +10,14 @@ import java.net.URISyntaxException;
  * Request Example :
  * http://{url_neutro}:{port_neutro}/v2.0/ports?device_id={vm_id}&network_id={network_id}
  */
-public class GetNetworkPortsResquest {
+public class GetNetworkPortsRequest {
 
     private URIBuilder uriBuilder;
 
     public static final String DEVICE_ID_KEY = "device_id";
     public static final String NETWORK_ID_KEY = "network_id";
 
-    public GetNetworkPortsResquest(Builder builder) throws URISyntaxException {
+    public GetNetworkPortsRequest(Builder builder) throws URISyntaxException {
         this.uriBuilder = new URIBuilder(builder.url);
         this.uriBuilder.addParameter(DEVICE_ID_KEY, builder.deviceId);
         this.uriBuilder.addParameter(NETWORK_ID_KEY, builder.networkId);
@@ -48,8 +48,8 @@ public class GetNetworkPortsResquest {
             return this;
         }
 
-        public GetNetworkPortsResquest build() throws URISyntaxException {
-            return new GetNetworkPortsResquest(this);
+        public GetNetworkPortsRequest build() throws URISyntaxException {
+            return new GetNetworkPortsRequest(this);
         }
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/volume/v2/OpenStackVolumePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/volume/v2/OpenStackVolumePlugin.java
@@ -104,17 +104,20 @@ public class OpenStackVolumePlugin implements VolumePlugin<OpenStackV3User> {
         doDeleteInstance(endpoint, cloudUser);
     }
 
-    protected void doDeleteInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    void doDeleteInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         this.client.doDeleteRequest(endpoint, cloudUser);
     }
     
-    protected VolumeInstance doGetInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    VolumeInstance doGetInstance(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         String json = doGetResponseFromCloud(endpoint, cloudUser);
         GetVolumeResponse response = doGetVolumeResponseFrom(json);
         return buildVolumeInstanceFrom(response);
     }
     
-    protected VolumeInstance buildVolumeInstanceFrom(GetVolumeResponse response) {
+    @VisibleForTesting
+    VolumeInstance buildVolumeInstanceFrom(GetVolumeResponse response) {
         String id = response.getId();
         String status = response.getStatus();
         String name = response.getName();
@@ -122,14 +125,16 @@ public class OpenStackVolumePlugin implements VolumePlugin<OpenStackV3User> {
         return new VolumeInstance(id, status, name, size);
     }
 
-    protected GetVolumeResponse doRequestInstance(String endpoint, String jsonRequest, OpenStackV3User cloudUser)
+    @VisibleForTesting
+    GetVolumeResponse doRequestInstance(String endpoint, String jsonRequest, OpenStackV3User cloudUser)
             throws FogbowException {
         
         String jsonResponse = this.client.doPostRequest(endpoint, jsonRequest, cloudUser);
         return doGetVolumeResponseFrom(jsonResponse);
     }
 
-    protected GetVolumeResponse doGetVolumeResponseFrom(String jsonResponse) throws InternalServerErrorException {
+    @VisibleForTesting
+    GetVolumeResponse doGetVolumeResponseFrom(String jsonResponse) throws InternalServerErrorException {
         try {
             return GetVolumeResponse.fromJson(jsonResponse);
         } catch (JsonSyntaxException e) {
@@ -138,12 +143,14 @@ public class OpenStackVolumePlugin implements VolumePlugin<OpenStackV3User> {
         }
     }
     
-    protected String getPrefixEndpoint(String projectId) {
+    @VisibleForTesting
+    String getPrefixEndpoint(String projectId) {
         return this.properties.getProperty(OpenStackPluginUtils.VOLUME_NOVA_URL_KEY) +
                 OpenStackConstants.CINDER_V2_API_ENDPOINT + OpenStackConstants.ENDPOINT_SEPARATOR + projectId;
     }
     
-    protected String generateJsonRequest(String size, String name, String volumeTypeId) throws JSONException {
+    @VisibleForTesting
+    String generateJsonRequest(String size, String name, String volumeTypeId) throws JSONException {
         CreateVolumeRequest createVolumeRequest = new CreateVolumeRequest.Builder()
                 .name(name)
                 .size(size)
@@ -153,7 +160,8 @@ public class OpenStackVolumePlugin implements VolumePlugin<OpenStackV3User> {
         return createVolumeRequest.toJson();
     }
 
-    protected String findVolumeTypeId(Map<String, String> requirements, String projectId, OpenStackV3User cloudUser)
+    @VisibleForTesting
+    String findVolumeTypeId(Map<String, String> requirements, String projectId, OpenStackV3User cloudUser)
             throws FogbowException {
 
         if (requirements == null || requirements.isEmpty()) {
@@ -184,7 +192,8 @@ public class OpenStackVolumePlugin implements VolumePlugin<OpenStackV3User> {
         throw new UnacceptableOperationException(message);
     }
     
-    protected GetAllTypesResponse doGetAllTypesResponseFrom(String json) throws InternalServerErrorException {
+    @VisibleForTesting
+    GetAllTypesResponse doGetAllTypesResponseFrom(String json) throws InternalServerErrorException {
         try {
             return GetAllTypesResponse.fromJson(json);
         } catch (Exception e) {
@@ -193,7 +202,8 @@ public class OpenStackVolumePlugin implements VolumePlugin<OpenStackV3User> {
         }
     }
 
-    protected String doGetResponseFromCloud(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
+    @VisibleForTesting
+    String doGetResponseFromCloud(String endpoint, OpenStackV3User cloudUser) throws FogbowException {
         String jsonResponse = this.client.doGetRequest(endpoint, cloudUser);
         return jsonResponse;
     }
@@ -202,7 +212,8 @@ public class OpenStackVolumePlugin implements VolumePlugin<OpenStackV3User> {
         this.client = new OpenStackHttpClient();
     }
 
-    public void setClient(OpenStackHttpClient client) {
+    @VisibleForTesting
+    void setClient(OpenStackHttpClient client) {
         this.client = client;
     }
 }

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/volume/v2/OpenStackVolumePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/volume/v2/OpenStackVolumePlugin.java
@@ -56,6 +56,7 @@ public class OpenStackVolumePlugin implements VolumePlugin<OpenStackV3User> {
 
     @Override
     public String requestInstance(VolumeOrder order, OpenStackV3User cloudUser) throws FogbowException {
+        LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String size = String.valueOf(order.getVolumeSize());
         String name = order.getName();
@@ -79,6 +80,8 @@ public class OpenStackVolumePlugin implements VolumePlugin<OpenStackV3User> {
 
     @Override
     public VolumeInstance getInstance(VolumeOrder order, OpenStackV3User cloudUser) throws FogbowException {
+        String instanceId = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.GETTING_INSTANCE_S, instanceId));
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String endpoint = getPrefixEndpoint(projectId) 
                 + OpenStackConstants.VOLUMES_ENDPOINT
@@ -90,6 +93,8 @@ public class OpenStackVolumePlugin implements VolumePlugin<OpenStackV3User> {
 
     @Override
     public void deleteInstance(VolumeOrder order, OpenStackV3User cloudUser) throws FogbowException {
+        String instanceId = order.getInstanceId();
+        LOGGER.info(String.format(Messages.Log.DELETING_INSTANCE_S, instanceId));
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String endpoint = getPrefixEndpoint(projectId) 
                 + OpenStackConstants.VOLUMES_ENDPOINT

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/image/v2/OpenStackImagePluginTest.java
@@ -132,7 +132,6 @@ public class OpenStackImagePluginTest extends BaseUnitTests{
     public void testGetUnavailableImage() throws FogbowException {
         //setup
         GetImageResponse getImageResponse = Mockito.mock(GetImageResponse.class);
-        Mockito.when(getImageResponse.getId()).thenReturn(TestUtils.FAKE_IMAGE_ID);
         Mockito.when(getImageResponse.getStatus()).thenReturn(UNAVAILABLE_STATE);
         Mockito.doReturn(getImageResponse).when(plugin).getImageResponse(Mockito.any(), Mockito.any());
         OpenStackV3User cloudUser = Mockito.mock(OpenStackV3User.class);
@@ -148,9 +147,11 @@ public class OpenStackImagePluginTest extends BaseUnitTests{
     public void testGetImage() throws FogbowException{
         //setup
         GetImageResponse getImageResponse = Mockito.mock(GetImageResponse.class);
-        Mockito.when(getImageResponse.getId()).thenReturn(TestUtils.FAKE_IMAGE_ID);
         Mockito.when(getImageResponse.getStatus()).thenReturn(ACTIVE_STATE);
         Mockito.doReturn(getImageResponse).when(plugin).getImageResponse(Mockito.any(), Mockito.any());
+        ImageInstance expectedImageInstance = Mockito.mock(ImageInstance.class);
+        Mockito.doReturn(expectedImageInstance).when(plugin).buildImageInstance(Mockito.eq(getImageResponse));
+
         OpenStackV3User cloudUser = Mockito.mock(OpenStackV3User.class);
         //exercise
         ImageInstance imageInstance = plugin.getImage(TestUtils.FAKE_IMAGE_ID, cloudUser);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/network/v2/OpenStackNetworkPluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/network/v2/OpenStackNetworkPluginTest.java
@@ -119,7 +119,7 @@ public class OpenStackNetworkPluginTest extends BaseUnitTests {
     public void testGetInstance() throws FogbowException {
         //setup
         Mockito.doReturn(TestUtils.EMPTY_STRING).when(openStackNetworkPlugin).doGetInstance(Mockito.any(), Mockito.any());
-        Mockito.doReturn(new NetworkInstance(NETWORK_ID)).when(openStackNetworkPlugin).buildInstance(Mockito.any(), Mockito.any());
+        Mockito.doReturn(new NetworkInstance(NETWORK_ID)).when(openStackNetworkPlugin).buildNetworkInstance(Mockito.any(), Mockito.any());
         NetworkOrder order = createNetworkOrder(NETWORK_ID, TestUtils.DEFAULT_CIDR, DEFAULT_GATEWAY_INFO, NetworkAllocationMode.DYNAMIC);
 
         //exercise
@@ -127,7 +127,7 @@ public class OpenStackNetworkPluginTest extends BaseUnitTests {
 
         //verify
         Mockito.verify(openStackNetworkPlugin, Mockito.times(TestUtils.RUN_ONCE)).doGetInstance(Mockito.any(), Mockito.any());
-        Mockito.verify(openStackNetworkPlugin, Mockito.times(TestUtils.RUN_ONCE)).buildInstance(Mockito.any(), Mockito.any());
+        Mockito.verify(openStackNetworkPlugin, Mockito.times(TestUtils.RUN_ONCE)).buildNetworkInstance(Mockito.any(), Mockito.any());
     }
 
     //test case: Check if the method makes the expected calls


### PR DESCRIPTION
This pull request refactors the OpenStack plugins

- **[All interoperability plugins]** Add logging for request and get instance actions
- **[All interoperability plugins]** Change protected for default visibility and add @VisibleForTesting annotation
- **[All interoperability plugins]** Remove @NotNull annotations
- **[Image/Plugin plugins]** Standardize plugins constructor using others as base
- **[ImagePlugin]** Extract buildImageInstance method
- **[PublicIpPlugin]** Fix typo in variable names
- **[Network/Compute plugins]** Extract constants from hardcoded values.
- **[StateMapper]** Update hardcoded constants holding class names for a call on class.getSimpleName()