### PR TITLE
Retry feature spawning processor

### DIFF
--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -87,6 +87,7 @@ public class Messages {
         public static final String VIRTUAL_MACHINE_ALREADY_PAUSED = "The Virtual Machine has already been paused.";
         public static final String VIRTUAL_MACHINE_IS_NOT_RUNNING = "The Virtual Machine is not running.";
         public static final String WRONG_URI_SYNTAX_S = "Wrong syntax for endpoint %s.";
+        public static final String ERROR_WHILE_CHECKING_INSTANCE_STATUS_ATTEMPTS_LEFT_D = "Error while checking instance status. Attempts left: %d";
     }
 
     public static class Log {

--- a/src/main/java/cloud/fogbow/ras/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/ras/constants/Messages.java
@@ -10,6 +10,7 @@ public class Messages {
         public static final String DELETE_OPERATION_ALREADY_ONGOING = "Delete operation is already on-going.";
         public static final String DEPENDENCY_DETECTED_S_S = "Cannot delete order '%s'. There are other orders associated with it: ids '%s'. You should remove those dependencies first.";
         public static final String EMPTY_PROPERTY_MAP = "Empty property getCloudUser.";
+        public static final String ERROR_WHILE_CHECKING_INSTANCE_STATUS_ATTEMPTS_LEFT_D = "Error while checking instance status; attempts left: %d";
         public static final String ERROR_WHILE_CREATING_RESOURCE_S = Log.ERROR_WHILE_CREATING_RESOURCE_S;
         public static final String ERROR_WHILE_GETTING_RESOURCE_S_FROM_CLOUD = Log.ERROR_WHILE_GETTING_RESOURCE_S_FROM_CLOUD;
         public static final String ERROR_WHILE_GETTING_VOLUME_INSTANCE = Log.ERROR_WHILE_GETTING_VOLUME_INSTANCE;
@@ -87,7 +88,6 @@ public class Messages {
         public static final String VIRTUAL_MACHINE_ALREADY_PAUSED = "The Virtual Machine has already been paused.";
         public static final String VIRTUAL_MACHINE_IS_NOT_RUNNING = "The Virtual Machine is not running.";
         public static final String WRONG_URI_SYNTAX_S = "Wrong syntax for endpoint %s.";
-        public static final String ERROR_WHILE_CHECKING_INSTANCE_STATUS_ATTEMPTS_LEFT_D = "Error while checking instance status. Attempts left: %d";
     }
 
     public static class Log {


### PR DESCRIPTION
## Description
This pull request implements a retry feature into SpawningProcessor. 

If an exception was thrown when attempting to get the order instance the processor will put this order into a map (the key is the order and the value is the number of failed get instance requests), instead of setting the order to FAILED_AFTER_SUCCESSFUL_REQUEST after the first failed attempt, it will transition the order to this state only after 5 times.