### PR TITLE
Created Google Cloud's PublicIp constructor

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/googlecloud/publicip/v1/GoogleCloudPublicIpPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/googlecloud/publicip/v1/GoogleCloudPublicIpPlugin.java
@@ -20,6 +20,10 @@ public class GoogleCloudPublicIpPlugin implements PublicIpPlugin<GoogleCloudUser
 
     private static final Logger LOGGER = Logger.getLogger(GoogleCloudPublicIpPlugin.class);
 
+    public GoogleCloudPublicIpPlugin(String confPathFile) {
+
+    }
+
     @Override
     public String requestInstance(PublicIpOrder publicIpOrder, GoogleCloudUser cloudUser) throws FogbowException {
         LOGGER.info(Messages.Log.REQUESTING_INSTANCE_FROM_PROVIDER);


### PR DESCRIPTION
## Description
This constructor is necessary to allow the usage of this public ip plugin in the google cloud plugin.conf file.
