### PR TITLE
Changed handling of communication errors between providers

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/cloudconnector/RemoteCloudConnector.java
+++ b/src/main/java/cloud/fogbow/ras/core/cloudconnector/RemoteCloudConnector.java
@@ -34,6 +34,9 @@ public class RemoteCloudConnector implements CloudConnector {
             RemoteGetOrderRequest remoteGetOrderRequest = new RemoteGetOrderRequest(localOrder);
             Order remoteOrder = remoteGetOrderRequest.send();
             return remoteOrder;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             LOGGER.error(e.toString(), e);
             throw new FogbowException(e.getMessage());
@@ -48,6 +51,9 @@ public class RemoteCloudConnector implements CloudConnector {
             // At the requesting provider, the instance Id should be null, since the instance
             // was not created at the requesting provider's cloud.
             return null;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             LOGGER.error(e.toString(), e);
             throw new FogbowException(e.getMessage());
@@ -62,6 +68,9 @@ public class RemoteCloudConnector implements CloudConnector {
         } catch (InstanceNotFoundException e) {
             LOGGER.info(Messages.Exception.INSTANCE_NOT_FOUND);
             throw e;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             String exceptionMessage = e.getMessage();
             LOGGER.error(exceptionMessage, e);
@@ -75,9 +84,9 @@ public class RemoteCloudConnector implements CloudConnector {
             RemoteGetInstanceRequest remoteGetInstanceRequest = new RemoteGetInstanceRequest(order);
             OrderInstance instance = remoteGetInstanceRequest.send();
             return instance;
-        } catch (InstanceNotFoundException e) {
-            LOGGER.info(Messages.Exception.INSTANCE_NOT_FOUND);
-            throw e;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             LOGGER.error(e.toString(), e);
             throw new FogbowException(e.getMessage());
@@ -91,6 +100,9 @@ public class RemoteCloudConnector implements CloudConnector {
                     this.cloudName, systemUser);
             Quota quota = remoteGetUserQuotaRequest.send();
             return quota;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             LOGGER.error(e.toString(), e);
             throw new FogbowException(e.getMessage());
@@ -104,6 +116,9 @@ public class RemoteCloudConnector implements CloudConnector {
                     this.cloudName, systemUser);
             List<ImageSummary> imagesSummaryList = remoteGetAllImagesRequest.send();
             return imagesSummaryList;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             LOGGER.error(e.toString(), e);
             throw new FogbowException(e.getMessage());
@@ -117,6 +132,9 @@ public class RemoteCloudConnector implements CloudConnector {
                     this.cloudName, imageId, systemUser);
             ImageInstance imageInstance = remoteGetImageRequest.send();
             return imageInstance;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             LOGGER.error(e.toString(), e);
             throw new FogbowException(e.getMessage());
@@ -129,6 +147,9 @@ public class RemoteCloudConnector implements CloudConnector {
             RemoteTakeSnapshotRequest remoteTakeSnapshotRequest = new RemoteTakeSnapshotRequest(computeOrder, name,
                     systemUser);
             remoteTakeSnapshotRequest.send();
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             LOGGER.error(e.toString(), e);
             throw new FogbowException(e.getMessage());
@@ -142,6 +163,9 @@ public class RemoteCloudConnector implements CloudConnector {
             RemoteGetAllSecurityRuleRequest remoteGetAllSecurityRuleRequest =
                     new RemoteGetAllSecurityRuleRequest(this.destinationProvider, order.getId(), systemUser);
             return remoteGetAllSecurityRuleRequest.send();
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             LOGGER.error(e.toString(), e);
             throw new FogbowException(e.getMessage());
@@ -156,6 +180,9 @@ public class RemoteCloudConnector implements CloudConnector {
                     securityRule, systemUser, this.destinationProvider, order);
             remoteCreateSecurityRuleRequest.send();
             return null;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             LOGGER.error(e.toString(), e);
             throw new FogbowException(e.getMessage());
@@ -168,6 +195,9 @@ public class RemoteCloudConnector implements CloudConnector {
             RemoteDeleteSecurityRuleRequest remoteDeleteSecurityRuleRequest = new RemoteDeleteSecurityRuleRequest(
                     this.destinationProvider, this.cloudName, securityRuleId, systemUser);
             remoteDeleteSecurityRuleRequest.send();
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             LOGGER.error(e.toString(), e);
             throw new FogbowException(e.getMessage());
@@ -179,9 +209,9 @@ public class RemoteCloudConnector implements CloudConnector {
         try {
             RemotePauseOrderRequest remotePauseOrderRequest = new RemotePauseOrderRequest(order);
             remotePauseOrderRequest.send();
-        } catch (InstanceNotFoundException e) {
-            LOGGER.info(Messages.Exception.INSTANCE_NOT_FOUND);
-            throw e;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             String exceptionMessage = e.getMessage();
             LOGGER.error(exceptionMessage, e);
@@ -194,9 +224,9 @@ public class RemoteCloudConnector implements CloudConnector {
         try {
             RemoteHibernateOrderRequest remoteHibernateOrderRequest = new RemoteHibernateOrderRequest(order);
             remoteHibernateOrderRequest.send();
-        } catch (InstanceNotFoundException e) {
-            LOGGER.info(Messages.Exception.INSTANCE_NOT_FOUND);
-            throw e;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             String exceptionMessage = e.getMessage();
             LOGGER.error(exceptionMessage, e);
@@ -209,9 +239,9 @@ public class RemoteCloudConnector implements CloudConnector {
         try {
             RemoteResumeOrderRequest remoteResumeOrderRequest = new RemoteResumeOrderRequest(order);
             remoteResumeOrderRequest.send();
-        } catch (InstanceNotFoundException e) {
-            LOGGER.info(Messages.Exception.INSTANCE_NOT_FOUND);
-            throw e;
+        } catch (FogbowException e) {
+        	LOGGER.error(e.toString(), e);
+        	throw e;
         } catch (Exception e) {
             String exceptionMessage = e.getMessage();
             LOGGER.error(exceptionMessage, e);

--- a/src/main/java/cloud/fogbow/ras/core/intercomponent/xmpp/XmppErrorConditionToExceptionTranslator.java
+++ b/src/main/java/cloud/fogbow/ras/core/intercomponent/xmpp/XmppErrorConditionToExceptionTranslator.java
@@ -7,7 +7,7 @@ import org.xmpp.packet.PacketError;
 
 public class XmppErrorConditionToExceptionTranslator {
 
-    public static void handleError(IQ response, String providerId) throws Exception {
+    public static void handleError(IQ response, String providerId) throws FogbowException {
         if (response == null) {
             throw new UnavailableProviderException(String.format(Messages.Exception.UNABLE_TO_RETRIEVE_RESPONSE_FROM_PROVIDER_S, providerId));
         } else if (response.getError() != null) {
@@ -17,7 +17,7 @@ public class XmppErrorConditionToExceptionTranslator {
         }
     }
 
-    private static void throwException(PacketError.Condition condition, String message) throws Exception {
+    private static void throwException(PacketError.Condition condition, String message) throws FogbowException {
         switch (condition) {
             case forbidden:
                 throw new UnauthorizedRequestException(message);
@@ -35,8 +35,10 @@ public class XmppErrorConditionToExceptionTranslator {
                 throw new ConfigurationErrorException(message);
             case internal_server_error:
                 throw new InternalServerErrorException(message);
+            case undefined_condition:
+            	throw new FogbowException(message);
             default:
-                throw new Exception(message);
+                throw new CommunicationErrorException(message);
         }
     }
 }

--- a/src/test/java/cloud/fogbow/ras/core/cloudconnector/RemoteCloudConnectorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/cloudconnector/RemoteCloudConnectorTest.java
@@ -1,5 +1,6 @@
 package cloud.fogbow.ras.core.cloudconnector;
 
+import cloud.fogbow.common.exceptions.CommunicationErrorException;
 import cloud.fogbow.common.exceptions.FogbowException;
 import cloud.fogbow.ras.core.LoggerAssert;
 import cloud.fogbow.ras.core.TestUtils;
@@ -67,7 +68,7 @@ public class RemoteCloudConnectorTest extends TestUtils {
         Mockito.when(packetSender.syncSendPacket(Mockito.any(Packet.class))).thenReturn(IQResponse);
 
         String exceptionMessageExpected = TestUtils.ANY_VALUE;
-        Exception exception = new Exception(exceptionMessageExpected);
+        Exception exception = new CommunicationErrorException(exceptionMessageExpected);
         PowerMockito.mockStatic(XmppErrorConditionToExceptionTranslator.class);
         PowerMockito.doThrow(exception).when(XmppErrorConditionToExceptionTranslator.class);
         XmppErrorConditionToExceptionTranslator.handleError(Mockito.eq(IQResponse), Mockito.eq(order.getProvider()));

--- a/src/test/java/cloud/fogbow/ras/core/intercomponent/xmpp/XmppErrorConditionToExceptionTranslatorTest.java
+++ b/src/test/java/cloud/fogbow/ras/core/intercomponent/xmpp/XmppErrorConditionToExceptionTranslatorTest.java
@@ -204,7 +204,7 @@ public class XmppErrorConditionToExceptionTranslatorTest {
         }
     }
 
-    //test case: checks if "handleError" is properly forwarding "Exception" from
+    //test case: checks if "handleError" is properly forwarding "FogbowException" from
     //"throwException" when the packet error condition is not equals to any switch case attribute.
     //In addition, it checks if its message error is correct
     @Test
@@ -219,9 +219,9 @@ public class XmppErrorConditionToExceptionTranslatorTest {
             XmppErrorConditionToExceptionTranslator.handleError(iq, this.providerId);
             //verify: if some exception occurred
             Assert.fail();
-        } catch (Exception e) {
+        } catch (FogbowException e) {
             //verify: if the message is correct
-            Assert.assertEquals(e.getClass(), Exception.class);
+            Assert.assertEquals(e.getClass(), FogbowException.class);
             Assert.assertEquals(this.messageError, e.getMessage());
         } catch (Throwable e) {
             //verify: if some exception different from the expected exception occurred


### PR DESCRIPTION
## Description
This PR fixes issue **https://github.com/fogbow/resource-allocation-service/issues/757** by adding a new catch of FogbowException to RemoteCloudConnector and handling the undefined_condition PacketError condition. The new catch case forces all FogbowException subclasses to be rethrown correctly and the new PacketError condition handling allows RAS to distinguish communication errors from unexpected errors reported by a remote provider.

## Proposed changes
** 

## Additional information
Requires https://github.com/fogbow/common/pull/274

## Reminding
PRs order:
current < your(PR1) < your(PR2)
