### PR TITLE
Fixed ComposedAuthorizationPlugin cast problem

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/AuthorizationPluginInstantiator.java
+++ b/src/main/java/cloud/fogbow/ras/core/AuthorizationPluginInstantiator.java
@@ -4,7 +4,7 @@ import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
 import cloud.fogbow.ras.core.models.RasOperation;
 
 public class AuthorizationPluginInstantiator {
-    private static ClassFactory classFactory = new ClassFactory();
+    private static RasClassFactory classFactory = new RasClassFactory();
 
     public static AuthorizationPlugin<RasOperation> getAuthorizationPlugin(String className) {
         return (AuthorizationPlugin<RasOperation>) AuthorizationPluginInstantiator.classFactory.createPluginInstance(className);

--- a/src/main/java/cloud/fogbow/ras/core/AuthorizationPluginInstantiator.java
+++ b/src/main/java/cloud/fogbow/ras/core/AuthorizationPluginInstantiator.java
@@ -1,12 +1,19 @@
 package cloud.fogbow.ras.core;
 
 import cloud.fogbow.common.plugins.authorization.AuthorizationPlugin;
+import cloud.fogbow.common.plugins.authorization.ComposedAuthorizationPlugin;
 import cloud.fogbow.ras.core.models.RasOperation;
 
 public class AuthorizationPluginInstantiator {
     private static RasClassFactory classFactory = new RasClassFactory();
 
     public static AuthorizationPlugin<RasOperation> getAuthorizationPlugin(String className) {
-        return (AuthorizationPlugin<RasOperation>) AuthorizationPluginInstantiator.classFactory.createPluginInstance(className);
+    	AuthorizationPlugin<RasOperation> plugin = 
+    			(AuthorizationPlugin<RasOperation>) AuthorizationPluginInstantiator.classFactory.createPluginInstance(className);
+    	if (className.equals("cloud.fogbow.common.plugins.authorization.ComposedAuthorizationPlugin")) {
+    		ComposedAuthorizationPlugin<RasOperation> composedPlugin = (ComposedAuthorizationPlugin<RasOperation>) plugin;
+    		composedPlugin.startPlugin(classFactory);
+    	}
+        return plugin;
     }
 }

--- a/src/main/java/cloud/fogbow/ras/core/InteroperabilityPluginInstantiator.java
+++ b/src/main/java/cloud/fogbow/ras/core/InteroperabilityPluginInstantiator.java
@@ -20,11 +20,11 @@ import cloud.fogbow.ras.core.plugins.interoperability.VolumePlugin;
 import cloud.fogbow.ras.core.plugins.mapper.SystemToCloudMapperPlugin;
 
 public class InteroperabilityPluginInstantiator {
-    private ClassFactory classFactory;
+    private RasClassFactory classFactory;
     private Map<String, Properties> cloudPropertiesCache;
 
     public InteroperabilityPluginInstantiator() {
-        this.classFactory = new ClassFactory();
+        this.classFactory = new RasClassFactory();
         this.cloudPropertiesCache = new HashMap<>();
     }
 

--- a/src/main/java/cloud/fogbow/ras/core/RasClassFactory.java
+++ b/src/main/java/cloud/fogbow/ras/core/RasClassFactory.java
@@ -1,15 +1,18 @@
 package cloud.fogbow.ras.core;
 
 import cloud.fogbow.common.exceptions.FatalErrorException;
+import cloud.fogbow.common.plugins.authorization.ComposedAuthorizationPlugin;
+import cloud.fogbow.common.util.ClassFactory;
 import cloud.fogbow.ras.constants.Messages;
+import cloud.fogbow.ras.core.models.RasOperation;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
 
 // Each package has to have its own ClassFactory
 
-public class ClassFactory {
-
+public class RasClassFactory implements ClassFactory {
+	
     public Object createPluginInstance(String pluginClassName, String ... params)
             throws FatalErrorException {
 
@@ -27,6 +30,11 @@ public class ClassFactory {
             }
 
             pluginInstance = constructor.newInstance(params);
+            
+        	if (pluginClassName.equals("cloud.fogbow.common.plugins.authorization.ComposedAuthorizationPlugin")) {
+        		ComposedAuthorizationPlugin<RasOperation> composedPlugin = (ComposedAuthorizationPlugin<RasOperation>) pluginInstance;
+        		composedPlugin.startPlugin(this);
+        	}
         } catch (ClassNotFoundException e) {
             throw new FatalErrorException(String.format(Messages.Exception.UNABLE_TO_FIND_CLASS_S, pluginClassName));
         } catch (Exception e) {

--- a/src/main/java/cloud/fogbow/ras/core/RasClassFactory.java
+++ b/src/main/java/cloud/fogbow/ras/core/RasClassFactory.java
@@ -1,10 +1,8 @@
 package cloud.fogbow.ras.core;
 
 import cloud.fogbow.common.exceptions.FatalErrorException;
-import cloud.fogbow.common.plugins.authorization.ComposedAuthorizationPlugin;
 import cloud.fogbow.common.util.ClassFactory;
 import cloud.fogbow.ras.constants.Messages;
-import cloud.fogbow.ras.core.models.RasOperation;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -30,11 +28,6 @@ public class RasClassFactory implements ClassFactory {
             }
 
             pluginInstance = constructor.newInstance(params);
-            
-        	if (pluginClassName.equals("cloud.fogbow.common.plugins.authorization.ComposedAuthorizationPlugin")) {
-        		ComposedAuthorizationPlugin<RasOperation> composedPlugin = (ComposedAuthorizationPlugin<RasOperation>) pluginInstance;
-        		composedPlugin.startPlugin(this);
-        	}
         } catch (ClassNotFoundException e) {
             throw new FatalErrorException(String.format(Messages.Exception.UNABLE_TO_FIND_CLASS_S, pluginClassName));
         } catch (Exception e) {


### PR DESCRIPTION
## Description
This PR fixes the issue on using ComposedAuthorizationPlugin in RAS. Normally, using this class as authorization plugin would cause an ClassCastException to be thrown.

## Proposed changes
Pass a ClassFactory created by RAS to the ComposedAuthorizationPlugin instance. This classFactory should be the one used to create the sub-plugins instances.

## Additional information
Requires https://github.com/fogbow/common/pull/271

## Reminding
PRs order:
current < your(PR1) < your(PR2)
