### PR TITLE
Azure intraplugin refactor

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePlugin.java
@@ -71,7 +71,7 @@ public class AzureComputePlugin implements ComputePlugin<AzureUser>, AzureAsync<
         String name = computeOrder.getName();
         String regionName = this.defaultRegionName;
         String resourceName = AzureGeneralUtil.generateResourceName();
-        String virtualNetworkName = getVirtualNetworkResourceName(computeOrder, azureUser);
+        String virtualNetworkName = getVirtualNetworkResourceName(computeOrder);
         String imageId = computeOrder.getImageId();
         String decodedImageId = AzureImageOperationUtil.decode(imageId);
         AzureGetImageRef imageRef = AzureImageOperationUtil.buildAzureVirtualMachineImageBy(decodedImageId);
@@ -138,7 +138,7 @@ public class AzureComputePlugin implements ComputePlugin<AzureUser>, AzureAsync<
     }
     
     @VisibleForTesting
-    String getVirtualNetworkResourceName(ComputeOrder computeOrder, AzureUser azureUser) throws FogbowException {
+    String getVirtualNetworkResourceName(ComputeOrder computeOrder) throws FogbowException {
         List<String> networkIdList = computeOrder.getNetworkIds();
         String resourceName = this.defaultVirtualNetworkName;
         if (!networkIdList.isEmpty()) {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDK.java
@@ -87,11 +87,11 @@ public class AzureVirtualMachineSDK {
 
     @VisibleForTesting
     static boolean isWindowsImage(String imageOffer, String imageSku) {
-        return containsWindownsOn(imageOffer) || containsWindownsOn(imageSku);
+        return containsWindowsOn(imageOffer) || containsWindowsOn(imageSku);
     }
 
     @VisibleForTesting
-    static boolean containsWindownsOn(String text) {
+    static boolean containsWindowsOn(String text) {
         String regex = ".*windows.*";
         Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
         Matcher matcherOffer = pattern.matcher(text);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/network/sdk/AzureVirtualNetworkOperationSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/network/sdk/AzureVirtualNetworkOperationSDK.java
@@ -170,10 +170,10 @@ public class AzureVirtualNetworkOperationSDK {
         Azure azure = AzureClientCacheManager.getAzure(azureUser);
 
         if (AzureResourceGroupOperationUtil.existsResourceGroup(azure, resourceName)) {
-            Completable deteteResourceGroupCompletable = AzureResourceGroupOperationUtil
+            Completable deleteResourceGroupCompletable = AzureResourceGroupOperationUtil
                     .deleteResourceGroupAsync(azure, resourceName);
 
-            setDeleteVirtualNetworkBehaviour(deteteResourceGroupCompletable)
+            setDeleteVirtualNetworkBehaviour(deleteResourceGroupCompletable)
                     .subscribeOn(this.scheduler)
                     .subscribe();
         } else {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/publicip/sdk/AzurePublicIPAddressSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/publicip/sdk/AzurePublicIPAddressSDK.java
@@ -22,8 +22,6 @@ import rx.Observable;
 public class AzurePublicIPAddressSDK {
 
     @VisibleForTesting
-    static final String RESOURCE_NAMES_SEPARATOR = "_";
-    @VisibleForTesting
     static final int SSH_ACCESS_PORT = 22;
 
     public static Observable<NetworkInterface> associatePublicIPAddressAsync(

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/quota/AzureQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/quota/AzureQuotaPlugin.java
@@ -232,7 +232,7 @@ public class AzureQuotaPlugin implements QuotaPlugin<AzureUser> {
                 .reduce(initialValue, Integer::sum);
     }
 
-   @VisibleForTesting
+    @VisibleForTesting
     Map<String, VirtualMachineSize> getVirtualMachineSizesInUse(List<String> sizeNames, Azure azure) {
         Map<String, VirtualMachineSize> sizes = new HashMap<>();
         AzureQuotaSDK.getVirtualMachineSizesByRegion(azure, this.defaultRegionName).stream()

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/quota/AzureQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/quota/AzureQuotaPlugin.java
@@ -9,6 +9,7 @@ import cloud.fogbow.common.util.connectivity.cloud.azure.AzureClientCacheManager
 import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.ras.api.http.response.quotas.ResourceQuota;
 import cloud.fogbow.ras.api.http.response.quotas.allocation.*;
+import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.plugins.interoperability.QuotaPlugin;
 import cloud.fogbow.ras.core.plugins.interoperability.azure.util.AzureGeneralPolicy;
 import com.google.common.annotations.VisibleForTesting;
@@ -19,12 +20,15 @@ import com.microsoft.azure.management.compute.Disk;
 import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.compute.VirtualMachineSize;
 import com.microsoft.azure.management.network.NetworkUsage;
+import org.apache.log4j.Logger;
 
 import javax.validation.constraints.NotNull;
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class AzureQuotaPlugin implements QuotaPlugin<AzureUser> {
+
+    public static final Logger LOGGER = Logger.getLogger(AzureQuotaPlugin.class);
 
     @VisibleForTesting
     static final String QUOTA_VM_INSTANCES_KEY = "virtualMachines";
@@ -58,6 +62,7 @@ public class AzureQuotaPlugin implements QuotaPlugin<AzureUser> {
 
     @Override
     public ResourceQuota getUserQuota(AzureUser cloudUser) throws FogbowException {
+        LOGGER.info(Messages.Log.GETTING_QUOTA);
         Azure azure = AzureClientCacheManager.getAzure(cloudUser);
 
         Map<String, ComputeUsage> computeUsages = this.getComputeUsageMap(azure);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/quota/AzureQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/quota/AzureQuotaPlugin.java
@@ -50,7 +50,7 @@ public class AzureQuotaPlugin implements QuotaPlugin<AzureUser> {
 
     private final String defaultRegionName;
 
-    public AzureQuotaPlugin(@NotNull String confFilePath) {
+    public AzureQuotaPlugin(String confFilePath) {
         Properties properties = PropertiesUtil.readProperties(confFilePath);
         this.defaultRegionName = properties.getProperty(AzureConstants.DEFAULT_REGION_NAME_KEY);
         AzureGeneralPolicy.checkRegionName(this.defaultRegionName);

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/quota/AzureQuotaPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/quota/AzureQuotaPlugin.java
@@ -4,6 +4,7 @@ import cloud.fogbow.common.constants.AzureConstants;
 import cloud.fogbow.common.constants.FogbowConstants;
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.models.AzureUser;
+import cloud.fogbow.common.util.BinaryUnit;
 import cloud.fogbow.common.util.connectivity.cloud.azure.AzureClientCacheManager;
 import cloud.fogbow.common.util.PropertiesUtil;
 import cloud.fogbow.ras.api.http.response.quotas.ResourceQuota;
@@ -40,14 +41,12 @@ public class AzureQuotaPlugin implements QuotaPlugin<AzureUser> {
     @VisibleForTesting
     static final int NO_USAGE = 0;
 
-    private static final int ONE_PETABYTE_IN_GIGABYTES = 1048576;
-
     /**
      * This value is hardcoded because at the time this plugin was developed, a value for maximum storage capacity was
      * not provided by the SDK. The current value is informed in the documentation.
      */
     @VisibleForTesting
-    static final int MAXIMUM_STORAGE_ACCOUNT_CAPACITY = 50 * ONE_PETABYTE_IN_GIGABYTES;
+    static final int MAXIMUM_STORAGE_ACCOUNT_CAPACITY = (int) BinaryUnit.petabytes(50).asGigabytes();
 
     private final String defaultRegionName;
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/quota/sdk/AzureQuotaSDK.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/quota/sdk/AzureQuotaSDK.java
@@ -1,0 +1,34 @@
+package cloud.fogbow.ras.core.plugins.interoperability.azure.quota.sdk;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.microsoft.azure.PagedList;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.compute.ComputeUsage;
+import com.microsoft.azure.management.compute.Disk;
+import com.microsoft.azure.management.compute.VirtualMachine;
+import com.microsoft.azure.management.compute.VirtualMachineSize;
+import com.microsoft.azure.management.network.NetworkUsage;
+
+public class AzureQuotaSDK {
+
+    public static PagedList<NetworkUsage> getNetworkUsageByRegion(Azure azure, String region) {
+        return azure.networkUsages().listByRegion(region);
+    }
+
+    public static PagedList<ComputeUsage> getComputeUsageByRegion(Azure azure, String region) {
+        return azure.computeUsages().listByRegion(region);
+    }
+
+    public static PagedList<Disk> getDisks(Azure azure) {
+        return azure.disks().list();
+    }
+
+    public static PagedList<VirtualMachineSize> getVirtualMachineSizesByRegion(Azure azure, String region) {
+        return azure.virtualMachines().sizes().listByRegion(region);
+    }
+
+    public static PagedList<VirtualMachine> getVirtualMachines(Azure azure) {
+        return azure.virtualMachines().list();
+    }
+
+}

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/securityrule/util/AzureSecurityRuleUtil.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/azure/securityrule/util/AzureSecurityRuleUtil.java
@@ -17,9 +17,9 @@ public interface AzureSecurityRuleUtil {
     String UDP_VALUE = "UDP";
 
     String PORTS_SEPARATOR = "-";
-    String CIRD_SEPARATOR = "/";
+    String CIDR_SEPARATOR = "/";
 
-    int IP_CIRD_ARRAY_POSITION = 0;
+    int IP_CIDR_ARRAY_POSITION = 0;
     int FROM_PORT_ARRAY_POSITION = 0;
     int TO_PORT_ARRAY_POSITION = 1;
     int SINGLE_PORT_SIZE = 1;
@@ -51,9 +51,9 @@ public interface AzureSecurityRuleUtil {
     }
 
     @Nullable
-    static String getIpAddress(String cird) {
-        String[] cirdChunks = cird.split(CIRD_SEPARATOR);
-        String ip = cirdChunks[IP_CIRD_ARRAY_POSITION];
+    static String getIpAddress(String cidr) {
+        String[] cidrChunks = cidr.split(CIDR_SEPARATOR);
+        String ip = cidrChunks[IP_CIDR_ARRAY_POSITION];
         return CidrUtils.isIpv4(ip) || CidrUtils.isIpv6(ip) ? ip : null;
     }
 

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePluginTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/AzureComputePluginTest.java
@@ -122,7 +122,7 @@ public class AzureComputePluginTest {
 
         // exercise
         String virtualNetworkId = this.azureComputePlugin
-                .getVirtualNetworkResourceName(computeOrder, this.azureUser);
+                .getVirtualNetworkResourceName(computeOrder);
 
         // verify
         Assert.assertEquals(expected, virtualNetworkId);
@@ -142,7 +142,7 @@ public class AzureComputePluginTest {
         
         // exercise
         String virtualNetworkId = this.azureComputePlugin
-                .getVirtualNetworkResourceName(computeOrder, this.azureUser);
+                .getVirtualNetworkResourceName(computeOrder);
 
         // verify
         Assert.assertEquals(expected, virtualNetworkId);
@@ -188,7 +188,7 @@ public class AzureComputePluginTest {
 
         String virtualNetworkName = "virtualNetworkName";
         Mockito.doReturn(virtualNetworkName).when(this.azureComputePlugin)
-                .getVirtualNetworkResourceName(Mockito.eq(computeOrder), Mockito.eq(this.azureUser));
+                .getVirtualNetworkResourceName(Mockito.eq(computeOrder));
 
         String decodeImageId = "decodeImageId";
         PowerMockito.mockStatic(AzureImageOperationUtil.class);

--- a/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDKTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/plugins/interoperability/azure/compute/sdk/AzureVirtualMachineSDKTest.java
@@ -157,7 +157,7 @@ public class AzureVirtualMachineSDKTest {
         // set up
         String text = "windows";
         // exercise
-        boolean containsWindows = AzureVirtualMachineSDK.containsWindownsOn(text);
+        boolean containsWindows = AzureVirtualMachineSDK.containsWindowsOn(text);
         // verify
         Assert.assertTrue(containsWindows);
     }
@@ -169,7 +169,7 @@ public class AzureVirtualMachineSDKTest {
         // set up
         String text = "WINDOWS";
         // exercise
-        boolean containsWindows = AzureVirtualMachineSDK.containsWindownsOn(text);
+        boolean containsWindows = AzureVirtualMachineSDK.containsWindowsOn(text);
         // verify
         Assert.assertTrue(containsWindows);
     }
@@ -181,7 +181,7 @@ public class AzureVirtualMachineSDKTest {
         // set up
         String text = "abc - windows WINDOWS  1204.65.78.9.8.7.86 _()}Ç:,vm";
         // exercise
-        boolean containsWindows = AzureVirtualMachineSDK.containsWindownsOn(text);
+        boolean containsWindows = AzureVirtualMachineSDK.containsWindowsOn(text);
         // verify
         Assert.assertTrue(containsWindows);
     }
@@ -193,7 +193,7 @@ public class AzureVirtualMachineSDKTest {
         // set up
         String text = "linux-v2";
         // exercise
-        boolean containsWindows = AzureVirtualMachineSDK.containsWindownsOn(text);
+        boolean containsWindows = AzureVirtualMachineSDK.containsWindowsOn(text);
         // verify
         Assert.assertFalse(containsWindows);
     }
@@ -205,7 +205,7 @@ public class AzureVirtualMachineSDKTest {
         // set up
         String text = "linux-wind.wos-WINDOW-S";
         // exercise
-        boolean containsWindows = AzureVirtualMachineSDK.containsWindownsOn(text);
+        boolean containsWindows = AzureVirtualMachineSDK.containsWindowsOn(text);
         // verify
         Assert.assertFalse(containsWindows);
     }


### PR DESCRIPTION
This pull request refactors the Azure plugins

**Requires:** https://github.com/fogbow/common/pull/171

- **[Quota/Image plugins]** Add logging for request and get instance actions
- **[QuotaPlugin]** Remove @NotNull annotations
- **[QuotaPlugin]** Create a SDK class with only azure SDK related methods
- **[QuotaPlugin]** Replace local byte conversion implementation for a common one.
- **[ComputePlugin]** Remove unused parameters
- **[AzureVirtualMachineSDK]** Fix typo in method name
- **[AzureVirtualNetworkOperationSDK, AzureSecurityRuleUtil]** Fix typo in variable name
- **[AzurePublicIPAddressSDK]** Remove unused constants. 
