### PR TITLE
Fixes openstack compute actions

### DIFF
--- a/src/main/java/cloud/fogbow/ras/api/http/request/Compute.java
+++ b/src/main/java/cloud/fogbow/ras/api/http/request/Compute.java
@@ -145,7 +145,7 @@ public class Compute {
     }
 
     @ApiOperation(value = ApiDocumentation.Compute.PAUSE_OPERATION)
-    @RequestMapping(value = "/pause/{computeId}", method = RequestMethod.POST)
+    @RequestMapping(value = "/{computeId}/pause", method = RequestMethod.POST)
     public void pauseCompute(
             @ApiParam(value = ApiDocumentation.Compute.ID)
             @PathVariable String computeId,
@@ -163,7 +163,7 @@ public class Compute {
     }
 
     @ApiOperation(value = ApiDocumentation.Compute.HIBERNATE_OPERATION)
-    @RequestMapping(value = "/hibernate/{computeId}", method = RequestMethod.POST)
+    @RequestMapping(value = "/{computeId}/hibernate", method = RequestMethod.POST)
     public void hibernateCompute(
             @ApiParam(value = ApiDocumentation.Compute.ID)
             @PathVariable String computeId,
@@ -181,7 +181,7 @@ public class Compute {
     }
 
     @ApiOperation(value = ApiDocumentation.Compute.RESUME_OPERATION)
-    @RequestMapping(value = "/resume/{computeId}", method = RequestMethod.POST)
+    @RequestMapping(value = "/{computeId}/resume", method = RequestMethod.POST)
     public void resumeCompute(
             @ApiParam(value = ApiDocumentation.Compute.ID)
             @PathVariable String computeId,

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/compute/v2/OpenStackComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/compute/v2/OpenStackComputePlugin.java
@@ -112,7 +112,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         LOGGER.info(String.format(Messages.Log.PAUSING_INSTANCE_S, instanceId));
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String endpoint = getComputeEndpoint(projectId, OpenStackConstants.SERVERS_ENDPOINT
-                + OpenStackConstants.ENDPOINT_SEPARATOR + computeOrder.getInstanceId());
+                + OpenStackConstants.ENDPOINT_SEPARATOR + computeOrder.getInstanceId()
+                + OpenStackConstants.ENDPOINT_SEPARATOR + OpenStackConstants.ACTION);
 
         PauseComputeRequest request = getPauseComputeRequest();
         String body = request.toJson();
@@ -126,7 +127,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         LOGGER.info(String.format(Messages.Log.HIBERNATING_INSTANCE_S, instanceId));
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String endpoint = getComputeEndpoint(projectId, OpenStackConstants.SERVERS_ENDPOINT
-                + OpenStackConstants.ENDPOINT_SEPARATOR + computeOrder.getInstanceId());
+                + OpenStackConstants.ENDPOINT_SEPARATOR + computeOrder.getInstanceId()
+                + OpenStackConstants.ENDPOINT_SEPARATOR + OpenStackConstants.ACTION);
 
         SuspendComputeRequest request = getSuspendComputeRequest();
         String body = request.toJson();
@@ -140,7 +142,8 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
         LOGGER.info(String.format(Messages.Log.RESUMING_INSTANCE_S, instanceId));
         String projectId = OpenStackPluginUtils.getProjectIdFrom(cloudUser);
         String endpoint = getComputeEndpoint(projectId, OpenStackConstants.SERVERS_ENDPOINT
-                + OpenStackConstants.ENDPOINT_SEPARATOR + computeOrder.getInstanceId());
+                + OpenStackConstants.ENDPOINT_SEPARATOR + computeOrder.getInstanceId()
+                + OpenStackConstants.ENDPOINT_SEPARATOR + OpenStackConstants.ACTION);
 
         if(computeOrder.getOrderState().equals(OrderState.PAUSED)) {
             UnpauseComputeRequest request = getUnpauseComputeRequest();
@@ -336,7 +339,9 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
 
     @VisibleForTesting
     UnpauseComputeRequest getUnpauseComputeRequest() {
-        UnpauseComputeRequest unpauseComputeRequest = new UnpauseComputeRequest.Builder().build();
+        UnpauseComputeRequest unpauseComputeRequest = new UnpauseComputeRequest.Builder()
+//                .unpause()
+                .build();
         return unpauseComputeRequest;
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/compute/v2/OpenStackComputePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/compute/v2/OpenStackComputePlugin.java
@@ -339,9 +339,7 @@ public class OpenStackComputePlugin implements ComputePlugin<OpenStackV3User> {
 
     @VisibleForTesting
     UnpauseComputeRequest getUnpauseComputeRequest() {
-        UnpauseComputeRequest unpauseComputeRequest = new UnpauseComputeRequest.Builder()
-//                .unpause()
-                .build();
+        UnpauseComputeRequest unpauseComputeRequest = new UnpauseComputeRequest.Builder().build();
         return unpauseComputeRequest;
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/sdk/v2/compute/models/PauseComputeRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/sdk/v2/compute/models/PauseComputeRequest.java
@@ -1,7 +1,7 @@
 package cloud.fogbow.ras.core.plugins.interoperability.openstack.sdk.v2.compute.models;
 
-import cloud.fogbow.common.util.GsonHolder;
 import cloud.fogbow.common.util.JsonSerializable;
+import cloud.fogbow.common.util.SerializeNullsGsonHolder;
 import com.google.gson.annotations.SerializedName;
 
 import static cloud.fogbow.common.constants.OpenStackConstants.Compute.*;
@@ -27,7 +27,7 @@ public class PauseComputeRequest implements JsonSerializable {
 
     @Override
     public String toJson() {
-        return GsonHolder.getInstance().toJson(this);
+        return SerializeNullsGsonHolder.getInstance().toJson(this);
     }
 
     public static class Builder {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/sdk/v2/compute/models/ResumeComputeRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/sdk/v2/compute/models/ResumeComputeRequest.java
@@ -1,7 +1,7 @@
 package cloud.fogbow.ras.core.plugins.interoperability.openstack.sdk.v2.compute.models;
 
-import cloud.fogbow.common.util.GsonHolder;
 import cloud.fogbow.common.util.JsonSerializable;
+import cloud.fogbow.common.util.SerializeNullsGsonHolder;
 import com.google.gson.annotations.SerializedName;
 
 import static cloud.fogbow.common.constants.OpenStackConstants.Compute.*;
@@ -27,7 +27,7 @@ public class ResumeComputeRequest implements JsonSerializable {
 
     @Override
     public String toJson() {
-        return GsonHolder.getInstance().toJson(this);
+        return SerializeNullsGsonHolder.getInstance().toJson(this);
     }
 
     public static class Builder {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/sdk/v2/compute/models/SuspendComputeRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/sdk/v2/compute/models/SuspendComputeRequest.java
@@ -1,7 +1,7 @@
 package cloud.fogbow.ras.core.plugins.interoperability.openstack.sdk.v2.compute.models;
 
-import cloud.fogbow.common.util.GsonHolder;
 import cloud.fogbow.common.util.JsonSerializable;
+import cloud.fogbow.common.util.SerializeNullsGsonHolder;
 import com.google.gson.annotations.SerializedName;
 
 import static cloud.fogbow.common.constants.OpenStackConstants.Compute.*;
@@ -27,7 +27,7 @@ public class SuspendComputeRequest implements JsonSerializable {
 
     @Override
     public String toJson() {
-        return GsonHolder.getInstance().toJson(this);
+        return SerializeNullsGsonHolder.getInstance().toJson(this);
     }
 
     public static class Builder {

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/sdk/v2/compute/models/UnpauseComputeRequest.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/openstack/sdk/v2/compute/models/UnpauseComputeRequest.java
@@ -1,7 +1,7 @@
 package cloud.fogbow.ras.core.plugins.interoperability.openstack.sdk.v2.compute.models;
 
-import cloud.fogbow.common.util.GsonHolder;
 import cloud.fogbow.common.util.JsonSerializable;
+import cloud.fogbow.common.util.SerializeNullsGsonHolder;
 import com.google.gson.annotations.SerializedName;
 
 import static cloud.fogbow.common.constants.OpenStackConstants.Compute.*;
@@ -27,7 +27,7 @@ public class UnpauseComputeRequest implements JsonSerializable {
 
     @Override
     public String toJson() {
-        return GsonHolder.getInstance().toJson(this);
+        return SerializeNullsGsonHolder.getInstance().toJson(this);
     }
 
     public static class Builder {


### PR DESCRIPTION
## Description
This pull request fixes bugs that were causing errors in the use of the new compute actions and also improve some related code.

- Fix compute endpoints to match REST endpoint patterns
    - /computes/pause/{computeId} -> /computes/{computeId}/pause
    - /computes/hibernate/{computeId} -> /computes/{computeId}/hibernate
    - /computes/resume/{computeId} -> /computes/{computeId}/resume
- Fix openstack compute actions endpoint
- Update openstack actions requests to use SerializeNullsGsonHolder instead of GsonHolder
    - all openstack actions requests (pause, unpause, resume, etc) should send the json with key and the null value (e.g { "suspend": null }) but the default Gson instance doesn't serialize nulls.


## Reminding
**PRs order:**
First merge https://github.com/fogbow/common/pull/266, then this PR.
