### PR TITLE
Fix google cloud volume plugin

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/googlecloud/util/GoogleCloudStateMapper.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/googlecloud/util/GoogleCloudStateMapper.java
@@ -4,6 +4,7 @@ import cloud.fogbow.ras.api.http.response.InstanceState;
 import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.models.ResourceType;
 import cloud.fogbow.ras.core.plugins.interoperability.googlecloud.compute.v1.GoogleCloudComputePlugin;
+import cloud.fogbow.ras.core.plugins.interoperability.googlecloud.volume.v1.GoogleCloudVolumePlugin;
 import org.apache.log4j.Logger;
 
 public class GoogleCloudStateMapper {
@@ -11,6 +12,7 @@ public class GoogleCloudStateMapper {
     private static final Logger LOGGER = Logger.getLogger(GoogleCloudStateMapper.class);
 
     private static final String COMPUTE_PLUGIN = GoogleCloudComputePlugin.class.getSimpleName();
+    private static final String VOLUME_PLUGIN = GoogleCloudVolumePlugin.class.getSimpleName();
 
     // Instance states
     private static final String PROVISIONING_STATE = "provisioning";
@@ -22,6 +24,13 @@ public class GoogleCloudStateMapper {
     private static final String SUSPENDING_STATE = "suspending";
     private static final String SUSPENDED_STATE = "suspended";
 
+    // Disk states
+    private static final String CREATING_STATE = "creating";
+    private static final String FAILED_STATE = "failed";
+    private static final String READY_STATE = "ready";
+    private static final String DELETING_STATE = "deleting";
+    private static final String RESTORING_STATE = "restoring";
+
     //Network states
     private static final String SIMULATED_ERROR_STATE = "error";
 
@@ -29,6 +38,21 @@ public class GoogleCloudStateMapper {
         state = state.toLowerCase();
 
         switch (type){
+            case VOLUME:
+                switch (state) {
+                    case READY_STATE:
+                        return InstanceState.READY;
+                    case CREATING_STATE:
+                        return InstanceState.CREATING;
+                    case FAILED_STATE:
+                        return InstanceState.FAILED;
+                    case DELETING_STATE:
+                    case RESTORING_STATE:
+                        return InstanceState.BUSY;
+                    default:
+                        LOGGER.error(String.format(Messages.Log.UNDEFINED_INSTANCE_STATE_MAPPING_S_S, state, VOLUME_PLUGIN));
+                        return InstanceState.INCONSISTENT;
+                }
             case PUBLIC_IP:
                 switch (state) {
                     // TODO: Implements states


### PR DESCRIPTION
## Description
This pull request fixes some bugs related to Google Cloud Volume Plugin.

## Bugs:
- Volume state mapping not implemented. It was causing the order state to be CREATING forever.
- Volume order requirements being required when it should be optional. The requirement field was required because of the field volumeTypeId (from create volume request body) was being used as required, but it is not required (check [docs](https://cloud.google.com/compute/docs/reference/rest/v1/disks/insert)). This field has a default value (standard disk) and it can be used to create the volume as a different type like a SSD, so I did not delete the implementation. This code can be improved to allow the user create a disk with SSD but it should not be required.
- The zone used to create the disk was constant instead of loaded from the properties (cloud.conf)

## System tests
I tested all the volume operations (create, get, list and delete) using and it worked.