### PR TITLE
Fixing bug on some processors startup

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/processors/HibernatingProcessor.java
+++ b/src/main/java/cloud/fogbow/ras/core/processors/HibernatingProcessor.java
@@ -4,8 +4,6 @@ import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.InstanceNotFoundException;
 import cloud.fogbow.common.models.linkedlists.ChainedList;
 import cloud.fogbow.ras.api.http.response.ComputeInstance;
-import cloud.fogbow.ras.api.http.response.InstanceState;
-import cloud.fogbow.ras.api.http.response.OrderInstance;
 import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.OrderStateTransitioner;
 import cloud.fogbow.ras.core.SharedOrderHolders;
@@ -22,10 +20,6 @@ public class HibernatingProcessor extends StoppableProcessor implements Runnable
 
     private String localProviderId;
     private ChainedList<Order> hibernatingOrdersList;
-    /**
-     * Attribute that represents the thread sleep time when there are no orders to be processed.
-     */
-    private Long sleepTime;
 
     public HibernatingProcessor(String localProviderId, String sleepTimeStr) {
         this.localProviderId = localProviderId;
@@ -38,43 +32,6 @@ public class HibernatingProcessor extends StoppableProcessor implements Runnable
 
     public void setSleepTime(Long sleepTime) {
         this.sleepTime = sleepTime;
-    }
-
-    /**
-     * Iterates over the assignedForDeletion orders list and tries to process one order at a time. When the order
-     * is null, it indicates that the iteration ended. A new iteration is started after some time.
-     */
-    @Override
-    public void run() {
-        boolean isActive = true;
-        while (isActive) {
-            try {
-                assignForDeletion();
-            } catch (InterruptedException e) {
-                isActive = false;
-            }
-        }
-    }
-
-    @VisibleForTesting
-    void assignForDeletion() throws InterruptedException {
-        try {
-            Order order = this.hibernatingOrdersList.getNext();
-
-            if (order != null) {
-                processHibernatingOrder(order);
-            } else {
-                this.hibernatingOrdersList.resetPointer();
-                Thread.sleep(this.sleepTime);
-            }
-        } catch (InterruptedException e) {
-            LOGGER.error(Messages.Log.THREAD_HAS_BEEN_INTERRUPTED, e);
-            throw e;
-        } catch (FogbowException e) {
-            LOGGER.error(e.getMessage(), e);
-        } catch (Throwable e) {
-            LOGGER.error(Messages.Log.UNEXPECTED_ERROR, e);
-        }
     }
 
     /**

--- a/src/main/java/cloud/fogbow/ras/core/processors/ResumingProcessor.java
+++ b/src/main/java/cloud/fogbow/ras/core/processors/ResumingProcessor.java
@@ -4,8 +4,6 @@ import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.common.exceptions.InstanceNotFoundException;
 import cloud.fogbow.common.models.linkedlists.ChainedList;
 import cloud.fogbow.ras.api.http.response.ComputeInstance;
-import cloud.fogbow.ras.api.http.response.InstanceState;
-import cloud.fogbow.ras.api.http.response.OrderInstance;
 import cloud.fogbow.ras.constants.Messages;
 import cloud.fogbow.ras.core.OrderStateTransitioner;
 import cloud.fogbow.ras.core.SharedOrderHolders;
@@ -22,10 +20,6 @@ public class ResumingProcessor extends StoppableProcessor implements Runnable {
 
     private String localProviderId;
     private ChainedList<Order> resumingOrdersList;
-    /**
-     * Attribute that represents the thread sleep time when there are no orders to be processed.
-     */
-    private Long sleepTime;
 
     public ResumingProcessor(String localProviderId, String sleepTimeStr) {
         this.localProviderId = localProviderId;
@@ -38,43 +32,6 @@ public class ResumingProcessor extends StoppableProcessor implements Runnable {
 
     public void setSleepTime(Long sleepTime) {
         this.sleepTime = sleepTime;
-    }
-
-    /**
-     * Iterates over the assignedForDeletion orders list and tries to process one order at a time. When the order
-     * is null, it indicates that the iteration ended. A new iteration is started after some time.
-     */
-    @Override
-    public void run() {
-        boolean isActive = true;
-        while (isActive) {
-            try {
-                assignForDeletion();
-            } catch (InterruptedException e) {
-                isActive = false;
-            }
-        }
-    }
-
-    @VisibleForTesting
-    void assignForDeletion() throws InterruptedException {
-        try {
-            Order order = this.resumingOrdersList.getNext();
-
-            if (order != null) {
-                processResumingOrder(order);
-            } else {
-                this.resumingOrdersList.resetPointer();
-                Thread.sleep(this.sleepTime);
-            }
-        } catch (InterruptedException e) {
-            LOGGER.error(Messages.Log.THREAD_HAS_BEEN_INTERRUPTED, e);
-            throw e;
-        } catch (FogbowException e) {
-            LOGGER.error(e.getMessage(), e);
-        } catch (Throwable e) {
-            LOGGER.error(Messages.Log.UNEXPECTED_ERROR, e);
-        }
     }
 
     /**


### PR DESCRIPTION
## Description
This PR fixes a bug in the new processors startup which prevented ProcessorsThreadController.startRasThreads() from returning.

## Proposed changes
The bug was caused by a redundant declaration of the class field sleepTime in some processors. This declaration caused a NullPointerException, caught in the doRun method. The processor, therefore, was never correctly started. This PR removes the redundant declaration and some unnecessary code from the processors.

## Additional information
** 

## Reminding
PRs order:
current < your(PR1) < your(PR2)
