### PR TITLE
Google cloud network plugin fix

### DIFF
--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/googlecloud/network/v1/GoogleCloudNetworkPlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/googlecloud/network/v1/GoogleCloudNetworkPlugin.java
@@ -228,7 +228,9 @@ public class GoogleCloudNetworkPlugin implements NetworkPlugin<GoogleCloudUser> 
         SecurityRule securityRule = new SecurityRule(direction, portFrom, portTo, cidr, etherType, protocol);
 
         GoogleCloudSecurityRulePlugin googleCloudSecurityRulePluginTemp = new GoogleCloudSecurityRulePlugin(confFilePath);
-
+        
+        // FIXME this code should not call this method. It should use SecurityRule creation
+        // API instead.
         return googleCloudSecurityRulePluginTemp.buildCreateSecurityRuleRequest(
                 securityRule,
                 majorOrder,

--- a/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/googlecloud/securityrule/v1/GoogleCloudSecurityRulePlugin.java
+++ b/src/main/java/cloud/fogbow/ras/core/plugins/interoperability/googlecloud/securityrule/v1/GoogleCloudSecurityRulePlugin.java
@@ -61,7 +61,9 @@ public class GoogleCloudSecurityRulePlugin implements SecurityRulePlugin<GoogleC
     }
 
     @VisibleForTesting
-    CreateFirewallRuleRequest buildCreateSecurityRuleRequest(SecurityRule securityRule, Order majorOrder, String securityRuleName) {
+    // FIXME The only reason this method is public is to not 
+    // break GoogleCloudNetworkPlugin, which needs refactoring.
+    public CreateFirewallRuleRequest buildCreateSecurityRuleRequest(SecurityRule securityRule, Order majorOrder, String securityRuleName) {
         return buildCreateSecurityRuleRequest(securityRule, majorOrder, GoogleCloudConstants.Network.Firewall.DEFAULT_RULE_PRIORITY, securityRuleName);
     }
 


### PR DESCRIPTION
## Description
This PR fixes compilation errors on GoogleCloudNetworkPlugin by changing the visibility of one method of SecurityRule plugin.

## Proposed changes
** 

## Additional information
** 

## Reminding
PRs order:
current < your(PR1) < your(PR2)
